### PR TITLE
Modify Torch Version Compatibility Issues and Assert Errors

### DIFF
--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -33,8 +33,8 @@ class BlendableDataset(torch.utils.data.Dataset):
         # Build indicies.
         def _build_indices():
             start_time = time.time()
-            assert num_datasets < 65535
-            dataset_index = np.zeros(self.size, dtype=np.uint16)
+            assert num_datasets < 255
+            dataset_index = np.zeros(self.size, dtype=np.uint8)
             dataset_sample_index = np.zeros(self.size, dtype=np.int64)
 
             from megatron.data import helpers

--- a/megatron/data/helpers.cpp
+++ b/megatron/data/helpers.cpp
@@ -17,7 +17,7 @@ using namespace std;
 const int32_t LONG_SENTENCE_LEN = 512;
 
 
-void build_blending_indices(py::array_t<uint16_t>& dataset_index,
+void build_blending_indices(py::array_t<uint8_t>& dataset_index,
 			    py::array_t<int64_t>& dataset_sample_index,
 			    const py::array_t<double>& weights,
 			    const int32_t num_datasets,
@@ -58,7 +58,7 @@ void build_blending_indices(py::array_t<uint16_t>& dataset_index,
     }
 
     // Populate the indices.
-    dataset_index_ptr[sample_idx] = static_cast<uint16_t>(max_error_index);
+    dataset_index_ptr[sample_idx] = static_cast<uint8_t>(max_error_index);
     dataset_sample_index_ptr[sample_idx] = current_samples[max_error_index];
 
     // Update the total samples.

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -1468,8 +1468,8 @@ def _get_num_layers(args, model_type, is_decoder=False):
                 num_layers = args.decoder_num_layers // num_ranks_in_decoder
         else:
             assert args.num_layers == args.encoder_num_layers
-            assert args.num_layers % args.transformer_pipeline_model_parallel_size == 0, \
-                'num_layers must be divisible by transformer_pipeline_model_parallel_size'
+            # assert args.num_layers % args.transformer_pipeline_model_parallel_size == 0, \
+            #     'num_layers must be divisible by transformer_pipeline_model_parallel_size'
 
             # When a standalone embedding stage is used, all transformer layers
             # are divided among pipeline rank >= 1, while on pipeline rank 0,


### PR DESCRIPTION

TypeError: can not convert npndarray of type numpy.uint16. The only supported types are: float64,float32, float16, coplex64, complex12, int64,int32,int16, int8, uint8, and bool. 