### PR TITLE
add loader_transformer, loader/saver_megatron

### DIFF
--- a/tools/convert.py
+++ b/tools/convert.py
@@ -1,0 +1,60 @@
+import sys
+import argparse
+import importlib
+import torch.multiprocessing as mp
+
+
+def load_plugin(plugin_type, name):
+    module_name = f"{plugin_type}_{name}"
+    try:
+        plugin = importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        module_name = name
+        try:
+            plugin = importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            sys.exit(f"Unable to load {plugin_type} plugin {name}. Exiting.")
+
+    if not hasattr(plugin, 'add_arguments'):
+        sys.exit(f"{module_name} module is not a plugin. Exiting.")
+
+    print(f"Loaded {module_name} as the {plugin_type}.")
+    return plugin
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert checkpoint")
+    # convert args
+    parser.add_argument('--model-type', type=str, required=True,
+                        choices=['aquila', 'mixtral'],
+                        help='Type of the model')
+    parser.add_argument('--loader', type=str, default='megatron',
+                        help='Module name to load checkpoint, should be on python path')
+    parser.add_argument('--saver', type=str, default='megatron',
+                        help='Module name to save checkpoint, shdoul be on python path')
+    parser.add_argument('--load-dir', type=str, required=True,
+                        help='Directory to load model checkpoint from')
+    parser.add_argument('--save-dir', type=str, required=True,
+                        help='Directory to save model checkpoint to')
+    parser.add_argument('--max-queue-size', type=int, default=50,
+                        help='Maximum number of tensors in the queue')
+
+    known_args, _ = parser.parse_known_args()
+    loader = load_plugin('loader', known_args.loader)
+    saver = load_plugin('saver', known_args.saver)
+
+    loader.add_arguments(parser)
+    saver.add_arguments(parser)
+
+    args = parser.parse_args()
+
+    queue = mp.Queue(maxsize=args.max_queue_size)
+    print("Starting saver...")
+    saver_proc = mp.Process(target=saver.save_checkpoint, args=(queue, args))
+    saver_proc.start()
+
+    print("Starting loader...")
+    loader.load_checkpoint(queue, args)
+
+    print("Waiting for saver to complete...")
+    saver_proc.join()

--- a/tools/loader_megatron.py
+++ b/tools/loader_megatron.py
@@ -132,7 +132,7 @@ def _load_checkpoint(queue, args):
         models = [[] for _ in range(vp_size)]
         for rank_id in range(count):
             tp_rank = rank_id % tp_size
-            ep_rank = rank_id // ep_size
+            ep_rank = rank_id // tp_size
             mpu.set_tensor_model_parallel_rank(tp_rank)
             mpu.set_expert_model_parallel_rank(ep_rank)
             if pp_size > 1 and vp_size > 1:

--- a/tools/loader_megatron.py
+++ b/tools/loader_megatron.py
@@ -1,0 +1,416 @@
+import os
+import sys
+import json
+import types
+import importlib
+
+import torch
+
+
+def add_arguments(parser):
+    group = parser.add_argument_group(title='Megatron loader')
+
+    group.add_argument('--true-vocab-size', type=int, default=None,
+                       help='original size of vocab, if specified will trim padding from embedding table.')
+    group.add_argument('--vocab-file', type=str, default=None,
+                       help='Path to the vocab file. If specified will use this to get vocab size and '
+                       'trim padding from the embedding table.')
+    group.add_argument('--megatron-path', type=str, default=None,
+                       help='Base directory of deepspeed repository')
+
+def _load_checkpoint(queue, args):
+
+    # Search in directory above this
+    root_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__),
+                     os.path.pardir))
+    sys.path.append(os.path.join(root_path, "megatron"))
+
+    if args.megatron_path is not None:
+        sys.path.insert(0, args.megatron_path)
+
+    try:
+        from megatron.arguments import parse_args, validate_args
+        from megatron.global_vars import set_global_variables
+        from megatron.checkpointing import load_args_from_checkpoint, load_checkpoint
+        from megatron.model import module
+        from megatron.core import mpu
+        from megatron import fused_kernels
+        from megatron.core.tensor_parallel.random import (
+                _CUDA_RNG_STATE_TRACKER, _DATA_PARALLEL_RNG_TRACKER_NAME, 
+                _EXPERT_PARALLEL_RNG_TRACKER_NAME, _MODEL_PARALLEL_RNG_TRACKER_NAME
+            )
+    except ModuleNotFoundError:
+        print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
+        queue.put("exit")
+        exit(1)
+
+    # We want all arguments to come from us
+    sys.argv = [
+        'script.py',
+        '--no-masked-softmax-fusion',
+        '--no-bias-gelu-fusion',
+        '--no-bias-dropout-fusion',
+        '--no-async-tensor-model-parallel-allreduce',
+        '--use-cpu-initialization',
+        '--micro-batch-size', '1',
+        '--no-load-optim',
+        '--no-load-rng',
+        '--use-mcore-models',
+        '--no-save-optim',
+        '--no-save-rng',
+        '--no-initialization',
+        '--load', args.load_dir
+    ]
+
+    margs = parse_args()
+    margs, checkpoint_args = load_args_from_checkpoint(margs)
+
+    def _set_arg(arg_name):
+        ckpt_value = getattr(checkpoint_args, arg_name, None)
+        setattr(margs, arg_name, ckpt_value)
+
+    _set_arg("expert_model_parallel_size")
+    _set_arg("num_experts")
+    _set_arg("sequence_parallel")
+
+    # Arguments do sanity checks on the world size, but we don't care,
+    # so trick it into thinking we are plenty of processes
+    margs.world_size = margs.tensor_model_parallel_size * margs.pipeline_model_parallel_size * margs.expert_model_parallel_size
+    if margs.expert_model_parallel_size > 1:
+        os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
+    margs = validate_args(margs)
+
+    def check_for_arg(arg_name, default=None):
+        if getattr(margs, arg_name, None) is None:
+            if default is not None:
+                setattr(margs, arg_name, default)
+            else:
+                print(f"Checkpoint does not specify the argument {arg_name}. Exiting.")
+                print(f"Arguments: {margs}")
+                queue.put("exit")
+                exit(1)
+
+    check_for_arg('tensor_model_parallel_size')
+    check_for_arg('pipeline_model_parallel_size')
+    check_for_arg('expert_model_parallel_size')
+    check_for_arg('num_layers')
+    check_for_arg('hidden_size')
+    check_for_arg('seq_length')
+    check_for_arg('num_attention_heads')
+    check_for_arg('max_position_embeddings')
+    check_for_arg('position_embedding_type')
+    check_for_arg('iteration')
+    check_for_arg('bert_binary_head')
+    check_for_arg('params_dtype')
+    check_for_arg('swiglu', False)
+    check_for_arg('disable_bias_linear', False)
+    check_for_arg('add_qkv_bias', getattr(margs, "add_bias_linear_qkv", True))
+
+    try:
+        model_plugin = importlib.import_module(args.model_type + ".model")
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("Please check model_type or model.py")
+
+    margs.consumed_train_samples = 0
+    margs.consumed_valid_samples = 0
+    margs.model_type = model_plugin.model_type
+    module.MegatronModule.embedding_warning_printed = True
+
+    def queue_put(name, msg):
+        print(f"sending {name}")
+        msg["name"] = name
+        queue.put(msg)
+
+    def get_models(count, dtype):
+        # for one pp stage
+        tp_size = margs.tensor_model_parallel_size
+        pp_size = margs.pipeline_model_parallel_size
+        ep_size = margs.expert_model_parallel_size
+        vp_size = margs.virtual_pipeline_model_parallel_size or 1
+
+        models = [[] for _ in range(vp_size)]
+        for rank_id in range(count):
+            tp_rank = rank_id % tp_size
+            ep_rank = rank_id // ep_size
+            mpu.set_tensor_model_parallel_rank(tp_rank)
+            mpu.set_expert_model_parallel_rank(ep_rank)
+            if pp_size > 1 and vp_size > 1:
+                model_ = []
+                for vp_rank in range(vp_size):
+                    mpu.set_virtual_pipeline_model_parallel_rank(vp_rank)
+                    # Set pre_process and post_process only after virtual rank is set.
+                    pre_process = mpu.is_pipeline_first_stage()
+                    post_process = mpu.is_pipeline_last_stage()
+                    this_model = model_plugin.get_mg_model(dtype, pre_process, post_process)
+                    model_.append(this_model)
+            else:
+                pre_process = mpu.is_pipeline_first_stage()
+                post_process = mpu.is_pipeline_last_stage() 
+                model_ = [model_plugin.get_mg_model(dtype, pre_process, post_process)]
+
+            load_checkpoint(model_, None, None)
+
+            for vp_rank in range(vp_size):
+                models[vp_rank].append(model_[vp_rank])
+
+        return models
+
+    # fake initializing distributed
+    set_global_variables(margs, build_tokenizer=False)
+    tp_size = margs.tensor_model_parallel_size
+    pp_size = margs.pipeline_model_parallel_size
+    ep_size = margs.expert_model_parallel_size
+    vp_size = margs.virtual_pipeline_model_parallel_size or 1
+
+    mpu.set_tensor_model_parallel_world_size(tp_size)
+    mpu.set_pipeline_model_parallel_world_size(pp_size)
+    mpu.set_expert_model_parallel_world_size(ep_size)
+    mpu.set_virtual_pipeline_model_parallel_world_size(vp_size)
+    mpu.set_tensor_model_parallel_rank(0)
+    mpu.set_pipeline_model_parallel_rank(0)
+    mpu.set_expert_model_parallel_rank(0)
+    mpu.set_virtual_pipeline_model_parallel_rank(0)
+
+    # fused kernel
+    fused_kernels.load(margs)
+
+    # random
+    _CUDA_RNG_STATE_TRACKER.reset()
+    torch.cuda.manual_seed(42)
+    _CUDA_RNG_STATE_TRACKER.add(_DATA_PARALLEL_RNG_TRACKER_NAME, 43)
+    _CUDA_RNG_STATE_TRACKER.add(_MODEL_PARALLEL_RNG_TRACKER_NAME, 44)
+    _CUDA_RNG_STATE_TRACKER.add(_EXPERT_PARALLEL_RNG_TRACKER_NAME, 45)
+
+    # Get true (non-padded) vocab size
+    if args.true_vocab_size is not None:
+        true_vocab_size = args.true_vocab_size
+    elif args.vocab_file is not None:
+        vocab = json.load(open(args.vocab_file))
+        true_vocab_size = len(vocab)
+        if args.true_vocab_size is not None and true_vocab_size != args.true_vocab_size:
+            print("Both --true-vocab-size and --vocab-file specified and the vocab size does not match, aborting.")
+            queue.put("exit")
+            exit(1)
+    else:
+        true_vocab_size = None
+
+    # Layernorm has bias; RMSNorm does not.
+    if hasattr(checkpoint_args, 'normalization'):
+        norm_has_bias = checkpoint_args.normalization == "LayerNorm"
+    else:
+        # older models only supported LayerNorm
+        norm_has_bias = True
+
+    # metadata
+    md = types.SimpleNamespace()
+    md.model_type = args.model_type
+    md.num_layers = margs.num_layers
+    md.num_experts = margs.num_experts
+    md.hidden_size = margs.hidden_size
+    md.seq_length = margs.seq_length
+    md.num_attention_heads = margs.num_attention_heads
+    md.max_position_embeddings = margs.max_position_embeddings
+    # md.tokenizer_type = margs.tokenizer_type
+    md.iteration = margs.iteration
+    md.params_dtype = margs.params_dtype
+    md.bert_binary_head = margs.bert_binary_head
+    md.output_layer = margs.untie_embeddings_and_output_weights
+    md.position_embedding_type = margs.position_embedding_type
+    md.add_bias_linear = margs.add_bias_linear
+    md.add_qkv_bias = margs.add_qkv_bias
+    md.norm_has_bias = norm_has_bias
+    md.swiglu = margs.swiglu
+    md.previous_tensor_parallel_size = margs.tensor_model_parallel_size
+    md.previous_pipeline_parallel_size = margs.pipeline_model_parallel_size
+    md.previous_expert_parallel_size = margs.expert_model_parallel_size
+    md.true_vocab_size = true_vocab_size
+    md.make_vocab_size_divisible_by = margs.make_vocab_size_divisible_by
+    md.checkpoint_args = checkpoint_args
+    md.consumed_train_samples = margs.consumed_train_samples
+    md.consumed_valid_samples = margs.consumed_valid_samples
+    queue.put(md)
+
+    # Get first pipe stage
+    mpu.set_pipeline_model_parallel_rank(0)
+    all_models = [get_models(tp_size * ep_size, md.params_dtype)]
+    models = all_models[0][0] # pp0vpp0
+
+    # Send embeddings
+    word_embeddings = []
+    complete_tp_ranks = []
+    for tp_ep_rank, model in enumerate(models):
+        tp_rank = tp_ep_rank % tp_size
+        if tp_rank in complete_tp_ranks:
+            continue
+        complete_tp_ranks.append(tp_rank)
+        word_embeddings.append(model.embedding.word_embeddings.weight.data)
+    message = {"word embeddings": torch.cat(word_embeddings, dim=0)}
+    if md.position_embedding_type == 'learned_absolute':
+        message["position embeddings"] = models[0].embedding.position_embeddings.weight.data
+    else:
+        assert not hasattr(models[0].embedding, 'position_embeddings')
+    queue_put("embeddings", message)
+
+    # Send transformer layer
+    total_layer_num = 0
+    for vp_rank in range(vp_size):
+        mpu.set_virtual_pipeline_model_parallel_rank(vp_rank)
+        for pp_rank in range(pp_size):
+            mpu.set_pipeline_model_parallel_rank(pp_rank)
+
+            if pp_rank > 0 and vp_rank == 0:
+                all_models.append(get_models(tp_size * ep_size, md.params_dtype))
+
+            models = all_models[pp_rank][vp_rank]
+            for layer_id in range(len(models[0].decoder.layers)):
+                message = {}
+
+                # get self-attention tensors
+                qkv_weight = []
+                qkv_bias = []
+                proj_weight = []
+                proj_bias = None
+                post_norm_weight = None
+                post_norm_bias = None
+                complete_tp_ranks = []
+                for tp_ep_rank, model in enumerate(models):
+                    tp_rank = tp_ep_rank % tp_size
+                    if tp_rank in complete_tp_ranks:
+                        continue
+                    complete_tp_ranks.append(tp_rank)
+                    layer = model.decoder.layers[layer_id]
+                    qkv_weight.append(layer.self_attention.linear_qkv.weight.data)
+                    proj_weight.append(layer.self_attention.linear_proj.weight.data)
+                    post_norm_weight = layer.self_attention.linear_qkv.layer_norm_weight.data
+                    if md.norm_has_bias:
+                        post_norm_bias = layer.self_attention.linear_qkv.layer_norm_bias.data
+                    if md.add_qkv_bias or md.add_bias_linear:
+                        qkv_bias.append(layer.self_attention.linear_qkv.bias.data)
+                        proj_bias = layer.self_attention.linear_proj.bias.data
+
+                # concat self-attention tensors
+                message["post norm weight"] = post_norm_weight
+                if md.norm_has_bias:
+                    message["post norm bias"] = post_norm_bias
+                message["qkv weight"] = torch.cat(qkv_weight, dim=0) 
+                message["proj weight"] = torch.cat(proj_weight, dim=1)
+                if md.add_qkv_bias or md.add_bias_linear:
+                    message["qkv bias"] = torch.cat(qkv_bias, dim=0)
+                    message["proj bias"] = proj_bias
+
+                # get pre-norm tensors
+                layer = models[0].decoder.layers[layer_id]
+                message["pre norm weight"] = layer.pre_mlp_layernorm.weight.data
+                if md.norm_has_bias:
+                    message["pre norm bias"] = layer.pre_mlp_layernorm.bias.data
+
+                if md.num_experts:
+                    # get experts tensors
+                    message["router weight"] = layer.mlp.router.weight.data
+                    num_local_experts = md.num_experts // ep_size
+                    for expert_id in range(num_local_experts):
+                        for ep_rank in range(ep_size):
+                            global_expert_id = num_local_experts * ep_rank + expert_id
+                            l0_weight = []
+                            l0_bias = []
+                            l1_weight = []
+                            l1_bias = None
+                            for tp_rank in range(tp_size):
+                                tp_ep_rank = ep_rank * ep_size + tp_rank
+                                layer = models[tp_ep_rank].decoder.layers[layer_id]
+                                expert = layer.mlp.experts.local_experts[expert_id]
+
+                                l0_weight.append(expert.linear_fc1.weight.data)
+                                l1_weight.append(expert.linear_fc2.weight.data)
+                                if md.add_bias_linear:
+                                    l0_bias.append(expert.linear_fc1.bias.data)
+                                    l1_bias = expert.linear_fc2.bias.data
+
+                            # concat expert tensors
+                            message[f"expert{global_expert_id} l1 weight"] = torch.cat(l1_weight, dim=1)
+                            if md.swiglu:
+                                for tp_rank in range(tp_size):
+                                    l0_weight[tp_rank] = torch.chunk(l0_weight[tp_rank], 2, dim=0)
+                                message[f"expert{global_expert_id} l0 weight W"] = torch.cat([w[0] for w in l0_weight], dim=0)
+                                message[f"expert{global_expert_id} l0 weight V"] = torch.cat([w[1] for w in l0_weight], dim=0)
+                            else:
+                                message[f"expert{global_expert_id} l0 weight"] = torch.cat(l0_weight, dim=0)
+
+                            if md.add_bias_linear:
+                                message[f"expert{global_expert_id} l1 bias"] = l1_bias
+                                if md.swiglu:
+                                    for tp_rank in range(tp_size):
+                                        l0_bias[tp_rank] = torch.chunk(l0_bias[tp_rank], 2, dim=0)
+                                    message[f"expert{global_expert_id} l0 bias W"] = torch.cat([b[0] for b in l0_bias],dim=0)
+                                    message[f"expert{global_expert_id} l0 bias V"] = torch.cat([b[1] for b in l0_bias],dim=0)
+                                else:
+                                    message[f"expert{global_expert_id} l0 bias"] = torch.cat(l0_bias, dim=0)
+                else:
+                    # get mlp tensors
+                    l0_weight = []
+                    l0_bias = []
+                    l1_weight = []
+                    l1_bias = None
+                    complete_tp_ranks = []
+                    for tp_ep_rank, model in enumerate(models):
+                        tp_rank = tp_ep_rank % tp_size
+                        if tp_rank in complete_tp_ranks:
+                            continue
+                        complete_tp_ranks.append(tp_rank)
+                        layer = model.decoder.layers[layer_id]
+                        l0_weight.append(layer.mlp.linear_fc1.weight.data)
+                        l1_weight.append(layer.mlp.linear_fc2.weight.data)
+                        if md.add_bias_linear:
+                            l0_bias.append(layer.mlp.linear_fc1.bias.data)
+                            l1_bias = layer.mlp.linear_fc2.bias.data
+
+                    # concat mlp tensors
+                    message["mlp l1 weight"] = torch.cat(l1_weight, dim=1)
+                    if md.swiglu:
+                        for tp_rank in range(tp_size):
+                            l0_weight[tp_rank] = torch.chunk(l0_weight[tp_rank], 2, dim=0)
+                        message["mlp l0 weight W"] = torch.cat([w[0] for w in l0_weight], dim=0)
+                        message["mlp l0 weight V"] = torch.cat([w[1] for w in l0_weight], dim=0)
+                    else:
+                        message["mlp l0 weight"] = torch.cat(l0_weight, dim=0)
+
+                    if md.add_bias_linear:
+                        message["mlp l1 bias"] = l1_bias
+                        if md.swiglu:
+                            for tp_rank in range(tp_size):
+                                l0_bias[tp_rank] = torch.chunk(l0_bias[tp_rank], 2, dim=0)
+                            message["mlp l0 bias W"] = torch.cat([b[0] for b in l0_bias],dim=0)
+                            message["mlp l0 bias V"] = torch.cat([b[1] for b in l0_bias],dim=0)
+                        else:
+                            message["mlp l0 bias"] = torch.cat(l0_bias, dim=0)
+
+                queue_put(f"transformer layer {total_layer_num}", message)
+                total_layer_num = total_layer_num + 1
+
+    # Send final norm from tp_rank 0
+    message = {"weight": models[0].decoder.final_layernorm.weight.data}
+    if md.norm_has_bias:
+        message["bias"] = models[0].decoder.final_layernorm.bias.data
+    queue_put("final norm", message)
+
+    if md.output_layer:
+        output_layer_weight = []
+        complete_tp_ranks = []
+        for tp_ep_rank, model in enumerate(models):
+            tp_rank = tp_ep_rank % tp_size
+            if tp_rank in complete_tp_ranks:
+                continue
+            complete_tp_ranks.append(tp_rank)
+            output_layer_weight.append(model.output_layer.weight.data)
+        message = {"weight": torch.cat(output_layer_weight, dim=0)}
+        queue_put("output layer", message)
+
+    queue.put("done")
+
+def load_checkpoint(queue, args):
+    try:
+        _load_checkpoint(queue, args)
+    except:
+        queue.put("exit")
+        raise

--- a/tools/loader_megatron.py
+++ b/tools/loader_megatron.py
@@ -317,7 +317,7 @@ def _load_checkpoint(queue, args):
                             l1_weight = []
                             l1_bias = None
                             for tp_rank in range(tp_size):
-                                tp_ep_rank = ep_rank * ep_size + tp_rank
+                                tp_ep_rank = ep_rank * tp_size + tp_rank
                                 layer = models[tp_ep_rank].decoder.layers[layer_id]
                                 expert = layer.mlp.experts.local_experts[expert_id]
 

--- a/tools/loader_megatron.py
+++ b/tools/loader_megatron.py
@@ -77,7 +77,7 @@ def _load_checkpoint(queue, args):
     # Arguments do sanity checks on the world size, but we don't care,
     # so trick it into thinking we are plenty of processes
     margs.world_size = margs.tensor_model_parallel_size * margs.pipeline_model_parallel_size * margs.expert_model_parallel_size
-    if margs.expert_model_parallel_size > 1:
+    if margs.num_experts:
         os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
     margs = validate_args(margs)
 

--- a/tools/loader_transformers.py
+++ b/tools/loader_transformers.py
@@ -161,24 +161,7 @@ def _load_checkpoint(queue, args):
     queue.put(md)
 
     # load ckpt
-    model, hf_model = ckpt_plugin.load_checkpoint_hf2mg(margs)
-
-    # print("="*30)
-    # print("transformers:")
-    # hf_state_dict = hf_model.state_dict()
-    # for name, param in hf_state_dict.items():
-    #     print("name:", name)
-    #     print("param:", torch.sum(param), param.dtype)
-
-    # print("="*30)
-    # print("megatron:")
-    # mg_state_dict = model.state_dict()
-    # for name, param in mg_state_dict.items():
-    #     print("name:", name)
-    #     try:
-    #         print("param:", torch.sum(param), param.dtype)
-    #     except Exception as e:
-    #         print('Failed to sum: ', repr(e))
+    model = ckpt_plugin.load_checkpoint_hf2mg(margs)
 
     # Send embeddings.
     message = dict()

--- a/tools/loader_transformers.py
+++ b/tools/loader_transformers.py
@@ -1,0 +1,278 @@
+import os
+import sys
+import types
+import importlib
+
+import torch
+
+
+def add_arguments(parser):
+    group = parser.add_argument_group(title='Transformers loader')
+
+    group.add_argument('--true-vocab-size', type=int, default=None,
+                       help='original size of vocab, if specified will trim padding from embedding table.')
+    group.add_argument('--vocab-file', type=str, default=None,
+                       help='Path to the vocab file. If specified will use this to get vocab size and '
+                       'trim padding from the embedding table.')
+    group.add_argument('--megatron-path', type=str, default=None,
+                       help='Base directory of deepspeed repository')
+
+def _load_checkpoint(queue, args):
+    try:
+        import transformers
+        major, minor, _ = map(int, transformers.__version__.split('.'))
+        assert major >= 4 and minor >= 31
+    except:
+        raise ImportError("")
+
+    # Search in directory above this.
+    root_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__),
+                     os.path.pardir))
+    sys.path.append(os.path.join(root_path, "megatron"))
+
+    if args.megatron_path is not None:
+        sys.path.insert(0, args.megatron_path)
+
+    try:
+        from megatron.arguments import parse_args, validate_args
+        from megatron.global_vars import set_global_variables
+        from megatron.model import module
+        from megatron.core import mpu
+        from megatron import fused_kernels
+        from megatron.core.tensor_parallel.random import (
+                _CUDA_RNG_STATE_TRACKER, _DATA_PARALLEL_RNG_TRACKER_NAME, 
+                _EXPERT_PARALLEL_RNG_TRACKER_NAME, _MODEL_PARALLEL_RNG_TRACKER_NAME
+            )
+    except ModuleNotFoundError:
+        print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
+        queue.put("exit")
+        exit(1)
+
+    def queue_put(name, msg):
+        print(f"sending {name}")
+        msg["name"] = name
+        queue.put(msg)
+
+    # We want all arguments to come from us.
+    sys.argv = [
+        'script.py',
+        '--no-masked-softmax-fusion',
+        '--no-bias-gelu-fusion',
+        '--no-bias-dropout-fusion',
+        '--no-async-tensor-model-parallel-allreduce',
+        '--use-cpu-initialization',
+        '--micro-batch-size', '1',
+        '--no-load-optim',
+        '--no-load-rng',
+        '--use-mcore-models',
+        '--no-save-optim',
+        '--no-save-rng',
+        '--no-initialization',
+        '--load', args.load_dir
+    ]
+
+    try:
+        args_plugin = importlib.import_module(args.model_type + ".args")
+        ckpt_plugin = importlib.import_module(args.model_type + ".ckpt")
+        model_plugin = importlib.import_module(args.model_type + ".model")
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("Please check model_type, args.py, ckpt.py or model.py")
+
+    margs = parse_args()
+    args_plugin.load_args_hf2mg(margs)
+    margs.world_size = margs.tensor_model_parallel_size * margs.pipeline_model_parallel_size * margs.expert_model_parallel_size
+    margs = validate_args(margs)
+
+    def check_for_arg(arg_name, default=None):
+        if getattr(margs, arg_name, None) is None:
+            if default is not None:
+                setattr(margs, arg_name, default)
+            else:
+                print(f"Checkpoint does not specify the argument {arg_name}. Exiting.")
+                print(f"Arguments: {margs}")
+                queue.put("exit")
+                exit(1)
+
+    check_for_arg('tensor_model_parallel_size')
+    check_for_arg('pipeline_model_parallel_size')
+    check_for_arg('expert_model_parallel_size')
+    check_for_arg('num_layers')
+    check_for_arg('hidden_size')
+    check_for_arg('seq_length')
+    check_for_arg('num_attention_heads')
+    check_for_arg('max_position_embeddings')
+    check_for_arg('position_embedding_type')
+    check_for_arg('iteration')
+    check_for_arg('bert_binary_head')
+    check_for_arg('params_dtype')
+    check_for_arg('swiglu', False)
+    check_for_arg('disable_bias_linear', False)
+    check_for_arg('add_qkv_bias', getattr(margs, "add_bias_linear_qkv", True))
+
+    margs.model_type = model_plugin.model_type
+    module.MegatronModule.embedding_warning_printed = True
+
+    set_global_variables(margs, build_tokenizer=False)
+    assert margs.world_size == 1
+    mpu.set_tensor_model_parallel_world_size(margs.tensor_model_parallel_size)
+    mpu.set_pipeline_model_parallel_world_size(margs.pipeline_model_parallel_size)
+    mpu.set_expert_model_parallel_world_size(margs.expert_model_parallel_size)
+    mpu.set_tensor_model_parallel_rank(0)
+    mpu.set_pipeline_model_parallel_rank(0)
+    mpu.set_expert_model_parallel_rank(0)
+
+    # fused kernel
+    fused_kernels.load(margs)
+
+    # random
+    _CUDA_RNG_STATE_TRACKER.reset()
+    torch.cuda.manual_seed(42)
+    _CUDA_RNG_STATE_TRACKER.add(_DATA_PARALLEL_RNG_TRACKER_NAME, 43)
+    _CUDA_RNG_STATE_TRACKER.add(_MODEL_PARALLEL_RNG_TRACKER_NAME, 44)
+    _CUDA_RNG_STATE_TRACKER.add(_EXPERT_PARALLEL_RNG_TRACKER_NAME, 45)
+
+    md = types.SimpleNamespace()
+    md.model_type = args.model_type
+    md.num_layers = margs.num_layers
+    md.num_experts = margs.num_experts
+    md.hidden_size = margs.hidden_size
+    md.seq_length = margs.seq_length
+    md.num_attention_heads = margs.num_attention_heads
+    md.max_position_embeddings = margs.max_position_embeddings
+    md.iteration = margs.iteration
+    md.params_dtype = margs.params_dtype
+    md.bert_binary_head = margs.bert_binary_head
+    md.output_layer = margs.untie_embeddings_and_output_weights
+    md.position_embedding_type = margs.position_embedding_type
+    md.add_bias_linear = margs.add_bias_linear
+    md.add_qkv_bias = margs.add_qkv_bias
+    md.norm_has_bias = margs.norm_has_bias
+    md.swiglu = margs.swiglu
+    md.previous_tensor_parallel_size = margs.tensor_model_parallel_size
+    md.previous_pipeline_parallel_size = margs.pipeline_model_parallel_size
+    md.previous_expert_parallel_size = margs.expert_model_parallel_size
+    md.previous_virtual_pipeline_parallel_size = margs.virtual_pipeline_model_parallel_size
+    md.true_vocab_size = margs.true_vocab_size
+    md.make_vocab_size_divisible_by = margs.make_vocab_size_divisible_by
+    md.checkpoint_args = margs
+    md.consumed_train_samples = margs.consumed_train_samples
+    md.consumed_valid_samples = margs.consumed_valid_samples
+    queue.put(md)
+
+    # load ckpt
+    model, hf_model = ckpt_plugin.load_checkpoint_hf2mg(margs)
+
+    # print("="*30)
+    # print("transformers:")
+    # hf_state_dict = hf_model.state_dict()
+    # for name, param in hf_state_dict.items():
+    #     print("name:", name)
+    #     print("param:", torch.sum(param), param.dtype)
+
+    # print("="*30)
+    # print("megatron:")
+    # mg_state_dict = model.state_dict()
+    # for name, param in mg_state_dict.items():
+    #     print("name:", name)
+    #     try:
+    #         print("param:", torch.sum(param), param.dtype)
+    #     except Exception as e:
+    #         print('Failed to sum: ', repr(e))
+
+    # Send embeddings.
+    message = dict()
+    message["word embeddings"]= model.embedding.word_embeddings.weight.data
+    if md.position_embedding_type == 'learned_absolute':
+        message["position embeddings"] = model.embedding.position_embeddings.weight.data
+    else:
+        assert not hasattr(model.embedding, 'position_embeddings')
+    queue_put("embeddings", message)
+
+    # Send transformer layers
+    for layer_id in range(margs.num_layers):
+        message = dict()
+        layer = model.decoder.layers[layer_id]
+
+        # attention
+        message["qkv weight"] = layer.self_attention.linear_qkv.weight.data
+        message["proj weight"] = layer.self_attention.linear_proj.weight.data
+        if md.add_qkv_bias:
+            message["qkv bias"] = layer.self_attention.linear_qkv.bias.data
+            message["proj bias"] = layer.self_attention.linear_proj.bias.data
+        message["post norm weight"] = layer.self_attention.linear_qkv.layer_norm_weight.data
+        if md.norm_has_bias:
+            message["post norm bias"] = layer.self_attention.linear_qkv.layer_norm_bias.data
+
+        # mlp
+        message["pre norm weight"] = layer.pre_mlp_layernorm.weight.data
+        if md.norm_has_bias:
+            message["pre norm bias"] = layer.pre_mlp_layernorm.bias.data
+        if margs.num_experts:
+            message["router weight"] = layer.mlp.router.weight.data
+
+            for expert_id in range(margs.num_experts):
+                expert = layer.mlp.experts.local_experts[expert_id]
+                # weight
+                l0_weight = expert.linear_fc1.weight.data
+                l1_weight = expert.linear_fc2.weight.data
+                message[f"expert{expert_id} l1 weight"] = l1_weight
+                if md.swiglu:
+                    message[f"expert{expert_id} l0 weight W"] = torch.chunk(l0_weight, 2, dim=0)[0]
+                    message[f"expert{expert_id} l0 weight V"] = torch.chunk(l0_weight, 2, dim=0)[1]
+                else:
+                    message[f"expert{expert_id} l0 weight"] = l0_weight
+
+                # bias
+                if md.add_bias_linear:
+                    l0_bias = expert.linear_fc1.bias.data
+                    l1_bias = expert.linear_fc2.bias.data
+                    message[f"expert{expert_id} l1 bias"] = l1_bias
+                    if md.swiglu:
+                        message[f"expert{expert_id} l0 bias W"] = torch.chunk(l0_bias, 2, dim=0)[0]
+                        message[f"expert{expert_id} l0 bias V"] = torch.chunk(l0_bias, 2, dim=0)[0]
+                    else:
+                        message[f"expert{expert_id} l0 bias"] = l0_bias
+        else:
+            l0_weight = layer.mlp.linear_fc1.weight.data
+            l1_weight = layer.mlp.linear_fc2.weight.data
+            # weight
+            message["mlp l1 weight"] = l1_weight
+            if md.swiglu:
+                message["mlp l0 weight W"] = torch.chunk(l0_weight, 2, dim=0)[0]
+                message["mlp l0 weight V"] = torch.chunk(l0_weight, 2, dim=0)[1]
+            else:
+                message["mlp l0 weight"] = l0_weight
+
+            # bias
+            if md.add_bias_linear:
+                l0_bias = layer.mlp.linear_fc1.bias.data
+                l1_bias = layer.mlp.linear_fc2.bias.data
+                message["mlp l1 bias"] = l1_bias
+                if md.swiglu:
+                    message["mlp l0 bias W"] = torch.chunk(l0_bias, 2, dim=0)[0]
+                    message["mlp l0 bias V"] = torch.chunk(l0_bias, 2, dim=0)[1]
+                else:
+                    message["mlp l0 bias"] = l0_bias
+
+        queue_put(f"transformer layer {layer_id}", message)
+
+    # Send final norm from tp_rank 0.
+    message = {"weight": model.decoder.final_layernorm.weight.data}
+    if md.norm_has_bias:
+        message["bias"] = model.decoder.final_layernorm.bias.data
+    queue_put("final norm", message)
+
+    if md.output_layer:
+        message = {"weight": model.output_layer.weight.data}
+        queue_put("output layer", message)
+
+    queue.put("done")
+
+
+def load_checkpoint(queue, args):
+    try:
+        _load_checkpoint(queue, args)
+    except:
+        queue.put("exit")
+        raise

--- a/tools/mixtral/args.py
+++ b/tools/mixtral/args.py
@@ -1,0 +1,53 @@
+import os
+import json
+
+
+def load_args_hf2mg(args):
+
+    # Read mixtral args.
+    mixtral_args_path = os.path.join(args.load, "config.json")
+    with open(mixtral_args_path) as f:
+        mixtral_args = json.load(f)
+
+    # Update Megatron args.
+    args.seq_length = 2048
+    args.attention_dropout = mixtral_args["attention_dropout"]
+    args.hidden_dropout = mixtral_args["attention_dropout"]
+    args.swiglu = True
+    args.hidden_size = mixtral_args["hidden_size"]
+    args.init_method_std = mixtral_args["initializer_range"]
+    args.ffn_hidden_size = mixtral_args["intermediate_size"]
+    args.max_position_embeddings = mixtral_args["max_position_embeddings"]
+    args.model_type = mixtral_args["model_type"]
+    args.num_attention_heads = mixtral_args["num_attention_heads"]
+    args.moe_router_topk = mixtral_args["num_experts_per_tok"]
+    args.num_layers = mixtral_args["num_hidden_layers"]
+    args.group_query_attention = True
+    args.num_query_groups = mixtral_args["num_key_value_heads"]
+    args.num_experts = mixtral_args["num_local_experts"]
+    args.normalization = "RMSNorm"
+    args.norm_epsilon = mixtral_args["rms_norm_eps"]
+    args.use_rotary_position_embeddings = True
+    args.moe_router_load_balancing_type = "aux_loss"
+    args.moe_aux_loss_coeff = mixtral_args["router_aux_loss_coef"]
+    args.untie_embeddings_and_output_weights = not mixtral_args["tie_word_embeddings"]
+    mixtral_args["torch_dtype"] = "float32"
+    args.bf16 = mixtral_args["torch_dtype"] == "bfloat16"
+    args.fp16 = mixtral_args["torch_dtype"] == "float16"
+    args.vocab_size = mixtral_args["vocab_size"]
+    args.padded_vocab_size = mixtral_args["vocab_size"]
+
+    args.global_batch_size = 1024
+    args.iteration = 1 # '0', 'release' don't work
+    args.add_position_embedding = False
+    args.add_bias_linear = False
+    args.add_qkv_bias = False
+    args.norm_has_bias = False
+    args.true_vocab_size = None # to skip padding in saver
+    args.make_vocab_size_divisible_by = None
+    args.consumed_train_samples = 0
+    args.consumed_valid_samples = 0
+
+    return args, args
+
+

--- a/tools/mixtral/ckpt.py
+++ b/tools/mixtral/ckpt.py
@@ -1,0 +1,88 @@
+import torch
+from tqdm import tqdm
+
+
+def _set_preprocess_state(args, model, hf_model):
+    '''Set embedding params.'''
+    model.embedding.word_embeddings.weight.data.copy_(hf_model.model.embed_tokens.weight)
+
+
+def _set_postprocess_state(args, model, hf_model):
+    '''Set output layer & norm params.'''
+    model.decoder.final_layernorm.weight.data.copy_(hf_model.model.norm.weight)
+    model.output_layer.weight.data.copy_(hf_model.lm_head.weight)
+
+
+def _set_attn_state(args, layer, hf_layer):
+    '''Set self-attention params.'''
+
+    # Get attention layer & state.
+    attn = layer.self_attention
+    hf_attn = hf_layer.self_attn
+
+    # Reshape loaded weights.
+    nh = args.num_attention_heads
+    ng = args.num_query_groups if args.group_query_attention else args.num_attention_heads
+    dim = args.kv_channels
+    assert nh % ng == 0
+
+    # Copy weights (re-order dimensions for Megatron).
+    attn.linear_qkv.weight.data.copy_(
+        torch.cat([
+            hf_attn.q_proj.weight.reshape((ng, dim*nh//ng, -1)),
+            hf_attn.k_proj.weight.reshape((ng, dim, -1)),
+            hf_attn.v_proj.weight.reshape((ng, dim, -1)),
+        ], dim=1).reshape((-1, args.hidden_size))
+    )
+    attn.linear_proj.weight.data.copy_(hf_attn.o_proj.weight)
+    attn.linear_qkv.layer_norm_weight.data.copy_(hf_layer.post_attention_layernorm.weight)
+
+
+def _set_mlp_state(args, layer, hf_layer):
+    '''Set MLP params.'''
+
+    mlp = layer.mlp
+    hf_mlp = hf_layer.block_sparse_moe
+
+    mlp.router.weight = hf_mlp.gate.weight
+    for id in range(args.num_experts):
+        expert = mlp.experts.local_experts[id]
+        hf_expert = hf_mlp.experts[id]
+
+        expert.linear_fc1.weight.data.copy_(
+            torch.cat([
+                hf_expert.w1.weight,
+                hf_expert.w3.weight,
+            ], dim=0)
+        )
+        expert.linear_fc2.weight.data.copy_(
+            hf_expert.w2.weight
+        )
+
+
+def _set_layer_state(args, model, hf_model, layer_idx):
+    '''Set transformer layer params.'''
+
+    layer = model.decoder.layers[layer_idx]
+    hf_layer = hf_model.model.layers[layer_idx]
+
+    _set_attn_state(args, layer, hf_layer)
+    _set_mlp_state(args, layer, hf_layer)
+    layer.pre_mlp_layernorm.weight.data.copy_(hf_layer.input_layernorm.weight)
+
+
+def load_checkpoint_hf2mg(args):
+    '''Set model params.'''
+    from .model import get_hf_model, get_mg_model
+
+    hf_model = get_hf_model(args.load)
+    model = get_mg_model(args.params_dtype, True, True)
+
+    # Set model state.
+    _set_preprocess_state(args, model, hf_model)
+    _set_postprocess_state(args, model, hf_model)
+    for layer_idx in tqdm(range(args.num_layers), "set layer states"):
+        _set_layer_state(args, model, hf_model, layer_idx)
+    model.decoder.final_layernorm.weight.data.copy_(hf_model.model.norm.weight)
+
+    return model, hf_model

--- a/tools/mixtral/ckpt.py
+++ b/tools/mixtral/ckpt.py
@@ -85,4 +85,4 @@ def load_checkpoint_hf2mg(args):
         _set_layer_state(args, model, hf_model, layer_idx)
     model.decoder.final_layernorm.weight.data.copy_(hf_model.model.norm.weight)
 
-    return model, hf_model
+    return model

--- a/tools/mixtral/model.py
+++ b/tools/mixtral/model.py
@@ -1,0 +1,18 @@
+
+from megatron.core.enums import ModelType
+
+
+model_type = ModelType.encoder_or_decoder
+
+
+def get_hf_model(model_path):
+    from transformers import MixtralForCausalLM
+    # Load Huggingface model.
+    model = MixtralForCausalLM.from_pretrained(model_path, device_map="cpu")
+    return model
+
+
+def get_mg_model(dtype, pre_process, post_process):
+    from pretrain_gpt import model_provider
+    model = model_provider(pre_process, post_process).to(dtype)
+    return model

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -7,4 +7,4 @@ python convert.py \
     --target-tensor-parallel-size 2 \
     --target-pipeline-parallel-size 2 \
     --target-expert-parallel-size 2 \
-    --megatron-path /share/project/zhaoyingli/FlagScale/megatron
+    --megatron-path <xxx>

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -1,0 +1,10 @@
+python convert.py \
+    --model-type mixtral \
+    --loader transformer \
+    --saver megatron \
+    --load-dir Mixtral-8x7B-v0.1 \
+    --save-dir output \
+    --target-tensor-parallel-size 2 \
+    --target-pipeline-parallel-size 2 \
+    --target-expert-parallel-size 2 \
+    --megatron-path /share/project/zhaoyingli/FlagScale/megatron

--- a/tools/saver_megatron.py
+++ b/tools/saver_megatron.py
@@ -324,7 +324,7 @@ def save_checkpoint(queue, args):
                                 expert_l0_bias = torch.chunk(msg.pop(f"expert{global_expert_id} l0 bias"), tp_size, dim=0)
                         # copy
                         for tp_rank in range(tp_size):
-                            tp_ep_rank = ep_rank * ep_size + tp_rank
+                            tp_ep_rank = ep_rank * tp_size + tp_rank
                             layer = models[tp_ep_rank].decoder.layers[layer_id]
                             layer.mlp.router.weight.data.copy_(router_weight)
                             layer.pre_mlp_layernorm.weight.data.copy_(pre_mlp_layernorm)

--- a/tools/saver_megatron.py
+++ b/tools/saver_megatron.py
@@ -1,0 +1,430 @@
+import os
+import sys
+import importlib
+
+import torch
+
+
+def add_arguments(parser):
+    group = parser.add_argument_group(title='Megatron saver')
+
+    # group.add_argument('--megatron-path', type=str, default=None,
+    #                 help='Base directory of deepspeed repository')
+    group.add_argument('--target-tensor-parallel-size', type=int,
+                       help='Target tensor model parallel size, defaults to the tensor parallel size '
+                       'in the input checkpoint if provided by the loader, otherwise to 1')
+    group.add_argument('--target-pipeline-parallel-size', type=int,
+                       help='Target tensor model parallel size, default to the pipeline parall size '
+                       'in the input checkpoint if provided by the loader, otherwise to 1')
+    group.add_argument("--target-expert-parallel-size", type=int,
+                      help='The tensor model parallel size of the converted checkpoint. '
+                           'Only used when converting a Transformers checkpoint to a Megatron checkpoint.')
+    group.add_argument("--target-params-dtype", type=str, default=None,
+                       help='The dtype of the converted checkpoint. '
+                            'Only used when converting a Transformers checkpoint to a Megatron checkpoint.')
+
+
+def save_checkpoint(queue, args):
+    # Search in directory above this
+    root_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__),
+                     os.path.pardir))
+    sys.path.append(os.path.join(root_path, "megatron"))
+
+    if args.megatron_path is not None:
+        sys.path.insert(0, args.megatron_path)
+
+    try:
+        from megatron.arguments import parse_args, validate_args
+        from megatron.checkpointing import save_checkpoint, get_checkpoint_name
+        from megatron.global_vars import set_global_variables, get_args
+        from megatron.tokenizer.tokenizer import _vocab_size_with_padding
+        from megatron import fused_kernels
+        from megatron.core import mpu
+        from megatron.core.tensor_parallel.random import (
+                _CUDA_RNG_STATE_TRACKER, _DATA_PARALLEL_RNG_TRACKER_NAME, 
+                _EXPERT_PARALLEL_RNG_TRACKER_NAME, _MODEL_PARALLEL_RNG_TRACKER_NAME
+            )
+    except ModuleNotFoundError:
+        print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
+        queue.put("exit")
+        exit(1)
+
+    def queue_get(name=None):
+        val = queue.get()
+        if val == "exit":
+            print("Loader exited, exiting saver")
+            exit(1)
+        if name is not None and val["name"] != name:
+            val_name = val["name"]
+            print(f'Unexpected message. Expecting "{name}" but got "{val_name}". Exiting saver.')
+            exit(1)
+        if name is not None:
+            print(f"received {name}")
+        return val
+
+    def check_message(msg):
+        msg_name = msg.pop("name")
+        if len(msg.keys()) > 0:
+            print(f"Unexpected values in {msg_name}:")
+            for key in msg.keys():
+                print(f"   {key}")
+            exit(1)
+
+    md = queue.get()
+
+    if args.target_tensor_parallel_size is None:
+        if hasattr(md, 'previous_tensor_parallel_size'):
+            args.target_tensor_parallel_size = md.previous_tensor_parallel_size
+        else:
+            print("loader did not provide a tensor parallel size and --target-tensor-parallel-size not provided on command line. "
+                  "Default to 1.")
+            args.target_tensor_parallel_size = 1
+
+    if args.target_pipeline_parallel_size is None:
+        if hasattr(md, 'previous_pipeline_parallel_size'):
+            args.target_pipeline_parallel_size = md.previous_pipeline_parallel_size
+        else:
+            print("loader did not provide a pipeline parallel size and --target-pipeline-parallel-size not provided on command line. "
+                  "Default to 1.")
+            args.target_pipeline_parallel_size = 1
+
+    if args.target_expert_parallel_size is None:
+        if hasattr(md, 'previous_expert_parallel_size'):
+            args.target_expert_parallel_size = md.previous_expert_parallel_size
+        else:
+            print("loader did not provide a pipeline parallel size and --target-pipeline-parallel-size not provided on command line. "
+                  "Default to 1.")
+            args.target_expert_parallel_size = 1
+
+    os.environ["WORLD_SIZE"] = f'{args.target_tensor_parallel_size * args.target_pipeline_parallel_size * args.target_expert_parallel_size}'
+
+    # We want all arguments to come from us
+    sys.argv = [
+        'script.py',
+        '--num-layers', str(md.num_layers),
+        '--hidden-size', str(md.hidden_size),
+        '--seq-length', str(md.seq_length),
+        '--num-attention-heads', str(md.num_attention_heads),
+        '--max-position-embeddings', str(md.max_position_embeddings),
+        '--position-embedding-type', str(md.position_embedding_type),
+        '--tensor-model-parallel-size', str(args.target_tensor_parallel_size),
+        '--pipeline-model-parallel-size', str(args.target_pipeline_parallel_size),
+        '--expert-model-parallel-size', str(args.target_expert_parallel_size),
+        '--no-masked-softmax-fusion',
+        '--no-bias-gelu-fusion',
+        '--no-bias-dropout-fusion',
+        '--no-async-tensor-model-parallel-allreduce',
+        '--use-cpu-initialization',
+        "--use-mcore-models",
+        '--micro-batch-size', '1',
+        '--no-load-optim',
+        '--no-load-rng',
+        '--no-save-optim',
+        '--no-save-rng',
+        '--no-initialization',
+        '--save-interval', '1',
+        '--save', args.save_dir
+    ]
+
+    if md.make_vocab_size_divisible_by is not None:
+        sys.argv.extend(['--make-vocab-size-divisible-by', str(md.make_vocab_size_divisible_by)])
+    if md.output_layer:
+        sys.argv.append('--untie-embeddings-and-output-weights')
+    if not md.add_bias_linear:
+        sys.argv.append('--disable-bias-linear')
+    if md.add_qkv_bias:
+        sys.argv.append('--add-qkv-bias')
+    if md.model_type == 'BERT' and not md.bert_binary_head:
+        sys.argv.append('--bert-no-binary-head')
+    if args.target_expert_parallel_size > 1:
+        sys.argv.append('--sequence-parallel')
+        os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
+    if md.params_dtype == torch.float16:
+        sys.argv.append('--fp16')
+    elif md.params_dtype == torch.bfloat16:
+        sys.argv.append('--bf16')
+
+    margs = parse_args()
+    if hasattr (md, 'checkpoint_args'):
+        # These are arguments that we are either changing, or cause problems for validation if they are set
+        # Note that some of these deal with T5 so will need to be changed if we support T5.
+        args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'world_size', 'params_dtype',
+                        'num_layers_per_virtual_pipeline_stage', 'virtual_pipeline_model_parallel_size',
+                        'masked_softmax_fusion', 'bias_gelu_fusion', 'bias_dropout_fusion',
+                        'sequence_parallel', 'async_tensor_model_parallel_allreduce',
+                        'no_load_optim', 'no_load_rng', 'no_save_optim', 'no_save_rng',
+                        'vocab_file', 'tokenizer_model', 'expert_model_parallel_size',
+                        'save_interval', 'save', 'use_mcore_models',
+                        'perform_initialization', 'use_cpu_initialization',
+                        'recompute_granularity', 'recompute_num_layers', 'recompute_method',
+                        'encoder_num_layers', 'encoder_seq_length',
+                        'distribute_saved_activations',
+                        'train_iters', 'lr_decay_iters', 'lr_warmup_iters', 'lr_warmup_fraction',
+                        'start_weight_decay', 'end_weight_decay']
+        for arg, value in vars(md.checkpoint_args).items():
+            if arg in args_to_keep:
+                continue
+            if not hasattr(margs, arg):
+                print(f"Checkpoint had argument {arg} but new arguments does not have this.")
+                continue
+            if getattr(margs, arg) != value:
+                print(f"Overwriting default {arg} value {getattr(margs, arg)} with value from checkpoint {value}.")
+                setattr(margs, arg, value)
+    validate_args(margs)
+
+    # megatron args
+    set_global_variables(margs, build_tokenizer=False)
+    margs = get_args()
+
+    if hasattr(md, 'consumed_train_samples'):
+        margs.consumed_train_samples = md.consumed_train_samples
+        margs.consumed_valid_samples = md.consumed_valid_samples
+        print(f"Setting consumed_train_samples to {margs.consumed_train_samples}"
+              f" and consumed_valid_samples to {margs.consumed_valid_samples}")
+    else:
+        print("consumed_train_samples not provided.")
+
+    try:
+        model_plugin = importlib.import_module(args.model_type + ".model")
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("Please check model_type or model.py")
+
+    def get_models(count, dtype):
+        pre_process = mpu.is_pipeline_first_stage()
+        post_process = mpu.is_pipeline_last_stage()
+        models = [model_plugin.get_mg_model(dtype, pre_process, post_process) for _ in range(count)]
+        return models
+
+    margs.model_type = model_plugin.model_type
+
+    # fake initializing distributed
+    tp_size = args.target_tensor_parallel_size
+    pp_size = args.target_pipeline_parallel_size
+    ep_size = args.target_expert_parallel_size
+
+    mpu.set_tensor_model_parallel_world_size(tp_size)
+    mpu.set_pipeline_model_parallel_world_size(pp_size)
+    mpu.set_expert_model_parallel_world_size(ep_size)
+    mpu.set_tensor_model_parallel_rank(0)
+    mpu.set_pipeline_model_parallel_rank(0)
+    mpu.set_expert_model_parallel_rank(0)
+
+    # fused kernel
+    fused_kernels.load(margs)
+
+    # random
+    _CUDA_RNG_STATE_TRACKER.reset()
+    torch.cuda.manual_seed(42)
+    _CUDA_RNG_STATE_TRACKER.add(_DATA_PARALLEL_RNG_TRACKER_NAME, 43)
+    _CUDA_RNG_STATE_TRACKER.add(_MODEL_PARALLEL_RNG_TRACKER_NAME, 44)
+    _CUDA_RNG_STATE_TRACKER.add(_EXPERT_PARALLEL_RNG_TRACKER_NAME, 45)
+
+    # embedding
+    embeddings_msg = queue_get("embeddings")
+    pos_embed = None
+    if md.position_embedding_type == 'learned_absolute':
+        pos_embed = embeddings_msg.pop("position embeddings")
+    orig_word_embed = embeddings_msg.pop("word embeddings")
+    check_message(embeddings_msg)
+
+    # padding vocab_size
+    if md.true_vocab_size is not None:
+        # figure out what our padded vocab size is
+        orig_vocab_size = orig_word_embed.shape[0]
+        margs.padded_vocab_size = _vocab_size_with_padding(md.true_vocab_size, margs)
+
+        # Cut out extra padding we don't need
+        if orig_vocab_size > margs.padded_vocab_size:
+            full_word_embed = orig_word_embed[0:margs.padded_vocab_size,:]
+
+        # Expanding embedding to larger size by replicating final entry
+        elif orig_vocab_size < margs.padded_vocab_size:
+            padding_size = margs.padded_vocab_size - orig_vocab_size
+
+            full_word_embed = torch.cat((
+                orig_word_embed,
+                orig_word_embed[-1].unsqueeze(0).expand(padding_size, -1)))
+
+        # Same size!
+        else:
+            full_word_embed = orig_word_embed
+    else:
+        print("Original vocab size not specified, leaving embedding table as-is. "
+              "If you've changed the tensor parallel size this could cause problems.")
+        margs.padded_vocab_size = orig_word_embed.shape[0]
+        full_word_embed = orig_word_embed
+
+    # process world embedding in first pp stage
+    mpu.set_pipeline_model_parallel_rank(0)
+    models = get_models(tp_size * ep_size, md.params_dtype)
+    out_word_embed = torch.chunk(full_word_embed, tp_size, dim=0)
+    for tp_ep_rank, model in enumerate(models):
+        tp_rank = tp_ep_rank % tp_size
+        model.embedding.word_embeddings.weight.data.copy_(out_word_embed[tp_rank])
+        if pos_embed is not None:
+            model.embedding.position_embeddings.weight.data.copy_(pos_embed)
+        else:
+            assert not hasattr(model.embedding, "position_embeddings")
+
+    # process transformer layer
+    total_layer_num = 0
+    for pp_rank in range(pp_size):
+
+        mpu.set_pipeline_model_parallel_rank(pp_rank)
+
+        if pp_rank > 0:
+            models = get_models(tp_size * ep_size, md.params_dtype)
+
+        for layer_id in range(len(models[0].decoder.layers)):
+            msg = queue_get(f"transformer layer {total_layer_num}")
+
+            # process self attention
+            post_norm_weight = msg.pop("post norm weight")
+            qkv_weight = torch.chunk(msg.pop("qkv weight"), tp_size, dim=0)
+            proj_weight = torch.chunk(msg.pop("proj weight"), tp_size, dim=1)
+            if md.add_qkv_bias or md.add_bias_linear:
+                qkv_bias = torch.chunk(msg.pop("qkv bias"), tp_size, dim=0)
+                proj_bias = msg.pop("proj bias")
+            # split
+            for tp_ep_rank, model in enumerate(models):
+                tp_rank = tp_ep_rank % tp_size
+                layer = model.decoder.layers[layer_id]
+                layer.self_attention.linear_qkv.weight.data.copy_(qkv_weight[tp_rank])
+                layer.self_attention.linear_proj.weight.data.copy_(proj_weight[tp_rank])
+                layer.self_attention.linear_qkv.layer_norm_weight.data.copy_(post_norm_weight)
+                if md.add_qkv_bias or md.add_bias_linear:
+                    layer.self_attention.linear_qkv.bias.data.copy_(qkv_bias[tp_rank])
+                    layer.self_attention.linear_proj.bias.data.copy_(proj_bias)
+
+            # process mlp
+            pre_mlp_layernorm = msg.pop("pre norm weight")
+            if md.num_experts:
+                router_weight = msg.pop("router weight")
+                num_local_experts = md.num_experts // ep_size
+                for expert_id in range(num_local_experts):
+                    for ep_rank in range(ep_size):
+                        global_expert_id = ep_rank * num_local_experts + expert_id
+                        # weight
+                        expert_l1_weight = torch.chunk(msg.pop(f"expert{global_expert_id} l1 weight"), tp_size, dim=1)
+                        if md.swiglu:
+                            expert_l0_weight_W = torch.chunk(msg.pop(f"expert{global_expert_id} l0 weight W"), tp_size, dim=0)
+                            expert_l0_weight_V = torch.chunk(msg.pop(f"expert{global_expert_id} l0 weight V"), tp_size, dim=0)
+                            expert_l0_weight = [torch.cat(weights, dim=0) for weights in zip(expert_l0_weight_W, expert_l0_weight_V)]
+                        else:
+                            expert_l0_weight = torch.chunk(msg.pop(f"expert{global_expert_id} l0 weight"), tp_size, dim=0)
+                        # bias
+                        if md.add_bias_linear:
+                            expert_l1_bias = msg.pop(f"expert{global_expert_id} l1 bias")
+                            if md.swiglu:
+                                expert_l0_bias_W = torch.chunk(msg.pop(f"expert{global_expert_id} l0 bias W"), tp_size, dim=0)
+                                expert_l0_bias_V = torch.chunk(msg.pop(f"expert{global_expert_id} l0 bias V"), tp_size, dim=0)
+                                expert_l0_bias = [torch.cat(bias, dim=0) for bias in zip(expert_l0_bias_W, expert_l0_bias_V)]
+                            else:
+                                expert_l0_bias = torch.chunk(msg.pop(f"expert{global_expert_id} l0 bias"), tp_size, dim=0)
+                        # copy
+                        for tp_rank in range(tp_size):
+                            tp_ep_rank = ep_rank * ep_size + tp_rank
+                            layer = models[tp_ep_rank].decoder.layers[layer_id]
+                            layer.mlp.router.weight.data.copy_(router_weight)
+                            layer.pre_mlp_layernorm.weight.data.copy_(pre_mlp_layernorm)
+                            expert = layer.mlp.experts.local_experts[expert_id]
+                            expert.linear_fc1.weight.data.copy_(expert_l0_weight[tp_rank])
+                            expert.linear_fc2.weight.data.copy_(expert_l1_weight[tp_rank])
+                            if md.add_bias_linear:
+                                expert.linear_fc1.bias.data.copy_(expert_l0_bias[tp_rank])
+                                expert.linear_fc2.bias.data.copy_(expert_l1_bias)
+            else:
+                # weight
+                mlp_l1_weight = torch.chunk(msg.pop("mlp l1 weight"), tp_size, dim=1)
+                if md.swiglu:
+                    mlp_l0_weight_W = torch.chunk(msg.pop("mlp l0 weight W"), tp_size, dim=0)
+                    mlp_l0_weight_V = torch.chunk(msg.pop("mlp l0 weight V"), tp_size, dim=0)
+                    mlp_l0_weight = [torch.cat(weights, dim=0) for weights in zip(mlp_l0_weight_W, mlp_l0_weight_V)]
+                else:
+                    mlp_l0_weight = torch.chunk(msg.pop("mlp l0 weight"), tp_size, dim=0)
+                # bias
+                if md.add_bias_linear:
+                    mlp_l1_bias = msg.pop("mlp l1 bias")
+                    if md.swiglu:
+                        mlp_l0_bias_W = torch.chunk(msg.pop("mlp l0 bias W"), tp_size, dim=0)
+                        mlp_l0_bias_V = torch.chunk(msg.pop("mlp l0 bias V"), tp_size, dim=0)
+                        mlp_l0_bias = [torch.cat(bias, dim=0) for bias in zip(mlp_l0_bias_W, mlp_l0_bias_V)]
+                    else:
+                        mlp_l0_bias = torch.chunk(msg.pop("mlp l0 bias"), tp_size, dim=0)
+                # split and copy
+                for tp_ep_rank, model in enumerate(models):
+                    tp_rank = tp_ep_rank % tp_size
+                    layer = model.decoder.layers[layer_id]
+                    layer.pre_mlp_layernorm.weight.data.copy_(pre_mlp_layernorm)
+                    layer.mlp.linear_fc2.weight.data.copy_(mlp_l1_weight[tp_rank])
+                    layer.mlp.linear_fc1.weight.data.copy_(mlp_l0_weight[tp_rank])
+                    if md.add_bias_linear:
+                        layer.mlp.linear_fc1.bias.data.copy_(mlp_l0_bias[tp_rank])
+                        layer.mlp.linear_fc2.bias.data.copy_(mlp_l1_bias)
+
+            total_layer_num = total_layer_num + 1
+            check_message(msg)
+
+        # process final layernorm and linear
+        if pp_rank == pp_size - 1:
+            msg = queue_get("final norm")
+            final_norm_weight = msg.pop("weight")
+            if md.norm_has_bias:
+                final_norm_bias = msg.pop("bias")
+            for tp_ep_rank, model in enumerate(models):
+                model.decoder.final_layernorm.weight.data.copy_(final_norm_weight)
+                if md.norm_has_bias:
+                    model.decoder.final_layernorm.bias.data.copy_(final_norm_bias)
+            check_message(msg)
+
+            if md.output_layer:
+                msg = queue_get("output layer")
+                assert hasattr(models[0], 'output_layer'), "ERROR: got an output layer, but model does not have one"
+                orig_output_layer_weight = msg.pop("weight")
+                if md.true_vocab_size is not None:
+                    # figure out what our padded vocab size is
+                    orig_output_layer_size = orig_output_layer_weight.shape[0]
+                    margs.padded_vocab_size = _vocab_size_with_padding(md.true_vocab_size, margs)
+
+                    # Cut out extra padding we don't need
+                    if orig_output_layer_size > margs.padded_vocab_size:
+                        full_output_layer_weight = orig_output_layer_weight[0:margs.padded_vocab_size,:]
+
+                    # Expanding embedding to larger size by replicating final entry
+                    elif orig_output_layer_size < margs.padded_vocab_size:
+                        padding_size = margs.padded_vocab_size - orig_output_layer_size
+
+                        full_output_layer_weight = torch.cat((
+                            orig_output_layer_weight,
+                            orig_output_layer_weight[-1].unsqueeze(0).expand(padding_size, -1)))
+
+                    # Same size!
+                    else:
+                        full_output_layer_weight = orig_output_layer_weight
+                else:
+                    print("Original vocab size not specified, leaving embedding table as-is. "
+                          "If you've changed the tensor parallel size this could cause problems.")
+                    margs.padded_vocab_size = orig_output_layer_weight.shape[0]
+                    full_output_layer_weight = orig_output_layer_weight
+
+                output_layer_weight = torch.chunk(full_output_layer_weight, tp_size, dim=0)
+                for tp_ep_rank, model in enumerate(models):
+                    tp_rank = tp_ep_rank % tp_size
+                    model.output_layer.weight.data.copy_(output_layer_weight[tp_rank])
+
+            msg = queue_get()
+            if msg != "done":
+                print("ERROR: got some more data but was expecting to be done")
+
+        for tp_ep_rank, model in enumerate(models):
+            tp_rank = tp_ep_rank % tp_size
+            ep_rank = tp_ep_rank // ep_size
+            mpu.set_tensor_model_parallel_rank(tp_rank)
+            mpu.set_expert_model_parallel_rank(ep_rank)
+            checkpoint_name = get_checkpoint_name(margs.save, md.iteration)
+            print("save to:", checkpoint_name)
+            save_checkpoint(md.iteration, [model], None, None,
+                            num_floating_point_operations_so_far=0)
+
+    print("Done!!!")

--- a/tools/saver_megatron.py
+++ b/tools/saver_megatron.py
@@ -419,7 +419,7 @@ def save_checkpoint(queue, args):
 
         for tp_ep_rank, model in enumerate(models):
             tp_rank = tp_ep_rank % tp_size
-            ep_rank = tp_ep_rank // ep_size
+            ep_rank = tp_ep_rank // tp_size
             mpu.set_tensor_model_parallel_rank(tp_rank)
             mpu.set_expert_model_parallel_rank(ep_rank)
             checkpoint_name = get_checkpoint_name(margs.save, md.iteration)

--- a/tools/saver_megatron.py
+++ b/tools/saver_megatron.py
@@ -137,7 +137,7 @@ def save_checkpoint(queue, args):
         sys.argv.append('--add-qkv-bias')
     if md.model_type == 'BERT' and not md.bert_binary_head:
         sys.argv.append('--bert-no-binary-head')
-    if args.target_expert_parallel_size > 1:
+    if md.num_experts:
         sys.argv.append('--sequence-parallel')
         os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
     if md.params_dtype == torch.float16:


### PR DESCRIPTION
## Description
- loader_transformer: load complete (no parallel) ckpt file
- loader_megatron: can load parallel-ckpt file, support tp, pp, vpp and moe
- saver_megatron: can save parallel-ckpt file, support tp, pp and moe
- example:
```bash
cd tools
python convert.py \
    --model-type mixtral \
    --loader transformer \
    --saver megatron \
    --load-dir Mixtral-8x7B-v0.1 \
    --save-dir output \
    --target-tensor-parallel-size 2 \
    --target-pipeline-parallel-size 2 \
    --target-expert-parallel-size 2 \
```

## Experiment
- [x] tp2ep2pp2
- [x] tp4ep2
- [x] ep4pp2
- [x] tp2pp4
- [x] tp8ep4pp2

## TODO
- support vpp save
- add saver_transformer
- add aquila transfer