### PR TITLE
[BugFix] Repair train_mixtral_8x7b.yaml

### DIFF
--- a/examples/mixtral/conf/train/train_mixtral_8x7b.yaml
+++ b/examples/mixtral/conf/train/train_mixtral_8x7b.yaml
@@ -1,7 +1,7 @@
 system:
-  tensor_model_parallel_size: 4
-  pipeline_model_parallel_size: 1
-  expert_model_parallel_size: 4
+  tensor_model_parallel_size: 1
+  pipeline_model_parallel_size: 4
+  expert_model_parallel_size: 8
   sequence_parallel: true
   use_distributed_optimizer: true
   precision:
@@ -22,7 +22,7 @@ model:
   hidden_size: 4096
   ffn_hidden_size: 14336
   num_attention_heads: 32
-  seq_length: 2048
+  seq_length: 4096
   max_position_embeddings: 32768
   swiglu: true
   normalization: RMSNorm
@@ -34,7 +34,7 @@ model:
   hidden_dropout: 0.0
   disable_bias_linear: true
   position_embedding_type: rope
-  rotary_base: 1000000.0
+  rotary_base: 1000000
   no_position_embedding: true
   no_masked_softmax_fusion: true
   untie_embeddings_and_output_weights: true
@@ -48,7 +48,7 @@ model:
   # seed: 42
   train_iters: 500000
   micro_batch_size: 1
-  global_batch_size: 128
+  global_batch_size: 256
   clip_grad: 1.0
   eval_interval: 1000
   eval_iters: 10
@@ -69,8 +69,4 @@ data:
   tokenizer:
     tokenizer_type: QwenTokenizerFS
     tokenizer_path: <xxxx>
-    vocab_file: examples/aquila/tokenizer/vocab.json
-    merge_file: examples/aquila/tokenizer/merges.txt
-    special_tokens_file: examples/aquila/tokenizer/special_tokens.txt
-    vocab_size: 151851
     make_vocab_size_divisible_by: 64


### PR DESCRIPTION
This PR, based on the [Megatron-LM repository scripts ](https://github.com/NVIDIA/Megatron-LM/blob/main/examples/mixtral/train_mixtral_8x7b_distributed.sh)and [the Mixtral-8x7B paper](https://arxiv.org/pdf/2401.04088), fixes some bugs that were present in the train_mixtral_8x7b.yaml file and modifies some unnecessary parameters.