### PR TITLE
[Bug Fix] Remove img_embedding_idx config

### DIFF
--- a/examples/llava/conf/train/train_llava1.5_7b.yaml
+++ b/examples/llava/conf/train/train_llava1.5_7b.yaml
@@ -43,7 +43,6 @@ model:
   micro_batch_size: 2
   global_batch_size: 256
   allow_missing_vision_projection_checkpoint: True
-  img_embedding_idx: 1
   apply_layernorm_1p: True
   use_te: True
   group_query_attention: True


### PR DESCRIPTION
This PR removes the `img_embedding_idx ` for llava due to latest llava doesn't need it.