### PR TITLE
[Model] Add llava mlp converter and update three models config

### DIFF
--- a/examples/llama/conf/config.yaml
+++ b/examples/llama/conf/config.yaml
@@ -43,8 +43,9 @@ experiment:
     hostfile: ${hostfile??} 
   envs:
     CUDA_VISIBLE_DEVICES: 0,1,2,3,4,5,6,7 
-    CUDA_DEVICE_MAX_CONNECTIONS: 1 
-
+    CUDA_DEVICE_MAX_CONNECTIONS: 1
+    NVTE_APPLY_QK_LAYER_SCALING: 0
+    NVTE_ALLOW_NONDETERMINISTIC_ALGO: 0
 action: run 
 
 hydra: 

--- a/examples/llama/conf/train/train_llama3_70b_finetune.yaml
+++ b/examples/llama/conf/train/train_llama3_70b_finetune.yaml
@@ -19,8 +19,10 @@ system:
     wandb_exp_name: "train-llama3-70B" 
   checkpoint:
     load: ${ckpt_path:??}
+    save: ${ckpt_path:??}
     ckpt_format: torch
     save_interval: 100
+    finetune: True
 
 model:
   num_layers: 80
@@ -53,16 +55,16 @@ model:
   seed: 42
 
   optimizer:
-    start_weight_decay: 1.5e-6
-    end_weight_decay: 1.5e-5
+    start_weight_decay: 0
+    end_weight_decay: 5e-7
     weight_decay_incr_style: cosine
     adam_beta1: 0.9
     adam_beta2: 0.95
     lr_scheduler:
-      lr: 1.5e-4
-      min_lr: 1.5e-5
+      lr: 5e-6
+      min_lr: 0
       lr_warmup_samples: 2048000
-      lr_decay_style: cosine 
+      lr_decay_style: cosine
 
 data:
   data_path: ${data_path:??}
@@ -71,3 +73,5 @@ data:
     tokenizer_type: Llama3TokenizerFS
     tokenizer_path: ${tokenizer_path:??}
     vocab_size: 128256
+
+    

--- a/examples/llava/conf/config.yaml
+++ b/examples/llava/conf/config.yaml
@@ -13,7 +13,7 @@ experiment:
     backend: torchrun
     nnodes: 4 
     nproc_per_node: 8
-    hostfile: /etc/hostfile
+    hostfile: <xxx>
   envs:
     CUDA_VISIBLE_DEVICES: 0,1,2,3,4,5,6,7 
     CUDA_DEVICE_MAX_CONNECTIONS: 1

--- a/examples/llava/conf/train/train_llava1.5_7b.yaml
+++ b/examples/llava/conf/train/train_llava1.5_7b.yaml
@@ -37,7 +37,7 @@ model:
   attention_dropout: 0.0
   hidden_dropout: 0.0
   clip_grad: 1.0
-  train_iters: 20000
+  train_iters: 5000
   eval_iters: 10
   eval_interval: 1000
   micro_batch_size: 2

--- a/examples/mixtral/conf/config.yaml
+++ b/examples/mixtral/conf/config.yaml
@@ -15,6 +15,7 @@ experiment:
   envs:
     CUDA_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
     CUDA_DEVICE_MAX_CONNECTIONS: 1
+    NVTE_ALLOW_NONDETERMINISTIC_ALGO: 0
 
 action: run
 

--- a/examples/mixtral/conf/train/train_mixtral_8x7b.yaml
+++ b/examples/mixtral/conf/train/train_mixtral_8x7b.yaml
@@ -47,7 +47,7 @@ model:
   # moe_grouped_gemm: true
 
   # seed: 42
-  train_iters: 500000
+  train_iters: 1000
   micro_batch_size: 1
   global_batch_size: 2048
   clip_grad: 1.0

--- a/megatron/examples/multimodal/mlp_converter.py
+++ b/megatron/examples/multimodal/mlp_converter.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2024, FlagScale CORPORATION. All rights reserved.
+import argparse
+import os
+
+import torch
+
+
+def convert(input_path, output_path, tensor_parallel_size):
+    device = "cuda"
+
+    state_dict = torch.load(input_path)
+
+    new_state_dicts = [{"model": dict()} for _ in range(tensor_parallel_size)]
+
+    for name, tensor in state_dict.items():
+
+        # Map parameter names to ones used in megatron.
+        new_name = ""
+        new_tensor = tensor
+        chunk_dim = None
+
+        # This is used for chunking some tensors to target tensor parallel size.
+        if name == "model.mm_projector.0.weight":
+            new_name = "encoder.linear_fc1.weight"
+            chunk_dim = 0
+        elif name == "model.mm_projector.0.bias":
+            new_name = "encoder.linear_fc1.bias"
+            chunk_dim = 0
+        elif name == "model.mm_projector.2.weight":
+            new_name = "encoder.linear_fc2.weight"
+            chunk_dim = 1
+        elif name == "model.mm_projector.2.bias":
+            new_name = "encoder.linear_fc2.bias"
+
+        assert new_name != "", f"unexpected name {name}"
+
+        if chunk_dim is None:
+            new_tensors = [new_tensor for _ in range(tensor_parallel_size)]
+        else:
+            new_tensors = torch.chunk(new_tensor, tensor_parallel_size, dim=chunk_dim)
+
+        for i in range(tensor_parallel_size):
+            # chunk() creates a view of a bigger tensor. clone() is used here to avoid excessive storage.
+            new_state_dicts[i]["model"][new_name] = new_tensors[i].clone()
+
+    for i in range(tensor_parallel_size):
+        output_path_tp = os.path.join(output_path, f"state_dict_tp_{i}.pt")
+        torch.save(new_state_dicts[i], output_path_tp)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""
+Convert LLaVA MLP weights to megatron format.
+
+
+Example usage:
+python mlp_converter.py --input /some/input/folder/mm_projector.bin --output /some/output/folder --tensor-parallel-size 2
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--input", type=str, required=True, help="The mlp weights with hf format")
+    parser.add_argument(
+        "--output", type=str, required=True, help="output directory for megatron state dict file(s)"
+    )
+    parser.add_argument(
+        "--tensor-parallel-size", type=int, default=1, help="model tensor parallel size"
+    )
+
+    args = parser.parse_args()
+
+    convert(args.input, args.output, args.tensor_parallel_size)
+
+    print("done.")
+

--- a/tools/checkpoint/llama/args.py
+++ b/tools/checkpoint/llama/args.py
@@ -22,7 +22,9 @@ def load_args_hf2mg(args):
     args.num_layers = llama_args["num_hidden_layers"]
     args.num_query_groups = llama_args["num_key_value_heads"]
     args.norm_epsilon = llama_args["rms_norm_eps"]
-    args.rotary_seq_len_interpolation_factor = None if llama_args["rope_scaling"] == 'null' else llama_args["rope_scaling"]
+    args.rotary_seq_len_interpolation_factor = (
+        None if llama_args["rope_scaling"] == "null" else llama_args["rope_scaling"]
+    )
     args.rotary_base = llama_args["rope_theta"]
     args.untie_embeddings_and_output_weights = not llama_args["tie_word_embeddings"]
     args.bf16 = llama_args["torch_dtype"] == "bfloat16"
@@ -32,7 +34,7 @@ def load_args_hf2mg(args):
 
     args.seq_length = 2048
     args.global_batch_size = 1024
-    args.iteration = 1 # '0', 'release' don't work
+    args.iteration = 1  # '0', 'release' don't work
     args.add_position_embedding = False
     args.group_query_attention = True
     args.normalization = "RMSNorm"
@@ -49,19 +51,42 @@ def save_args_mg2hf(args):
     from transformers import LlamaConfig
 
     config = LlamaConfig(
-        vocab_size = args.vocab_size,
-        hidden_size = args.hidden_size,
-        intermediate_size = args.ffn_hidden_size,
-        num_hidden_layers = args.encoder_num_layers,
-        num_attention_heads = args.num_attention_heads,
-        num_key_value_heads = args.num_query_groups,
-        max_position_embeddings = args.max_position_embeddings,
-        rms_norm_eps = args.norm_epsilon,
-        tie_word_embeddings = not args.untie_embeddings_and_output_weights,
-        rope_theta = args.rotary_base,
-        attention_dropout = args.attention_dropout,
-        torch_dtype = args.params_dtype,
-        attention_bias= args.add_qkv_bias
+        vocab_size=args.vocab_size,
+        hidden_size=args.hidden_size,
+        intermediate_size=args.ffn_hidden_size,
+        num_hidden_layers=args.encoder_num_layers,
+        num_attention_heads=args.num_attention_heads,
+        num_key_value_heads=args.num_query_groups,
+        hidden_act="silu" if args.swiglu else False,
+        max_position_embeddings=args.max_position_embeddings,
+        initializer_range=args.init_method_std,
+        rms_norm_eps=args.norm_epsilon,
+        use_cache=True,
+        tie_word_embeddings=not args.untie_embeddings_and_output_weights,
+        rope_theta=args.rotary_base,
+        rope_scaling=args.rotary_seq_len_interpolation_factor,
+        attention_bias=args.add_qkv_bias,
+        attention_dropout=args.attention_dropout,
+        torch_dtype=args.params_dtype,
+        bias_dropout_fusion=args.bias_dropout_fusion,
+        end_weight_decay=args.end_weight_decay,
+        global_batch_size=args.global_batch_size,
+        hidden_dropout=args.hidden_dropout,
+        lr=args.lr,
+        lr_decay_style=args.lr_decay_style,
+        make_vocab_size_divisible_by=args.make_vocab_size_divisible_by,
+        masked_softmax_fusion=args.masked_softmax_fusion,
+        min_lr=args.min_lr,
+        norm_init_weight=args.norm_init_weight,
+        perform_initialization=args.perform_initialization,
+        reset_attention_mask=args.reset_attention_mask,
+        reset_position_ids=args.reset_position_ids,
+        rotary_base=args.rotary_base,
+        seed=args.seed,
+        split=args.split,
+        start_weight_decay=args.start_weight_decay,
+        use_flash_attn=args.use_flash_attn,
+        weight_decay_incr_style=args.weight_decay_incr_style,
     )
     config.save_pretrained(args.save)
 

--- a/tools/checkpoint/run.sh
+++ b/tools/checkpoint/run.sh
@@ -40,3 +40,17 @@ python convert.py \
     --target-params-dtype bf16 \
     --true-vocab-size 128256 \
     --megatron-path <xxx>
+
+python convert.py \
+    --model-type llama \
+    --loader transformers \
+    --saver mcore \
+    --load-dir ${transformers_ckpt_path:??} \
+    --save-dir ${mcore_ckpt_path:??} \
+    --target-tensor-parallel-size 8 \
+    --target-pipeline-parallel-size 4 \
+    --target-expert-parallel-size 1 \
+    --max-queue-size 50 \
+    --target-params-dtype bf16 \
+    --true-vocab-size 128256 \
+    --megatron-path <xxx>


### PR DESCRIPTION
This PR adds mlp ckpt conversation from hf to megatron in the llava pretrain phase.
An tp2 example of the ckpt conversation for the LLaVA Pretrain phase is shown below:

- CLIP
`
cd FlagScale/megatron && python examples/multimodal/clip_converter.py --download-root <clip_hf_dir>  --output <clip_megatron_dir> --tensor-parallel-size 2 --use-te-layernorm-linear
`

- Vicuna
`
cd FlagScale/megatron && python tools/checkpoint/convert.py --model-type GPT --loader llama_mistral --saver mcore --target-tensor-parallel-size 2 --checkpoint-type hf --load-dir <vicuna_hf_dir> --save-dir <vicuna_megatron_dir> --tokenizer-model <vicuna_hf_dir>/tokenizer.model --bf16 --model-size llama2-7Bf --true-vocab-size 32256 --megatron-path <flagscale_dir>
`

- MLP
`
cd FlagScale/megatron && python examples/multimodal/mlp_converter.py --input <mlp_hf_dir>/mm_projector.bin  --output <mlp_megatron_dir> --tensor-parallel-size 2
`

And combine them:
`
cd FlagScale/megatron && PYTHONPATH=FlagScale/megatron:FlagScale/ python examples/multimodal/combine_state_dicts.py   --input     <vicuna_megatron_dir>/iter_0000001/mp_rank_00/model_optim_rng.pt    <clip_megatron_dir>/state_dict_tp_0.pt     <mlp_megatron_dir>/state_dict_tp_0.pt  <vicuna_megatron_dir>/iter_0000001/mp_rank_01/model_optim_rng.pt    <clip_megatron_dir>/state_dict_tp_1.pt     <mlp_megatron_dir>/state_dict_tp_1.pt     --prefixes language_model vision_model vision_projection language_model vision_model vision_projection     --output <output_dir>/iter_0000001/mp_rank_00/model_optim_rng.pt <output_dir>/iter_0000001/mp_rank_01/model_optim_rng.pt && cd <output_idr> && echo "1" > latest_checkpointed_iteration.txt
`

This PR also updates three models config.