### PR TITLE
[CI] Only perform unit-test coverage checks when pull_request.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
   # Megatron Coverage Test
   megatron-coverage-test:
     needs: megatron-unit-tests
+    if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/coverage-tests.yml
     with:
       backend: megatron
@@ -56,6 +57,7 @@ jobs:
   # Flagscale Coverage Test
   flagscale-coverage-test:
     needs: flagscale-unit-tests
+    if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/coverage-tests.yml
     with:
       backend: flagscale


### PR DESCRIPTION
Compared with the common ancestor of the main branch during pull_request for unit-test coverage testing of newly added code.