### PR TITLE
[CI] Coverage Online Report Location Advance

### DIFF
--- a/.github/workflows/coverage-tests.yml
+++ b/.github/workflows/coverage-tests.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Coverage Online Report
         run: |
           REPORT_ADDR=$(cat "/workspace/config/report_address")
-          echo "You can access the test diff-coverage report at the http://${REPORT_ADDR}/${{github.sha}}/diff-cover-report-${{ inputs.backend }}.html"
+          echo "You can access the test diff-coverage report at the http://${REPORT_ADDR}/${{github.sha}}/cov-report-${{ inputs.backend }}/diff-cover-report-${{ inputs.backend }}.html"
 
         

--- a/.github/workflows/coverage-tests.yml
+++ b/.github/workflows/coverage-tests.yml
@@ -38,14 +38,15 @@ jobs:
           submodules: false
           set-safe-directory: true
       
+      - name: Coverage Online Report
+        run: |
+          REPORT_ADDR=$(cat "/workspace/config/report_address")
+          echo "After 'Run Unit Tests and Check Coverage' is completed/stopped, you can access the test diff-coverage report at the http://${REPORT_ADDR}/${{github.sha}}/cov-report-${{ inputs.backend }}/diff-cover-report-${{ inputs.backend }}.html"
+
       - name: Run Unit Tests and Check Coverage
         run: |
           # Execute the test coverage script with the appropriate backend and id (commit SHA)
           tests/scripts/unit_tests/test_coverage.sh --backend ${{ inputs.backend }} --id ${{ github.sha }} --status online
       
-      - name: Coverage Online Report
-        run: |
-          REPORT_ADDR=$(cat "/workspace/config/report_address")
-          echo "You can access the test diff-coverage report at the http://${REPORT_ADDR}/${{github.sha}}/cov-report-${{ inputs.backend }}/diff-cover-report-${{ inputs.backend }}.html"
 
         

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,11 +40,12 @@ jobs:
           lfs: false
           submodules: false
           set-safe-directory: true
-      
-      - name: Run Unit Test
-        run: tests/scripts/unit_tests/test_subset.sh --backend ${{ inputs.backend }} --subset ${{ inputs.subset }} --id ${{ github.sha }}
-      
+
       - name: Unit Test Coverage Online Report
         run: | 
           REPORT_ADDR=$(cat "/workspace/config/report_address")
-          echo "You can access the test coverage report at http://${REPORT_ADDR}/${{github.sha}}/cov-report-${{ inputs.backend }}/index.html"
+          echo "After 'Run Unit Test' is completed/stopped, you can access the test coverage report at http://${REPORT_ADDR}/${{github.sha}}/cov-report-${{ inputs.backend }}/index.html"
+
+      - name: Run Unit Test
+        run: tests/scripts/unit_tests/test_subset.sh --backend ${{ inputs.backend }} --subset ${{ inputs.subset }} --id ${{ github.sha }}
+


### PR DESCRIPTION
Output the address information of the test report in advance, so that the address information of the report can still be output in case of unit test failure or test coverage failure.