### PR TITLE
[Fix] "auto_tuner" should be under the field config.experiment.

### DIFF
--- a/flagscale/auto_tuner/record/recorder.py
+++ b/flagscale/auto_tuner/record/recorder.py
@@ -17,7 +17,7 @@ class Recorder:
         )
         # Metric to grep in the last rank of last node log file
         if (
-            "auto_tuner" in self.config
+            "auto_tuner" in self.config.experiment
             and "performance" in self.config.experiment.auto_tuner
         ):
             self.metric = self.config.experiment.auto_tuner.performance.get(
@@ -28,7 +28,7 @@ class Recorder:
 
         # Sort order of performance, order just in [ascend, and descend], default ascend
         if (
-            "auto_tuner" in self.config
+            "auto_tuner" in self.config.experiment
             and "performance" in self.config.experiment.auto_tuner
         ):
             self.sorted_order = self.config.experiment.auto_tuner.performance.get(

--- a/flagscale/runner/runner_train.py
+++ b/flagscale/runner/runner_train.py
@@ -122,7 +122,7 @@ def _get_runner_cmd_train(
     rdzv_id = runner_config.get("rdzv_id", "default")
     log_dir = runner_config.get("log_dir", logging_config.details_dir)
     log_dir = os.path.abspath(log_dir)
-    no_shared_fs = config.experiment.get("no_shared_fs", False)
+    no_shared_fs = runner_config.get("no_shared_fs", False)
     if no_shared_fs:
         log_dir = os.path.join(log_dir, f"host")
     else:


### PR DESCRIPTION
I want to change the default metric to TFLOPs and change the order to descend, but it doesn't work. Because, the "auto_tuner" is under config.experiment instead of config.

After making the following changes it worked.
Change
if (
    "auto_tuner" in self.config
    and "performance" in self.config.experiment.auto_tuner
):
to
if (
    "auto_tuner" in self.config.experiment
    and "performance" in self.config.experiment.auto_tuner
):