### PR TITLE
[LLaVA-OV] Support LLaVA-OneVision eval loss and data filtering

### DIFF
--- a/tools/datasets/llava_onevision/filter_by_json.py
+++ b/tools/datasets/llava_onevision/filter_by_json.py
@@ -1,0 +1,99 @@
+
+import os
+import json
+import argparse
+import webdataset as wds
+import tarfile
+from multiprocessing import Pool
+
+
+def find_tar_files(input_dir):
+    tar_files = []
+    for root, dirs, files in os.walk(input_dir):
+        for file in files:
+            if file.endswith('.tar'):
+                input_tarfile = os.path.join(root, file)
+                tar_files.append(input_tarfile)
+    assert tar_files
+    return tar_files
+                
+
+def process_tar_files_in_node(tar_files, input_dir, output_dir, ids_to_keep):
+    num_tar_files_in_node = len(tar_files)
+    assert num_tar_files_in_node > 0
+    if num_tar_files_in_node == 1:
+        num_process = 1
+    else:
+        num_process = num_tar_files_in_node // 2
+        num_process = 8 if num_process >= 8 else num_process
+
+    num_tar_files_per_process = num_tar_files_in_node // num_process
+    for i in range(num_process):
+        start = i * num_tar_files_per_process
+        end = (i + 1) * num_tar_files_per_process if i!= (num_process-1) else num_tar_files_in_node
+        process_files = tar_files[start:end]
+        with Pool(num_process) as p:
+            p.starmap(process_tarfile, [(tf, input_dir, output_dir, ids_to_keep) for tf in process_files])
+
+
+def process_tarfile(input_tarfile, input_dir, output_dir, ids_to_keep):
+    print(f"Process {os.getpid()} is processing {input_tarfile}")
+    relative_path = os.path.relpath(input_tarfile, input_dir)
+    output_tarfile = os.path.join(output_dir, relative_path)
+    output_tarfile_dir = os.path.dirname(output_tarfile)
+    os.makedirs(output_tarfile_dir, exist_ok=True)
+
+    dataset = wds.WebDataset(input_tarfile, shardshuffle=False)
+    keep_samples = []
+
+    for sample in dataset:
+        if sample["__key__"] not in ids_to_keep:
+            print(f"id {sample['__key__']} is filtered out.")
+        else:
+            new_sample = {"__key__": sample["__key__"], "sequence.pyd": sample["sequence.pyd"]}
+            keep_samples.append(new_sample)
+    if not keep_samples:
+        print(f"All id in {input_tarfile} are filtered out.")
+    else:
+        output_dataset = wds.TarWriter(output_tarfile)
+        print(f"Writing {input_tarfile} to {output_tarfile} ...")
+        for sample in keep_samples:
+            output_dataset.write(sample)
+        output_dataset.close()
+        print(f"Writing {output_tarfile} done.")
+
+def main():
+    parser = argparse.ArgumentParser(description='Filter a webdataset and save the filtered samples.')
+    parser.add_argument('--input_dir', type=str, help='Original Directory')
+    parser.add_argument('--output_dir', type=str, help='Directory to save the filtered data')
+    parser.add_argument('--json_file', type=str, help='Path to the JSON file containing ids')
+    args = parser.parse_args()
+
+    input_dir = args.input_dir
+    output_dir = args.output_dir
+    os.makedirs(output_dir, exist_ok=True)
+    json_file = args.json_file
+
+    # Node size
+    size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", 1))
+    # Node rank
+    rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", 0))
+
+    with open(json_file, 'r') as f:
+        ids_to_keep = json.load(f)["ids"]
+
+    tar_files = find_tar_files(input_dir)
+    num_tar_files = len(tar_files)
+    assert num_tar_files > size
+    num_tar_files_per_node = num_tar_files // size
+    start_index = rank * num_tar_files_per_node
+    end_index = (rank + 1) * num_tar_files_per_node if rank!= size - 1 else num_tar_files
+    node_tar_files = tar_files[start_index:end_index]
+    print(f"node_tar_files: ", node_tar_files)
+    process_tar_files_in_node(node_tar_files, input_dir, output_dir, ids_to_keep)
+    print("Done")
+
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/datasets/llava_onevision/filter_to_json.py
+++ b/tools/datasets/llava_onevision/filter_to_json.py
@@ -1,0 +1,45 @@
+import os
+import re
+import json
+import argparse
+from typing import Dict
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Grep id and loss from log files.')
+    parser.add_argument('--input_dir', type=str, help='Directory to search log files.')
+    parser.add_argument('--output', type=str, help='Path to save the result.')
+    args = parser.parse_args()
+
+    result_dict: Dict[str, float] = {}
+    for root, dirs, files in os.walk(args.input_dir):
+        for file in files:
+            if file.endswith('.log'):
+                file_path = os.path.join(root, file)
+                with open(file_path, 'r') as f:
+                    lines = f.readlines()
+                    for line in lines:
+                        match = re.search(r'Evaluating id: (\d+), loss: ([\d.]+)', line)
+                        if match:
+                            evaluating_id = match.group(1)
+                            loss = float(match.group(2))
+                            if evaluating_id in result_dict:
+                                assert loss == result_dict[evaluating_id]
+                            # Customize filtering rules such as
+                            # if loss < 0.5:
+                            #    result_dict[evaluating_id] = loss
+
+                            # NOTE: No filtering currently, Comment out if Customize
+                            result_dict[evaluating_id] = loss
+
+    ids = list(result_dict.keys())
+    print("Keep id count: ", len(ids))
+    result = {"ids": ids}
+    assert args.output.endswith(".json")
+    with open(args.output, 'w') as f:
+        json.dump(result, f, indent=4)
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/datasets/llava_onevision/make_llava_ov_wds.sh
+++ b/tools/datasets/llava_onevision/make_llava_ov_wds.sh
@@ -27,6 +27,12 @@ set -u
   HOSTFILE=$3
 set +u
 
+if [ $# -ge 4 ]; then
+    FILTER_JSON=$4
+else
+    FILTER_JSON=""
+fi
+
 echo "BASE_RUN_NAME: ${EXPNAME_PATH}"
 
 CKPT_PATH="./checkpoints"
@@ -52,6 +58,7 @@ do
     export WANDB_MODE=offline && \
     export ACCELERATE_CPU_AFFINITY=1 && \
     export PYTHONPATH=$LLaVA_NeXT_HOME:$PYTHONPATH && \
+    export FILTER_JSON=$FILTER_JSON && \
     source /root/miniconda3/bin/activate flagscale && \
     torchrun --nproc_per_node=8 --nnodes=${NNodes} --node_rank=${rank} --master_addr=${MASTER_ADDR} --master_port=13888 llava_ov_wds.py \
         --model_name_or_path ${CKPT_PATH} \


### PR DESCRIPTION
This PR adds three important features:

-  In the eval mode, the loss corresponding to each sample is output, so that data filtering can be performed subsequently. To enable this feature, simply set `skip_train: True`, and the rest of the settings are consistent with those in the train mode.  
- Data filtering is provided, which allows custom filtering rules, reads the loss corresponding to the sample from the log, and stores the sample id that need to be retained in a JSON file.Usage: `python filter_to_json.py --input_dir outputs --output sample_ids.json`
- When processing data, the input of filter_json is added, and if the sample ID is not in this JSON file, it can be skipped. Usgae: `bash make_llava_ov_wds.sh $DATA_PATH $EXPNAME_PATH $HOSTFILE $FILTER_JSON`
- If you do not want to make it from scratch and only filter it from the already made tar file according to `filter_json`, Usage: `python filter_by_json.py --input_dir raw_dir --output_dir output_dir --json_file filter_json`，and you can use mpirun to start multiple nodes to process.