### PR TITLE
[Core] Support sigmoid router for aux_loss in moe

### DIFF
--- a/megatron/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/megatron/core/transformer/moe/moe_utils.py
@@ -94,6 +94,17 @@ def sequence_load_balancing_loss_func(
 
     return seq_aux_loss
 
+def score_function(
+    input: torch.Tensor,
+    score_function_type: str = "softmax",
+):
+    if score_function_type == "softmax":
+        scores = torch.softmax(input, dim=-1, dtype=torch.float32).type_as(input)
+    elif score_function_type == "sigmoid":
+        scores = input.sigmoid()
+    else:
+        raise ValueError(f"Unsupported MoE routing score function type: {score_function_type}")
+    return scores
 
 def z_loss_func(logits, z_loss_coeff):
     """Encourages the router's logits to remain small to enhance stability.
@@ -323,6 +334,7 @@ def topk_softmax_with_capacity(
     moe_router_topk_limited_devices: int = None,
     moe_router_topk_scaling_factor: float = None,
     deterministic_mode: bool = False,
+    score_function_type: str = "softmax",
 ):
     """Apply capacity and padding to the top-k selection.
     Args:
@@ -355,7 +367,7 @@ def topk_softmax_with_capacity(
     num_experts = logits.shape[1]
     if use_pre_softmax:
         # Pre softmax
-        scores = torch.softmax(logits, dim=-1, dtype=torch.float32).type_as(logits)
+        scores = score_function(logits, score_function_type)
 
         if moe_router_topk_limited_devices:
             probs, top_indices = device_limited_topk(
@@ -382,7 +394,11 @@ def topk_softmax_with_capacity(
             )
         else:
             scores, top_indices = torch.topk(logits, k=topk, dim=1)
-        probs = torch.softmax(scores, dim=-1, dtype=torch.float32).type_as(logits)
+        probs = score_function(scores, score_function_type)
+
+    if score_function_type == "sigmoid":
+        tmp = probs.sum(dim=-1, keepdim=True)
+        probs = probs / tmp
 
     # TODO Try using element-wise operations instead of scatter?
     topk_masked_gates = torch.zeros_like(logits).scatter(1, top_indices, probs)

--- a/megatron/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/megatron/core/transformer/moe/moe_utils.py
@@ -97,9 +97,12 @@ def sequence_load_balancing_loss_func(
 def score_function(
     input: torch.Tensor,
     score_function_type: str = "softmax",
+    target_dtype: torch.dtype = None,
 ):
     if score_function_type == "softmax":
-        scores = torch.softmax(input, dim=-1, dtype=torch.float32).type_as(input)
+        scores = torch.softmax(input, dim=-1, dtype=torch.float32)
+        if target_dtype:
+            scores = scores.type(target_dtype)
     elif score_function_type == "sigmoid":
         scores = input.sigmoid()
     else:
@@ -367,7 +370,7 @@ def topk_softmax_with_capacity(
     num_experts = logits.shape[1]
     if use_pre_softmax:
         # Pre softmax
-        scores = score_function(logits, score_function_type)
+        scores = score_function(logits, score_function_type, logits.dtype)
 
         if moe_router_topk_limited_devices:
             probs, top_indices = device_limited_topk(
@@ -394,7 +397,7 @@ def topk_softmax_with_capacity(
             )
         else:
             scores, top_indices = torch.topk(logits, k=topk, dim=1)
-        probs = score_function(scores, score_function_type)
+        probs = score_function(scores, score_function_type, logits.dtype)
 
     if score_function_type == "sigmoid":
         tmp = probs.sum(dim=-1, keepdim=True)

--- a/megatron/megatron/core/transformer/moe/router.py
+++ b/megatron/megatron/core/transformer/moe/router.py
@@ -118,7 +118,7 @@ class TopKRouter(Router):
         """
 
         def _sinkhorn_activation(logits):
-            if self.topk == 1 or self.score_function_type == "sigmoid":
+            if self.topk == 1:
                 logits = torch.sigmoid(logits)
 
             else:  # k > 1
@@ -136,11 +136,6 @@ class TopKRouter(Router):
         else:
             logits = _sinkhorn_activation(logits)
             _, indices = torch.topk(logits, k=self.topk, dim=1)
-
-        if self.score_function_type == "sigmoid":
-            tmp = logits.sum(dim=-1, keepdim=True)
-            logits = logits / tmp
-
         map = torch.zeros_like(logits).int().scatter(1, indices, 1).bool()
         scores = logits * map
         return scores, map
@@ -174,7 +169,6 @@ class TopKRouter(Router):
             if self.score_function_type == "sigmoid":
                 tmp = scores.sum(dim=-1, keepdim=True)
                 scores = scores / tmp
-
             aux_loss_func = partial(
                 switch_load_balancing_loss_func,
                 probs=scores,

--- a/megatron/megatron/core/transformer/moe/router.py
+++ b/megatron/megatron/core/transformer/moe/router.py
@@ -120,7 +120,6 @@ class TopKRouter(Router):
         def _sinkhorn_activation(logits):
             if self.topk == 1:
                 logits = torch.sigmoid(logits)
-
             else:  # k > 1
                 logits = torch.softmax(logits, dim=-1, dtype=torch.float32).type_as(logits)
             return logits
@@ -322,7 +321,6 @@ class TopKRouter(Router):
                 use_pre_softmax=self.config.moe_router_pre_softmax,
                 moe_router_topk_scaling_factor=self.config.moe_router_topk_scaling_factor,
                 deterministic_mode=self.config.deterministic_mode,
-                score_function_type=self.score_function_type,
             )
         else:
             raise ValueError(f"Unsupported MoE routing type: {self.routing_type}")

--- a/megatron/megatron/core/transformer/transformer_config.py
+++ b/megatron/megatron/core/transformer/transformer_config.py
@@ -283,6 +283,9 @@ class TransformerConfig(ModelParallelConfig):
     which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing 
     algorithm used in S-BASE, and "none" implies no load balancing. The default is "aux_loss"."""
 
+    moe_router_score_function_type: str = "softmax"
+    """Determines the score function type for the router."""
+
     moe_router_topk: int = 2
     """Number of experts to route to for each token."""
 

--- a/megatron/megatron/core/transformer/transformer_config.py
+++ b/megatron/megatron/core/transformer/transformer_config.py
@@ -284,7 +284,7 @@ class TransformerConfig(ModelParallelConfig):
     algorithm used in S-BASE, and "none" implies no load balancing. The default is "aux_loss"."""
 
     moe_router_score_function_type: str = "softmax"
-    """Determines the score function type for the router, currently support "aux_loss" and "seq_aux_loss" load balancing type."""
+    """Determines the score function type for the router, currently support two load balancing type: "aux_loss" and "seq_aux_loss"."""
 
     moe_router_topk: int = 2
     """Number of experts to route to for each token."""

--- a/megatron/megatron/core/transformer/transformer_config.py
+++ b/megatron/megatron/core/transformer/transformer_config.py
@@ -284,7 +284,7 @@ class TransformerConfig(ModelParallelConfig):
     algorithm used in S-BASE, and "none" implies no load balancing. The default is "aux_loss"."""
 
     moe_router_score_function_type: str = "softmax"
-    """Determines the score function type for the router."""
+    """Determines the score function type for the router, currently support "aux_loss" and "seq_aux_loss" load balancing type."""
 
     moe_router_topk: int = 2
     """Number of experts to route to for each token."""

--- a/megatron/megatron/training/arguments.py
+++ b/megatron/megatron/training/arguments.py
@@ -2233,7 +2233,7 @@ def _add_moe_args(parser):
     group.add_argument('--moe-router-score-function-type', type=str,
                        choices=['softmax', 'sigmoid'],
                        default='softmax',
-                       help='Determines the score function type for the router, currently support "aux_loss" and "seq_aux_loss" load balancing type.')
+                       help='Determines the score function type for the router, currently support two load balancing type: "aux_loss" and "seq_aux_loss".')
     group.add_argument('--moe-router-topk', type=int, default=2,
                        help='Number of experts to route to for each token. The default is 2.')
     group.add_argument('--moe-router-pre-softmax', action='store_true',

--- a/megatron/megatron/training/arguments.py
+++ b/megatron/megatron/training/arguments.py
@@ -2233,7 +2233,7 @@ def _add_moe_args(parser):
     group.add_argument('--moe-router-score-function-type', type=str,
                        choices=['softmax', 'sigmoid'],
                        default='softmax',
-                       help='Determines the score function type for the router.')
+                       help='Determines the score function type for the router, currently support "aux_loss" and "seq_aux_loss" load balancing type.')
     group.add_argument('--moe-router-topk', type=int, default=2,
                        help='Number of experts to route to for each token. The default is 2.')
     group.add_argument('--moe-router-pre-softmax', action='store_true',

--- a/megatron/megatron/training/arguments.py
+++ b/megatron/megatron/training/arguments.py
@@ -2230,6 +2230,10 @@ def _add_moe_args(parser):
                        choices=['aux_loss', 'seq_aux_loss', 'sinkhorn', 'none'],
                        default='aux_loss',
                        help='Determines the load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the load balancing loss used in DeepSeekV2, which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing algorithm used in S-BASE, and "none" implies no load balancing. The default is "aux_loss".')
+    group.add_argument('--moe-router-score-function-type', type=str,
+                       choices=['softmax', 'sigmoid'],
+                       default='softmax',
+                       help='Determines the score function type for the router.')
     group.add_argument('--moe-router-topk', type=int, default=2,
                        help='Number of experts to route to for each token. The default is 2.')
     group.add_argument('--moe-router-pre-softmax', action='store_true',


### PR DESCRIPTION
Support sigmoid router in moe similar to DeepSeek V3
- add a configuration str <moe_router_score_function_type> in TransformerConfig
- support using sigmoid+normalization to compute prob scores

The implementation in this PR, is similar to that in DeepSeek V3, as shown in the figure below. Scores are first calculated using a sigmoid for x, and then the topk function is used to select the k largest scores, finally the k scores are averaged.

Currently, sigmoid router is supported for two load balancing types: auxiliary loss and sequence auxiliary loss.
We will support auxiliary loss free load balancing in the future.

<img width="955" alt="20250107-142500" src="https://github.com/user-attachments/assets/1ff0f0c2-226c-4599-914d-df87c5b5fe82" />
references to: https://github.com/deepseek-ai/DeepSeek-V3/blob/main/DeepSeek_V3.pdf