### PR TITLE
[Core] Support to skip samples according to spiky loss

### DIFF
--- a/flagscale/train/__init__.py
+++ b/flagscale/train/__init__.py
@@ -4,4 +4,6 @@ from .global_vars import get_extra_input_tensor
 from .global_vars import set_extra_input_tensor
 from .global_vars import get_parallel_context
 from .global_vars import set_parallel_context
+from .global_vars import get_spiky_loss_detector
+from .global_vars import set_get_spiky_loss_detector
 from .arguments import FSTrainArguments

--- a/flagscale/train/global_vars.py
+++ b/flagscale/train/global_vars.py
@@ -1,11 +1,12 @@
 import torch
 
 from flagscale.train.hetero.parallel_context import ParallelContext
+from flagscale.train.spiky_loss import SpikyLossDetector
 
 _GLOBAL_EXTRA_VALID_DATASETS = None
 _GLOBAL_EXATRA_INPUT_TENSOR = None
 _GLOBAL_PARALLEL_CONTEXT = None
-
+_GLOBAL_SPIKY_LOSS_DETECTOR = None
 
 def _ensure_var_is_initialized(var, name):
     """Make sure the input variable is not None."""
@@ -49,3 +50,15 @@ def set_parallel_context(args):
     global _GLOBAL_PARALLEL_CONTEXT
     _ensure_var_is_not_initialized(_GLOBAL_PARALLEL_CONTEXT, 'parallel context')
     _GLOBAL_PARALLEL_CONTEXT = ParallelContext(args)
+
+def get_spiky_loss_detector():
+    """Return spiky loss detector."""
+    _ensure_var_is_initialized(_GLOBAL_SPIKY_LOSS_DETECTOR, 'spiky loss detector')
+    return _GLOBAL_SPIKY_LOSS_DETECTOR
+
+
+def set_get_spiky_loss_detector(args):
+    """Initialize spiky loss detector."""
+    global _GLOBAL_SPIKY_LOSS_DETECTOR
+    _ensure_var_is_not_initialized(_GLOBAL_SPIKY_LOSS_DETECTOR, 'spiky loss detector')
+    _GLOBAL_SPIKY_LOSS_DETECTOR = SpikyLossDetector(args.spiky_loss_threshold)

--- a/flagscale/train/spiky_loss.py
+++ b/flagscale/train/spiky_loss.py
@@ -38,7 +38,7 @@ class SpikyLossDetector:
             elif math.isinf(loss) or math.isinf(self.last_loss):
                 return True
             else:
-                result = math.fabs(loss - self.last_loss) / self.last_loss >= self.threshold
+                result = (loss - self.last_loss) / self.last_loss >= self.threshold
                 if result:
                     return True
                 else:

--- a/flagscale/train/spiky_loss.py
+++ b/flagscale/train/spiky_loss.py
@@ -1,0 +1,49 @@
+import math
+import torch
+
+class SpikyLossDetector:
+    def __init__(self, threshold=0.2, loss = None):
+        self.last_loss = loss
+        self.threshold = threshold
+
+    def reduce_losses(self, losses_reduced):
+        loss_reduced = {}
+        from megatron.core import mpu
+        if mpu.is_pipeline_last_stage(ignore_virtual=True):
+            # Average loss across microbatches.
+            for key in losses_reduced[0].keys():
+                numerator = 0
+                denominator = 0
+                for x in losses_reduced:
+                    val = x[key]
+                    # there is one dict per microbatch. in new reporting, we average
+                    # over the total number of tokens across the global batch.
+                    if isinstance(val, tuple) or isinstance(val, list):
+                        numerator += val[0]
+                        denominator += val[1]
+                    else:
+                        # legacy behavior. we average over the number of microbatches,
+                        # and so the denominator is 1.
+                        numerator += val
+                        denominator += 1
+                loss_reduced[key] = numerator / denominator
+        return loss_reduced.get('lm loss')
+    
+    def is_spkiy_loss(self, loss):
+        if loss is None:
+            return False
+        if self.last_loss is not None:
+            if math.isnan(loss) or math.isnan(self.last_loss):
+                self.last_loss = loss
+            elif math.isinf(loss) or math.isinf(self.last_loss):
+                return True
+            else:
+                result = math.fabs(loss - self.last_loss) / self.last_loss >= self.threshold
+                if result:
+                    return True
+                else:
+                    self.last_loss = loss
+        else:
+            self.last_loss = loss
+        return False
+    

--- a/flagscale/train/spiky_loss.py
+++ b/flagscale/train/spiky_loss.py
@@ -2,6 +2,9 @@ import math
 import torch
 
 class SpikyLossDetector:
+    '''This class represents a Spiky Loss Detector.
+        It is used to detect spikes in loss values during training.
+    '''
     def __init__(self, threshold=0.2, loss = None):
         self.last_loss = loss
         self.threshold = threshold

--- a/flagscale/train/train.py
+++ b/flagscale/train/train.py
@@ -1585,6 +1585,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
 
         # Run training step.
         args.curr_iteration = iteration
+
         ###########FlagScale begin ##########
         if args.skip_samples_range or args.skip_iters_range:
             current_global_batch_size = get_current_global_batch_size()

--- a/flagscale/train/train.py
+++ b/flagscale/train/train.py
@@ -832,7 +832,7 @@ def train_step(forward_step_func, data_iterator,
     if should_exit:
         return {}, True, should_checkpoint, should_exit, exit_code, None, None
 
-    ###########FlagScale begin ##########
+    ########## FlagScale Begin ##########
     if args.auto_skip_spiky_loss and (args.consumed_train_samples > args.lr_warmup_samples and args.curr_iteration > args.lr_warmup_iters):
         spiky_loss_detector = get_spiky_loss_detector()
         loss_ = spiky_loss_detector.reduce_losses(losses_reduced)
@@ -842,7 +842,7 @@ def train_step(forward_step_func, data_iterator,
         is_spiky_loss = is_spiky_loss_tensor.item()
         if is_spiky_loss > 0:
             return {}, True, should_checkpoint, should_exit, exit_code, None, None
-    #########FlagScale end ############
+    ########## FlagScale Begin ##########
     
     # Empty unused memory.
     if args.empty_unused_memory_level >= 1:
@@ -1586,7 +1586,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
         # Run training step.
         args.curr_iteration = iteration
 
-        ###########FlagScale begin ##########
+        ########## FlagScale Begin ##########
         if args.skip_samples_range or args.skip_iters_range:
             current_global_batch_size = get_current_global_batch_size()
             start_skip_iteration = 0
@@ -1612,7 +1612,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
                 iteration += 1
                 
             args.curr_iteration = iteration
-        ###########FlagScale end ##########
+        ########## FlagScale Begin ##########
                 
         loss_dict, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad = \
             train_step(forward_step_func,

--- a/flagscale/train/train_aquila.py
+++ b/flagscale/train/train_aquila.py
@@ -168,7 +168,7 @@ def get_batch(data_iterator):
 
 
 # define spiky loss as a variation of 20% or more
-SPIKY_LOSS_PERC = 0.08
+SPIKY_LOSS_PERC = 0.2
 
 
 def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor):

--- a/flagscale/train/train_aquila.py
+++ b/flagscale/train/train_aquila.py
@@ -168,7 +168,7 @@ def get_batch(data_iterator):
 
 
 # define spiky loss as a variation of 20% or more
-SPIKY_LOSS_PERC = 0.2
+SPIKY_LOSS_PERC = 0.08
 
 
 def loss_func(loss_mask: torch.Tensor, output_tensor: torch.Tensor):

--- a/megatron/megatron/training/arguments.py
+++ b/megatron/megatron/training/arguments.py
@@ -62,6 +62,7 @@ def parse_args(extra_args_provider=None, ignore_unknown_args=False):
     parser = _add_rerun_machine_args(parser)
     parser = _add_hetero_args(parser)
     parser = _add_auto_tuner_args(parser)
+    parser = _add_auto_skip_spiky_loss(parser)
 
     # Custom arguments.
     if extra_args_provider is not None:
@@ -1405,6 +1406,10 @@ def _add_training_args(parser):
                        help='Total number of samples to train over all '
                        'training runs. Note that either train-iters or '
                        'train-samples should be provided.')
+    group.add_argument('--skip-samples-range', nargs='+', type=int, default=None,
+                       help='Range of samples to skip during training.')
+    group.add_argument('--skip-iters-range', nargs='+', type=int, default=None,
+                       help='Range of iterations to skip during training.')
     group.add_argument('--log-interval', type=int, default=100,
                        help='Report loss and timing interval.')
     group.add_argument('--exit-interval', type=int, default=None,
@@ -2359,4 +2364,14 @@ def _add_auto_tuner_args(parser):
     group.add_argument('--auto-tune', action='store_true',
                        help='use auto tuner')
 
+    return parser
+
+
+def _add_auto_skip_spiky_loss(parser):
+    group = parser.add_argument_group(title='auto skip spiky loss')
+    
+    group.add_argument('--auto-skip-spiky-loss', action='store_true',
+                       help='Automatically skip spiky loss iterations.')
+    group.add_argument('--spiky-loss-threshold', type=float, default=0.2,
+                          help='Threshold for skipping spiky loss iterations.')
     return parser

--- a/megatron/megatron/training/initialize.py
+++ b/megatron/megatron/training/initialize.py
@@ -28,7 +28,7 @@ from megatron.core.fusions.fused_bias_swiglu import bias_swiglu
 from megatron.core.utils import get_te_version, is_te_min_version, is_torch_min_version
 
 from flagscale.train import FSTrainArguments
-from flagscale.train import set_parallel_context  
+from flagscale.train import set_parallel_context, set_get_spiky_loss_detector
 logger = logging.getLogger(__name__)
 
 
@@ -106,6 +106,9 @@ def initialize_megatron(
             error_injection_type=RerunDiagnostic(args.error_injection_type),
         ),
     )
+    
+    if args.auto_skip_spiky_loss:
+        set_get_spiky_loss_detector(args=args)
 
     # torch.distributed initialization
     def finish_mpu_init():

--- a/tests/functional_tests/test_cases/hetero_train/aquila/conf/train/tp2pp1_tp4pp1_tp2pp1.yaml
+++ b/tests/functional_tests/test_cases/hetero_train/aquila/conf/train/tp2pp1_tp4pp1_tp2pp1.yaml
@@ -71,6 +71,8 @@ model:
   micro_batch_size: 4 
   global_batch_size: 1024 
   seed: 42
+  auto_skip_spiky_loss: true
+  spiky_loss_threshold: 0.25
 
   optimizer:
     weight_decay: 0.1

--- a/tests/unit_tests/test_spiky_loss_detector.py
+++ b/tests/unit_tests/test_spiky_loss_detector.py
@@ -1,0 +1,25 @@
+import torch
+
+from flagscale.train.spiky_loss import SpikyLossDetector
+from tests.unit_tests.test_utilities import Utils
+
+def test_spiky_loss_detector(pp_size=2, threshold=0.2):
+    Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=pp_size,
+            expert_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+    
+    detector = SpikyLossDetector(threshold=threshold, loss=10.0)
+    # 
+    losses = [{"lm loss": 10.23}, {"lm loss": 10.32}, {"lm loss": 10.30}]
+    reduced_loss = detector.reduce_losses(losses)
+    is_spiky_loss = detector.is_spkiy_loss(reduced_loss)
+    is_spiky_loss_tensor = torch.tensor(is_spiky_loss, dtype=torch.int, device="cuda")
+    torch.distributed.all_reduce(is_spiky_loss_tensor, op=torch.distributed.ReduceOp.MAX)
+    is_spiky_loss = is_spiky_loss_tensor.item()
+    assert is_spiky_loss == 1, f"Expected 1, got {is_spiky_loss}"
+    
+    Utils.destroy_model_parallel()

--- a/tests/unit_tests/test_spiky_loss_detector.py
+++ b/tests/unit_tests/test_spiky_loss_detector.py
@@ -30,6 +30,6 @@ def test_spiky_loss_detector(pp_size=2, threshold=0.2):
     is_spiky_loss_tensor = torch.tensor(is_spiky_loss, dtype=torch.int, device="cuda")
     torch.distributed.all_reduce(is_spiky_loss_tensor, op=torch.distributed.ReduceOp.MAX)
     is_spiky_loss = is_spiky_loss_tensor.item()
-    assert is_spiky_loss == 1, f"Expected 0, got {is_spiky_loss}"
+    assert is_spiky_loss == 1, f"Expected 1, got {is_spiky_loss}"
     
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/test_spiky_loss_detector.py
+++ b/tests/unit_tests/test_spiky_loss_detector.py
@@ -13,13 +13,23 @@ def test_spiky_loss_detector(pp_size=2, threshold=0.2):
         )
     
     detector = SpikyLossDetector(threshold=threshold, loss=10.0)
-    # 
+    
+    # test case 1: loss is not spiky
     losses = [{"lm loss": 10.23}, {"lm loss": 10.32}, {"lm loss": 10.30}]
     reduced_loss = detector.reduce_losses(losses)
     is_spiky_loss = detector.is_spkiy_loss(reduced_loss)
     is_spiky_loss_tensor = torch.tensor(is_spiky_loss, dtype=torch.int, device="cuda")
     torch.distributed.all_reduce(is_spiky_loss_tensor, op=torch.distributed.ReduceOp.MAX)
     is_spiky_loss = is_spiky_loss_tensor.item()
-    assert is_spiky_loss == 1, f"Expected 1, got {is_spiky_loss}"
+    assert is_spiky_loss == 0, f"Expected 0, got {is_spiky_loss}"
+    
+    # test case 2: loss is spiky
+    losses = [{"lm loss": 14.23}, {"lm loss": 14.32}, {"lm loss": 14.30}]
+    reduced_loss = detector.reduce_losses(losses)
+    is_spiky_loss = detector.is_spkiy_loss(reduced_loss)
+    is_spiky_loss_tensor = torch.tensor(is_spiky_loss, dtype=torch.int, device="cuda")
+    torch.distributed.all_reduce(is_spiky_loss_tensor, op=torch.distributed.ReduceOp.MAX)
+    is_spiky_loss = is_spiky_loss_tensor.item()
+    assert is_spiky_loss == 1, f"Expected 0, got {is_spiky_loss}"
     
     Utils.destroy_model_parallel()


### PR DESCRIPTION
Support to skip samples according to spiky loss. There are two methods to skip samples:
1.    You can manually set the skipping range
```
skip_samples_range: [20, 30]
```
2.    Automatically detect the spiky loss and skip the samples
```
auto_skip_spiky_loss: true
spiky_loss_threshold: 0.25
```
