### PR TITLE
[Core] Add FlagScale CLI

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))

--- a/flagscale/cli.py
+++ b/flagscale/cli.py
@@ -1,0 +1,89 @@
+import os
+import sys
+
+import click
+
+from run import main as run_main
+
+VERSION = "0.6.0"
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(
+    VERSION, "-v", "--version", message=f"flagscale version {VERSION}"
+)
+def flagscale():
+    """
+    FlagScale is a comprehensive toolkit designed to support the entire lifecycle of large models,
+    developed with the backing of the Beijing Academy of Artificial Intelligence (BAAI).
+    """
+    pass
+
+
+@flagscale.command()
+@click.argument("yaml_path", type=click.Path(exists=True))
+def train(yaml_path):
+    """
+    Train model from yaml.
+    """
+    click.echo(f"Start training from the yaml {yaml_path}...")
+    yaml_path = os.path.abspath(yaml_path)
+    config_path = os.path.dirname(yaml_path)
+    config_name = os.path.splitext(os.path.basename(yaml_path))[0]
+    click.echo(f"config_path: {config_path}")
+    click.echo(f"config_name: {config_name}")
+
+    sys.argv = [
+        "run.py",
+        f"--config-path={config_path}",
+        f"--config-name={config_name}",
+    ]
+    run_main()
+
+
+@flagscale.command()
+@click.argument("model_name", type=str)
+@click.argument("yaml_path", type=click.Path(exists=True), required=False)
+def serve(model_name, yaml_path=None):
+    """
+    Serve model from yaml.
+    """
+    if yaml_path:
+        if os.path.isabs(yaml_path):
+            yaml_path = yaml_path
+        else:
+            yaml_path = os.path.join(os.getcwd(), yaml_path)
+        if not os.path.exists(yaml_path):
+            click.echo(f"Error: The yaml {yaml_path} does not exist.", err=True)
+            return
+        click.echo(f"Using configuration yaml: {yaml_path}")
+    else:
+        default_dir = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+        yaml_path = os.path.join(
+            default_dir, "examples", model_name, "conf", f"config_{model_name}.yaml"
+        )
+        if not os.path.exists(yaml_path):
+            click.echo(f"Error: The yaml {yaml_path} does not exist.", err=True)
+            return
+        click.echo(f"Using default configuration yaml: {yaml_path}")
+    click.secho(
+        "Warning: When serving, please specify the relevant environment variables. When serving on multiple machines, ensure that the necessary parameters, such as hostfile, are set correctly. For details, refer to the following link: https://github.com/FlagOpen/FlagScale/blob/main/flagscale/serve/README.md",
+        fg="yellow",
+    )
+    click.echo(f"Start serving from the yaml {yaml_path}...")
+    yaml_path = os.path.abspath(yaml_path)
+    config_path = os.path.dirname(yaml_path)
+    config_name = os.path.splitext(os.path.basename(yaml_path))[0]
+    click.echo(f"config_path: {config_path}")
+    click.echo(f"config_name: {config_name}")
+
+    sys.argv = [
+        "run.py",
+        f"--config-path={config_path}",
+        f"--config-name={config_name}",
+    ]
+    run_main()
+
+
+if __name__ == "__main__":
+    flagscale()

--- a/flagscale/serve/run_vllm.py
+++ b/flagscale/serve/run_vllm.py
@@ -11,6 +11,12 @@ import ray
 from dag_utils import check_and_get_port
 from omegaconf import OmegaConf
 
+# Compatible with both command-line execution and source code execution.
+try:
+    import flag_scale
+except Exception as e:
+    pass
+
 from flagscale import serve
 
 timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,74 @@
+import os
+import subprocess
+
+from setuptools import find_packages, setup
+from setuptools.command.install import install
+
+
+def is_nvidia_chip():
+    try:
+        result = subprocess.run(
+            ["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        if result.returncode == 0:
+            return True
+    except FileNotFoundError:
+        pass
+    return False
+
+
+class InstallRequirement(install):
+    def run(self):
+        if is_nvidia_chip():
+            # TODO: At present, it is assumed that the relevant dependencies have been installed,
+            # and automatic installation of the relevant dependencies is supported in the future.
+            # After verification, open the comment.
+            """
+            print("In NVIDIA chip, install train and inference dependencies automatically...")
+            # Install train requirements
+            print("Install train dependencies...")
+            env_param = '--env train'
+            subprocess.check_call(['bash', './install/install-requirements.sh', env_param])
+
+            # Install vllm requirements
+            print("Install inference dependencies...")
+            env_param = "--env inference"
+            subprocess.check_call(
+                ["bash", "./install/install-requirements.sh", env_param]
+            )
+            """
+            pass
+        # Continue to install
+        install.run(self)
+
+
+setup(
+    name="flag_scale",
+    version="0.6.0",
+    description="FlagScale is a comprehensive toolkit designed to support the entire lifecycle of large models, developed with the backing of the Beijing Academy of Artificial Intelligence (BAAI). ",
+    url="https://github.com/FlagOpen/FlagScale",
+    packages=[
+        "flag_scale",
+        "flag_scale.megatron",
+        "flag_scale.flagscale",
+        "flag_scale.examples",
+    ],
+    package_dir={
+        "flag_scale": "",
+        "flag_scale.megatron": "megatron",
+        "flag_scale.flagscale": "flagscale",
+        "flag_scale.examples": "examples",
+    },
+    package_data={
+        "flag_scale.megatron": ["**/*"],
+        "flag_scale.flagscale": ["**/*"],
+        "flag_scale.examples": ["**/*"],
+    },
+    install_requires=["click", "cryptography"],
+    entry_points={
+        "console_scripts": [
+            "flagscale=flag_scale.flagscale.cli:flagscale",
+        ],
+    },
+    cmdclass={"install": InstallRequirement},
+)


### PR DESCRIPTION
This PR introduces the flagscale CLI. To install it, navigate to the FlagScale directory and run:
`cd FlagScale && pip install .`
The `examples` will be packaged.

To uninstall, simply run:
`pip uninstall flag_scale`

Currently, the flagscale CLI supports the serve command.

To serve a model using flagscale, run:
`flagscale serve deepseek_r1 <yaml_path>` or 'flagscale serve deepseek_r1'

NOTE: If u want to use `flagscale serve model_name` to serve model, u should modify the `examples` to add your moedel yaml. Then run `pip install .`