### PR TITLE
[Serve] serve supports other device more than gpu and cpu

### DIFF
--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -201,6 +201,7 @@ def _generate_run_script_serve(
                         ssh_cmd = f"ssh -n {ip} \"docker exec {docker_name} /bin/bash -c '{node_cmd}'\""
                     f.write(f"{ssh_cmd}\n")
         else:
+            # Note: config key device_type is specified for single node serving in neither gpu or cpu.
             device_type = None
             nproc_per_node = None
             if config.experiment.get("runner", None) and config.experiment.runner.get(


### PR DESCRIPTION
## Type
Improvement

## Description

in config.yaml, specify **nproc_per_node** and **device_type** on target device.
Note: config key  **device_type** is specified for _**single node serving**_ in neither gpu or cpu. In **_multiple nodes_** case, use config key **hostfile** instead.
```
experiment:
  runner:
    nproc_per_node: 8
    device_type: xxx
```