### PR TITLE
[Megatron-LM] Update np.product to np.prod

### DIFF
--- a/megatron/megatron/core/dist_checkpointing/exchange_utils.py
+++ b/megatron/megatron/core/dist_checkpointing/exchange_utils.py
@@ -62,7 +62,7 @@ class ShardDistribution(NamedTuple):
 def _shard_size(sh_ten: ShardedTensor):
     """Returns size in bytes of a given sharded tensor."""
     if sh_ten.flattened_range is None:
-        numel = np.product(sh_ten.local_shape)
+        numel = np.prod(sh_ten.local_shape)
     else:
         numel = sh_ten.flattened_range.stop - sh_ten.flattened_range.start
     return numel * torch._utils._element_size(sh_ten.dtype)

--- a/megatron/megatron/core/dist_checkpointing/mapping.py
+++ b/megatron/megatron/core/dist_checkpointing/mapping.py
@@ -198,7 +198,7 @@ class ShardedTensor(ShardedBase):
             )
 
         # TODO: np.unravel_index?
-        mask = np.zeros(np.product(self.local_shape), dtype=bool)
+        mask = np.zeros(np.prod(self.local_shape), dtype=bool)
         mask[self.flattened_range] = True
         return np.nonzero(mask.reshape(self.local_shape))
 

--- a/megatron/megatron/core/dist_checkpointing/validation.py
+++ b/megatron/megatron/core/dist_checkpointing/validation.py
@@ -494,7 +494,7 @@ def _validate_sharding_for_key_flattened(tensors_by_shard):
         all_slices.append((sharding.flattened_range.start, sharding.flattened_range.stop))
 
     starts, stops = map(np.asarray, zip(*sorted(all_slices)))
-    expected_size = np.product(local_shape)
+    expected_size = np.prod(local_shape)
     if starts[0] != 0 or stops[-1] != expected_size or not np.all(starts[1:] == stops[:-1]):
         raise CheckpointingException(
             f'Flattened ranges dont cover the whole shard {tensors_by_shard[0]} of size {expected_size}. Ranges: {(starts, stops)}'


### PR DESCRIPTION
np.product was deprecated in NumPy 1.25.0 and was removed in NumPy 2.0.