### PR TITLE
[Core] Fix ucc comm-backend when using `FlagCX` backend

### DIFF
--- a/megatron/megatron/core/model_parallel_config.py
+++ b/megatron/megatron/core/model_parallel_config.py
@@ -19,8 +19,10 @@ class ModelParallelConfig:
     tensor_model_parallel_size: int = 1
     """Intra-layer model parallelism. Splits tensors across GPU ranks."""
 
-    pipeline_model_parallel_comm_backend: str = "nccl"
-    """Configuring backend option of pipeline parallel communication (e.g., nccl, ucc)"""
+    pipeline_model_parallel_comm_backend: Optional[str] = None
+    """Configuring backend option of pipeline parallel communication (e.g., nccl, ucc)
+       If None, the default backend will be used.
+    """
 
     pipeline_model_parallel_size: int = 1
     """Inter-layer model parallelism. Splits transformer layers across GPU ranks."""

--- a/megatron/megatron/core/parallel_state.py
+++ b/megatron/megatron/core/parallel_state.py
@@ -461,7 +461,7 @@ def initialize_model_parallel(
     pipeline_model_parallel_size: int = 1,
     virtual_pipeline_model_parallel_size: Optional[int] = None,
     pipeline_model_parallel_split_rank: Optional[int] = None,
-    pipeline_model_parallel_comm_backend: Optional[str] = "nccl",
+    pipeline_model_parallel_comm_backend: Optional[str] = None,
     use_sharp: bool = False,
     ulysses_parallel_size: int  = 1,
     context_parallel_size: int = 1,
@@ -1143,7 +1143,8 @@ def initialize_model_parallel(
             group_desc='PIPELINE_MODEL_PARALLEL_GROUP',
         )
         assert (
-            pipeline_model_parallel_comm_backend == 'nccl'
+            pipeline_model_parallel_comm_backend == None
+            or pipeline_model_parallel_comm_backend == 'nccl'
             or pipeline_model_parallel_comm_backend == 'ucc'
         ), f'"{pipeline_model_parallel_comm_backend}" backend for PP communication is currently not supported'
 

--- a/megatron/megatron/training/arguments.py
+++ b/megatron/megatron/training/arguments.py
@@ -1627,9 +1627,10 @@ def _add_training_args(parser):
     group.add_argument('--disable-tp-comm-split-rs', action='store_false',
                        help='Disables the Reduce-Scatter overlap with fprop GEMM.',
                        dest='tp_comm_split_rs')
-    group.add_argument('--pipeline-model-parallel-comm-backend', type=str, default='nccl',
+    group.add_argument('--pipeline-model-parallel-comm-backend', type=str, default=None,
                        choices=['nccl', 'ucc'],
-                       help='Select a communicator backend for pipeline parallel communication.')
+                       help='Select a communicator backend for pipeline parallel communication. '
+                       'If None, the default backend will be used.')
 
     return parser
 


### PR DESCRIPTION
Change the default value of  `pipeline-model-parallel-comm-backend` to `None` to support the `distributed-backend` is not `nccl`.