### PR TITLE
[Tools] Support for ckpt conversion of deepseek v3

### DIFF
--- a/examples/deepseek_v3/conf/config_deepseek_v3.yaml
+++ b/examples/deepseek_v3/conf/config_deepseek_v3.yaml
@@ -1,5 +1,4 @@
-# Demo for testing
-# TODO: Release 671B version
+# DeepSeek 16B, 2.4A Model
 defaults:
   - _self_
   - train: train_deepseek_v3.yaml

--- a/examples/deepseek_v3/conf/train/train_deepseek_v3.yaml
+++ b/examples/deepseek_v3/conf/train/train_deepseek_v3.yaml
@@ -1,23 +1,21 @@
 system:
   no_shared_fs: ${experiment.runner.no_shared_fs}
   num_workers: 16
-  tensor_model_parallel_size: 2
-  pipeline_model_parallel_size: 2
-  expert_model_parallel_size: 2
+  tensor_model_parallel_size: 1
+  pipeline_model_parallel_size: 1
+  expert_model_parallel_size: 1
   context_parallel_size: 1
   disable_bias_linear: true
   reset_position_ids: True
   reset_attention_mask: True
-  add_qkv_bias: true
   qk_layernorm: true
   sequence_parallel: true
   use_distributed_optimizer: true
   overlap_grad_reduce: true
   overlap_param_gather: true
+  finetune: false
   precision:
     bf16: true
-    initial_loss_scale: 522893
-    min_loss_scale: 1.0
     attention_softmax_in_fp32: true
     accumulate_allreduce_grads_in_fp32: true
   logging:
@@ -38,9 +36,8 @@ system:
 
 model:
   transformer_impl: transformer_engine
-  num_layers: 24
+  num_layers: 27
   hidden_size: 2048
-  ffn_hidden_size: 1408
   num_attention_heads: 16
   group_query_attention: true
   num_query_groups: 16 # num_key_value_heads
@@ -48,13 +45,13 @@ model:
   max_position_embeddings: 4096
   norm_epsilon: 1e-6
   use_rotary_position_embeddings: true
-  rotary_base: 10000
-  norm_init_weight: 0.5
+  rotary_base: 1000000
   swiglu: true
   normalization: RMSNorm
   init_method_std: 0.02
   attention_dropout: 0.0
   hidden_dropout: 0.0
+  clip_grad: 1.0
   position_embedding_type: rope
   untie_embeddings_and_output_weights: true
   no_position_embedding: true
@@ -62,51 +59,53 @@ model:
 
   # mla args ==================
   multi_latent_attention: true
-  q_lora_rank: 1536
   kv_lora_rank: 512
   qk_head_dim: 128
   qk_pos_emb_head_dim: 64
   v_head_dim: 128
 
   # moe args ===================
-  moe_shared_expert_intermediate_size: 1408
+  ffn_hidden_size: 11264
+  moe_ffn_hidden_size: 1408
+  moe_grouped_gemm: true
+  moe_shared_expert_intermediate_size: 2816
   num_experts: 64
-  moe_router_load_balancing_type: "aux_loss"
+  moe_router_load_balancing_type: "seq_aux_loss"
   moe_router_score_function: sigmoid
   moe_router_enable_expert_bias: true
   moe_router_bias_update_rate: 0.001
   moe_aux_loss_coeff: 0.02
-  moe_layer_freq: "[0]+[1]*23"
+  moe_layer_freq: "[0]+[1]*26"
   # node limited routing
   moe_router_num_groups: 1
   moe_router_group_topk: 1
   moe_router_topk: 6
+  moe_router_topk_scaling_factor: 2.446
+  moe_token_dispatcher_type: "alltoall"
+  # moe_permute_fusion: true
 
   # training
   seed: ${experiment.seed}
-  train_iters: 10000
+  # finetune: false
   micro_batch_size: 1
-  global_batch_size: 32
-  eval_interval: 1000
-  eval_iters: 5
+  global_batch_size: 2048
+  eval_iters: 0
+  train_samples: 244141056 #1T #29297664 #120B tokens
 
-  # optimizer
-  no_load_optim: True
-  no_load_rng: True
-  optimizer: adam
-  lr: 0.0005
-  min_lr: 0.00005
-  weight_decay: 0.1
-  adam_beta1: 0.9
-  adam_beta2: 0.95
-  adam_eps: 1.0e-6
-  clip_grad: 1.0
-  lr_warmup_fraction: 0.02
-  lr_decay_iters: 120000
-  lr_decay_style: cosine
+  optimizer:
+    weight_decay: 0.1
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    lr_scheduler:
+      lr: 3.0e-3
+      min_lr: 3.0e-4
+      lr_warmup_samples: 2048000
+      lr_decay_style: WSD
+      lr_wsd_decay_style: cosine
+      lr_wsd_decay_samples: 2048
+
 
 data:
-  no_create_attention_mask_in_dataloader: true
   data_path: /path
   split: 1
   no_mmap_bin_files: true

--- a/flagscale/train/train_deepseek_v3.py
+++ b/flagscale/train/train_deepseek_v3.py
@@ -67,6 +67,7 @@ def model_provider(pre_process=True, post_process=True) -> Union[GPTModel, megat
     """
     args = get_args()
     use_te = args.transformer_impl == "transformer_engine"
+    assert use_te is True, "DeepSeek V3 requires Transformer Engine"
 
     if args.record_memory_history:
         torch.cuda.memory._record_memory_history(True,

--- a/tools/checkpoint/deepseek_v3/args.py
+++ b/tools/checkpoint/deepseek_v3/args.py
@@ -13,65 +13,23 @@ def load_args_hf2mg(args):
     args.vocab_size = deepseek_v3_args["vocab_size"]
     args.hidden_size = deepseek_v3_args["hidden_size"]
     args.ffn_hidden_size = deepseek_v3_args["intermediate_size"]
-    moe_intermediate_size = deepseek_v3_args["intermediate_size"]
-    assert (
-        moe_intermediate_size == args.ffn_hidden_size
-    ), "mlp intermediate size is not matched with moe"
     args.num_layers = deepseek_v3_args["num_hidden_layers"]
-    args.num_mtp_predictor = deepseek_v3_args["num_nextn_predict_layers"]
     args.num_attention_heads = deepseek_v3_args["num_attention_heads"]
-    n_shared_experts = deepseek_v3_args["n_shared_experts"]
-    if n_shared_experts > 0:
-        args.moe_shared_expert_intermediate_size = moe_intermediate_size
-    args.num_experts = deepseek_v3_args["n_routed_experts"]
-    routed_scaling_factor = deepseek_v3_args["routed_scaling_factor"]
-    topk_method = deepseek_v3_args["topk_method"]
-    n_group = deepseek_v3_args["n_group"]
-    topk_group = deepseek_v3_args["topk_group"]
-    args.moe_router_topk = deepseek_v3_args["num_experts_per_tok"]
-    args.moe_layer_freq = deepseek_v3_args["moe_layer_freq"]
-    # if set first k dense replace, then updating moe_layer_freq
-    first_k_dense_replace = deepseek_v3_args["first_k_dense_replace"]
-    args.moe_layer_freq = eval(
-        "[0]*"
-        + str(first_k_dense_replace)
-        + "+[1]*"
-        + str(args.num_layers - first_k_dense_replace)
-    )
-
-    norm_topk_prob = deepseek_v3_args["norm_topk_prob"]
-    args.moe_router_score_function = deepseek_v3_args["scoring_func"]
-    aux_loss_alpha = deepseek_v3_args["aux_loss_alpha"]
-    seq_aux = deepseek_v3_args["seq_aux"]
     args.num_query_groups = deepseek_v3_args["num_key_value_heads"]
     hidden_act = deepseek_v3_args["hidden_act"]
+    args.swiglu = True if hidden_act == "silu" else False
     args.max_position_embeddings = deepseek_v3_args["max_position_embeddings"]
     args.init_method_std = deepseek_v3_args["initializer_range"]
     args.norm_epsilon = deepseek_v3_args["rms_norm_eps"]
-    use_cache = deepseek_v3_args["use_cache"]
-    # pad_token_id = deepseek_v3_args["pad_token_id"]
-    bos_token_id = deepseek_v3_args["bos_token_id"]
-    eos_token_id = deepseek_v3_args["eos_token_id"]
-    pretraining_tp = deepseek_v3_args["pretraining_tp"]
     args.untie_embeddings_and_output_weights = not deepseek_v3_args[
         "tie_word_embeddings"
     ]
     args.rotary_base = deepseek_v3_args["rope_theta"]
-    rope_scaling = deepseek_v3_args["rope_scaling"]
-    attention_bias = deepseek_v3_args["attention_bias"]
+    args.disable_bias_linear = not deepseek_v3_args["attention_bias"]
     args.attention_dropout = deepseek_v3_args["attention_dropout"]
-    args.q_lora_rank = deepseek_v3_args["q_lora_rank"]
-    args.kv_lora_rank = deepseek_v3_args["kv_lora_rank"]
-    args.qk_head_dim = deepseek_v3_args["qk_nope_head_dim"]
-    args.qk_pos_emb_head_dim = deepseek_v3_args["qk_rope_head_dim"]
-    args.v_head_dim = deepseek_v3_args["v_head_dim"]
-    args.multi_latent_attention = True
     args.qk_layernorm = True
-    args.swiglu = True
     args.bf16 = deepseek_v3_args["torch_dtype"] == "bfloat16"
     args.fp16 = deepseek_v3_args["torch_dtype"] == "float16"
-    args.moe_router_enable_expert_bias = True
-    args.moe_router_bias_update_rate = 0.001
     args.apply_rope_fusion = False
     args.seq_length = 4096
     args.global_batch_size = 800
@@ -87,6 +45,92 @@ def load_args_hf2mg(args):
     args.consumed_train_samples = 0
     args.consumed_valid_samples = 0
     args.norm_has_bias = False
-    args.tokenizer_type = "Emu3TokenizerFS"
+    args.tokenizer_type = "QwenTokenizerFS"
+
+    # MoE Related
+    args.moe_ffn_hidden_size = deepseek_v3_args["moe_intermediate_size"]
+    n_shared_experts = deepseek_v3_args["n_shared_experts"]
+    if n_shared_experts > 0:
+        args.moe_shared_expert_intermediate_size = (
+            n_shared_experts * args.moe_ffn_hidden_size
+        )
+    args.moe_grouped_gemm = True
+    args.num_experts = deepseek_v3_args["n_routed_experts"]
+    args.moe_router_topk_scaling_factor = deepseek_v3_args["routed_scaling_factor"]
+    args.moe_router_num_groups = deepseek_v3_args["n_group"]
+    args.moe_router_group_topk = deepseek_v3_args["topk_group"]
+    args.moe_router_topk = deepseek_v3_args["num_experts_per_tok"]
+    args.moe_layer_freq = deepseek_v3_args["moe_layer_freq"]
+    # if set first k dense replace, then updating moe_layer_freq
+    first_k_dense_replace = deepseek_v3_args["first_k_dense_replace"]
+    args.moe_layer_freq = eval(
+        "[0]*"
+        + str(first_k_dense_replace)
+        + "+[1]*"
+        + str(args.num_layers - first_k_dense_replace)
+    )
+    args.moe_router_score_function = deepseek_v3_args["scoring_func"]
+    if args.moe_router_score_function == "sigmoid":
+        args.moe_router_enable_expert_bias = True
+        args.moe_router_bias_update_rate = 0.001
+    seq_aux = deepseek_v3_args["seq_aux"]
+    if seq_aux:
+        args.moe_router_load_balancing_type == "seq_aux_loss"
+
+    # MLA Related
+    if deepseek_v3_args["q_lora_rank"] != "null":
+        args.q_lora_rank = deepseek_v3_args["q_lora_rank"]
+    args.kv_lora_rank = deepseek_v3_args["kv_lora_rank"]
+    args.qk_head_dim = deepseek_v3_args["qk_nope_head_dim"]
+    args.qk_pos_emb_head_dim = deepseek_v3_args["qk_rope_head_dim"]
+    args.v_head_dim = deepseek_v3_args["v_head_dim"]
+    args.multi_latent_attention = True
+
+    # MTP Related
+    # MTP is used in DeepSeek V3
+    if "num_nextn_predict_layers" in deepseek_v3_args:
+        args.num_mtp_predictor = deepseek_v3_args["num_nextn_predict_layers"]
 
     return args, args
+
+
+def save_args_mg2hf(args):
+    from .moonlight_deepseek.configuration_deepseek import DeepseekV3Config
+
+    first_k_dense_replace = args.moe_layer_freq.index(1)
+    seq_aux = True if args.moe_router_load_balancing_type == "seq_aux_loss" else False
+    config = DeepseekV3Config(
+        vocab_size=args.vocab_size,
+        hidden_size=args.hidden_size,
+        intermediate_size=args.ffn_hidden_size,
+        moe_intermediate_size=args.moe_ffn_hidden_size,
+        num_hidden_layers=args.num_layers,
+        num_nextn_predict_layers=args.num_mtp_predictor,
+        num_attention_heads=args.num_attention_heads,
+        num_key_value_heads=args.num_query_groups,
+        n_shared_experts=args.moe_shared_expert_intermediate_size
+        // args.moe_ffn_hidden_size,
+        n_routed_experts=args.num_experts,
+        routed_scaling_factor=args.moe_router_topk_scaling_factor,
+        kv_lora_rank=args.kv_lora_rank,
+        q_lora_rank=args.q_lora_rank,
+        qk_rope_head_dim=args.qk_pos_emb_head_dim,
+        v_head_dim=args.v_head_dim,
+        qk_nope_head_dim=args.qk_head_dim,
+        n_group=args.moe_router_num_groups,
+        topk_group=args.moe_router_group_topk,
+        num_experts_per_tok=args.moe_router_topk,
+        first_k_dense_replace=first_k_dense_replace,
+        scoring_func=args.moe_router_score_function,
+        seq_aux=seq_aux,
+        max_position_embeddings=args.max_position_embeddings,
+        initializer_range=args.init_method_std,
+        rms_norm_eps=args.norm_epsilon,
+        tie_word_embeddings=not args.untie_embeddings_and_output_weights,
+        rope_theta=args.rotary_base,
+        attention_dropout=args.attention_dropout,
+        torch_dtype=args.params_dtype,
+    )
+    config.save_pretrained(args.save)
+
+    return config

--- a/tools/checkpoint/deepseek_v3/ckpt.py
+++ b/tools/checkpoint/deepseek_v3/ckpt.py
@@ -6,6 +6,16 @@ sys.path.append("..")
 from utils import padding_vocab_size
 
 
+def _get_parallel_size(args):
+    return (
+        args.tensor_model_parallel_size,
+        args.pipeline_model_parallel_size,
+        args.expert_model_parallel_size,
+        args.virtual_pipeline_model_parallel_size or 1,
+    )
+
+
+#### load from huggingface ckpt
 def get_hf_attn_ckpt(message, model, layer_id, args):
     nh = args.num_attention_heads
     ng = (
@@ -18,14 +28,17 @@ def get_hf_attn_ckpt(message, model, layer_id, args):
 
     tf_layer = model.model.layers[layer_id]
 
-    message["q a weight"] = tf_layer.self_attn.q_a_proj.weight.data
-    message["q a norm weight"] = tf_layer.self_attn.q_a_layernorm.weight.data
-    message["q b weight"] = tf_layer.self_attn.q_b_proj.weight.data
+    if args.q_lora_rank is not None:
+        message["q a weight"] = tf_layer.self_attn.q_a_proj.weight.data
+        message["q a norm weight"] = tf_layer.self_attn.q_a_layernorm.weight.data
+        message["q b weight"] = tf_layer.self_attn.q_b_proj.weight.data
+    else:
+        message["q weight"] = tf_layer.self_attn.q_proj.weight.data
+
     message["kv a weight"] = tf_layer.self_attn.kv_a_proj_with_mqa.weight.data
     message["kv a norm weight"] = tf_layer.self_attn.kv_a_layernorm.weight.data
     message["kv b weight"] = tf_layer.self_attn.kv_b_proj.weight.data
     message["o weight"] = tf_layer.self_attn.o_proj.weight.data
-
     message["input norm weight"] = tf_layer.input_layernorm.weight.data
     message["post norm weight"] = tf_layer.post_attention_layernorm.weight.data
 
@@ -50,7 +63,8 @@ def get_hf_moe_mlp_ckpt(message, model, layer_id, args):
     tf_layer = model.model.layers[layer_id]
 
     message["router weight"] = tf_layer.mlp.gate.weight.data
-    message["router e score bias"] = tf_layer.mlp.gate.e_score_correction_bias.data
+    if hasattr(tf_layer.mlp.gate, "e_score_correction_bias"):
+        message["router e score bias"] = tf_layer.mlp.gate.e_score_correction_bias.data
     message["shared expert gate weight"] = (
         tf_layer.mlp.shared_experts.gate_proj.weight.data
     )
@@ -81,15 +95,7 @@ def get_hf_mtp_ckpt(message, model, mtp_layer_id, args):
     get_hf_moe_mlp_ckpt(message, model, args.num_layers + mtp_layer_id, args)
 
 
-def _get_parallel_size(args):
-    return (
-        args.tensor_model_parallel_size,
-        args.pipeline_model_parallel_size,
-        args.expert_model_parallel_size,
-        args.virtual_pipeline_model_parallel_size or 1,
-    )
-
-
+#### set to megatron ckpt
 def set_embedding_ckpt(message, models, md, args):
     tp_size, _, _, _ = _get_parallel_size(args)
     assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
@@ -116,9 +122,13 @@ def set_attn_ckpt(message, models, layer_id, md, args):
     assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
 
     # weight
-    q_a_weight = message.pop("q a weight")
-    q_a_norm_weight = message.pop("q a norm weight")
-    q_b_weight = message.pop("q b weight")
+    if args.q_lora_rank is not None:
+        q_a_weight = message.pop("q a weight")
+        q_a_norm_weight = message.pop("q a norm weight")
+        q_b_weight = message.pop("q b weight")
+    else:
+        q_weight = message.pop("q weight")
+
     kv_a_weight = message.pop("kv a weight")
     kv_a_norm_weight = message.pop("kv a norm weight")
     kv_b_weight = message.pop("kv b weight")
@@ -135,11 +145,15 @@ def set_attn_ckpt(message, models, layer_id, md, args):
             tf_layer = model.decoder.layers[layer_id]
         else:
             tf_layer = model.transformer_layer  # for mtp
-        tf_layer.self_attention.linear_q_down_proj.weight.data.copy_(q_a_weight)
-        tf_layer.self_attention.linear_q_up_proj.layer_norm_weight.data.copy_(
-            q_a_norm_weight
-        )
-        tf_layer.self_attention.linear_q_up_proj.weight.data.copy_(q_b_weight)
+        if args.q_lora_rank is not None:
+            tf_layer.self_attention.linear_q_down_proj.weight.data.copy_(q_a_weight)
+            tf_layer.self_attention.linear_q_up_proj.layer_norm_weight.data.copy_(
+                q_a_norm_weight
+            )
+            tf_layer.self_attention.linear_q_up_proj.weight.data.copy_(q_b_weight)
+        else:
+            tf_layer.self_attention.linear_q_proj.weight.data.copy_(q_weight)
+
         tf_layer.self_attention.linear_kv_down_proj.weight.data.copy_(kv_a_weight)
         tf_layer.self_attention.linear_kv_up_proj.layer_norm_weight.data.copy_(
             kv_a_norm_weight
@@ -189,7 +203,11 @@ def set_moe_mlp_ckpt(message, models, layer_id, md, args):
 
     # router
     router_weight = message.pop("router weight")
-    router_score_bias = message.pop("router e score bias")
+    router_score_bias = None
+    use_router_score_bias = False
+    if "router e score bias" in message.keys():
+        use_router_score_bias = True
+        router_score_bias = message.pop("router e score bias")
 
     # shared expert
     shared_expert_gate_weight = message.pop("shared expert gate weight")
@@ -199,7 +217,7 @@ def set_moe_mlp_ckpt(message, models, layer_id, md, args):
     )
     shared_expert_linear2_weight = message.pop("shared expert down weight")
 
-    # routed expert
+    # if not args.moe_grouped_gemm:
     num_local_experts = md.previous_num_experts // ep_size
     for expert_id in range(num_local_experts):
         for ep_rank in range(ep_size):
@@ -220,15 +238,26 @@ def set_moe_mlp_ckpt(message, models, layer_id, md, args):
                 # router
                 router = tf_layer.mlp.router
                 router.weight.data.copy_(router_weight)
-                router.score_bias.data.copy_(router_score_bias)
+                if use_router_score_bias:
+                    router.score_bias.data.copy_(router_score_bias)
                 # shared expert
                 shared_expert = tf_layer.mlp.shared_experts
                 shared_expert.linear_fc1.weight.data.copy_(shared_expert_linear1_weight)
                 shared_expert.linear_fc2.weight.data.copy_(shared_expert_linear2_weight)
                 # routed expert
-                expert = tf_layer.mlp.experts.local_experts[expert_id]
-                expert.linear_fc1.weight.data.copy_(linear1_weight)
-                expert.linear_fc2.weight.data.copy_(linear2_weight)
+                if not args.moe_grouped_gemm:
+                    expert = tf_layer.mlp.experts.local_experts[expert_id]
+                    expert.linear_fc1.weight.data.copy_(linear1_weight)
+                    expert.linear_fc2.weight.data.copy_(linear2_weight)
+                else:  # using TEGroupedMLP
+                    expert_linear_fc1_weight = getattr(
+                        tf_layer.mlp.experts.linear_fc1, f"weight{expert_id}", None
+                    )
+                    expert_linear_fc2_weight = getattr(
+                        tf_layer.mlp.experts.linear_fc2, f"weight{expert_id}", None
+                    )
+                    expert_linear_fc1_weight.data.copy_(linear1_weight)
+                    expert_linear_fc2_weight.data.copy_(linear2_weight)
 
 
 def set_final_norm_ckpt(message, models, md, args):
@@ -263,14 +292,384 @@ def set_mtp_ckpt(message, models, md, mtp_layer_id, args):
 
     # get and set other weights
     # mtp embeddings weight is shared with main model embeddings
+    mtp_embeddings_weight = message.pop("mtp word embeddings weight")
+    full_word_embed = padding_vocab_size(mtp_embeddings_weight, md, args)
     mtp_enorm_weight = message.pop("mtp enorm weight")
     mtp_hnorm_weight = message.pop("mtp hnorm weight")
     mtp_eh_weight = message.pop("mtp eh weight")
     mtp_shared_head_norm_weight = message.pop("mtp shared head norm weight")
     for tp_ep_rank, model in enumerate(models):
+        model.mtp_embedding.weight.data.copy_(full_word_embed)
         mtp_layer = model.mtp_predictor.mtp_modules[mtp_layer_id]
         mtp_layer.norm1.weight.data.copy_(mtp_enorm_weight)
         mtp_layer.norm2.weight.data.copy_(mtp_hnorm_weight)
         mtp_layer.linear_proj.weight.data.copy_(mtp_eh_weight)
         mtp_layer.final_norm.weight.data.copy_(mtp_shared_head_norm_weight)
     # mtp output lm head is the same with main model output lm head
+
+
+#### load from megatron ckpt
+def get_embedding_ckpt(message, models, args):
+    tp_size, _, _, _ = _get_parallel_size(args)
+    assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
+
+    word_embeddings = None
+    complete_tp_ranks = []
+    for tp_ep_rank, model in enumerate(models):
+        tp_rank = tp_ep_rank % tp_size
+        if tp_rank in complete_tp_ranks:
+            continue
+        complete_tp_ranks.append(tp_rank)
+        word_embeddings = model.embedding.word_embeddings.weight.data
+    message["word embeddings"] = word_embeddings
+
+
+def get_attn_ckpt(message, models, layer_id, args):
+    tp_size, _, _, _ = _get_parallel_size(args)
+    assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
+
+    # parallel tensor
+    q_a_weight = None
+    q_a_norm_weight = None
+    q_b_weight = None
+    q_weight = None
+    kv_a_weight = None
+    kv_a_norm_weight = None
+    kv_b_weight = None
+    o_weight = None
+    # non-parallel tensor
+    input_norm_weight = None
+    post_norm_weight = None
+
+    first_k_dense_replace = args.moe_layer_freq.index(1)
+    complete_tp_ranks = []
+    for tp_ep_rank, model in enumerate(models):
+        tp_rank = tp_ep_rank % tp_size
+        if tp_rank in complete_tp_ranks:
+            continue
+        complete_tp_ranks.append(tp_rank)
+
+        if hasattr(model, "decoder"):
+            tf_layer = model.decoder.layers[layer_id]
+        else:
+            tf_layer = model.transformer_layer  # for mtp
+        # weight
+        if args.q_lora_rank is not None:
+            q_a_weight = tf_layer.self_attention.linear_q_down_proj.weight.data
+            q_a_norm_weight = (
+                tf_layer.self_attention.linear_q_up_proj.layer_norm_weight.data
+            )
+            q_b_weight = tf_layer.self_attention.linear_q_up_proj.weight.data
+        else:
+            q_weight = tf_layer.self_attention.linear_q_proj.weight.data
+
+        kv_a_weight = tf_layer.self_attention.linear_kv_down_proj.weight.data
+        kv_a_norm_weight = (
+            tf_layer.self_attention.linear_kv_up_proj.layer_norm_weight.data
+        )
+        kv_b_weight = tf_layer.self_attention.linear_kv_up_proj.weight.data
+        o_weight = tf_layer.self_attention.linear_proj.weight.data
+        input_norm_weight = tf_layer.input_layernorm.weight.data
+
+        if args.total_layer_num >= first_k_dense_replace:
+            post_norm_weight = tf_layer.pre_mlp_layernorm.weight.data
+
+    # weight
+    if args.q_lora_rank is not None:
+        message["q a weight"] = q_a_weight
+        message["q a norm weight"] = q_a_norm_weight
+        message["q b weight"] = q_b_weight
+    else:
+        message["q weight"] = q_weight
+
+    message["kv a weight"] = kv_a_weight
+    message["kv a norm weight"] = kv_a_norm_weight
+    message["kv b weight"] = kv_b_weight
+    message["o weight"] = o_weight
+    message["input norm weight"] = input_norm_weight
+    if args.total_layer_num >= first_k_dense_replace:
+        message["post norm weight"] = post_norm_weight
+
+
+def get_mlp_ckpt(message, models, layer_id, args):
+    first_k_dense_replace = args.moe_layer_freq.index(1)
+    if args.total_layer_num < first_k_dense_replace:
+        get_dense_mlp_ckpt(message, models, layer_id, args)
+    else:
+        get_moe_mlp_ckpt(message, models, layer_id, args)
+
+
+def get_dense_mlp_ckpt(message, models, layer_id, args):
+    tp_size, _, _, _ = _get_parallel_size(args)
+    assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
+
+    # parallel tensor
+    post_norm_weight = None
+    gate_weight = None
+    up_weight = None
+    down_weight = None
+
+    complete_tp_ranks = []
+    for tp_ep_rank, model in enumerate(models):
+        tp_rank = tp_ep_rank % tp_size
+        if tp_rank in complete_tp_ranks:
+            continue
+        complete_tp_ranks.append(tp_rank)
+
+        if hasattr(model, "decoder"):
+            tf_layer = model.decoder.layers[layer_id]
+        else:
+            tf_layer = model.transformer_layer  # for mtp
+        post_norm_weight = tf_layer.mlp.linear_fc1.layer_norm_weight.data
+        gate_weight = tf_layer.mlp.linear_fc1.weight.data[0]
+        up_weight = tf_layer.mlp.linear_fc1.weight.data[1]
+        down_weight = tf_layer.mlp.linear_fc2.weight.data
+
+    # weight
+    message["post norm weight"] = post_norm_weight
+    message["gate weight"] = gate_weight
+    message["up weight"] = up_weight
+    message["down weight"] = down_weight
+
+
+def get_moe_mlp_ckpt(message, models, layer_id, args):
+    tp_size, _, ep_size, _ = _get_parallel_size(args)
+    assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
+
+    assert args.num_experts is not None and args.num_experts % ep_size == 0
+    num_local_experts = args.num_experts // ep_size
+    for expert_id in range(num_local_experts):
+        for ep_rank in range(ep_size):
+            global_expert_id = num_local_experts * ep_rank + expert_id
+
+            # local experts
+            use_router_score_bias = False
+            for tp_rank in range(tp_size):
+                tp_ep_rank = ep_rank * tp_size + tp_rank
+                if hasattr(models[tp_ep_rank], "decoder"):
+                    tf_layer = models[tp_ep_rank].decoder.layers[layer_id]
+                else:
+                    tf_layer = models[tp_ep_rank].transformer_layer  # for mtp
+
+                # router
+                router = tf_layer.mlp.router
+                router_weight = router.weight.data
+                if hasattr(router, "score_bias"):
+                    use_router_score_bias = True
+                    router_score_bias = router.score_bias.data
+                # shared experts
+                shared_expert = tf_layer.mlp.shared_experts
+                shared_expert_gate_weight = shared_expert.linear_fc1.weight.data[0]
+                shared_expert_up_weight = shared_expert.linear_fc1.weight.data[1]
+                shared_expert_down_weight = shared_expert.linear_fc2.weight.data
+                # routed experts
+                if not args.moe_grouped_gemm:
+                    expert = tf_layer.mlp.experts.local_experts[expert_id]
+                    expert_gate_weight = expert.linear_fc1.weight.data[0]
+                    expert_up_weight = expert.linear_fc1.weight.data[1]
+                    expert_down_weight = expert.lienar_fc2.weight.data
+                else:  # using TEGroupedMLP
+                    expert_linear_fc1_weight = getattr(
+                        tf_layer.mlp.experts.linear_fc1, f"weight{expert_id}", None
+                    )
+                    expert_gate_weight = expert_linear_fc1_weight.data[0]
+                    expert_up_weight = expert_linear_fc1_weight.data[1]
+                    expert_down_weight = getattr(
+                        tf_layer.mlp.experts.linear_fc2, f"weight{expert_id}", None
+                    )
+
+            message["router weight"] = router_weight
+            if use_router_score_bias:
+                message["router e score bias"] = router_score_bias
+            message["shared expert gate weight"] = shared_expert_gate_weight
+            message["shared expert up weight"] = shared_expert_up_weight
+            message["shared expert down weight"] = shared_expert_down_weight
+
+            message[f"expert{global_expert_id} gate weight"] = expert_gate_weight
+            message[f"expert{global_expert_id} up weight"] = expert_up_weight
+            message[f"expert{global_expert_id} down weight"] = expert_down_weight
+
+
+def get_final_norm_ckpt(message, models, args):
+    tp_size, _, _, _ = _get_parallel_size(args)
+    assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
+
+    final_layernorm_weight = None
+    complete_tp_ranks = []
+    for tp_ep_rank, model in enumerate(models):
+        tp_rank = tp_ep_rank % tp_size
+        if tp_rank in complete_tp_ranks:
+            continue
+        complete_tp_ranks.append(tp_rank)
+        final_layernorm_weight = model.decoder.final_layernorm.weight.data
+
+    message["weight"] = final_layernorm_weight
+
+
+def get_output_layer_ckpt(message, models, args):
+    tp_size, _, _, _ = _get_parallel_size(args)
+    assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
+
+    output_layer_weight = None
+    complete_tp_ranks = []
+    for tp_ep_rank, model in enumerate(models):
+        tp_rank = tp_ep_rank % tp_size
+        if tp_rank in complete_tp_ranks:
+            continue
+        complete_tp_ranks.append(tp_rank)
+        output_layer_weight = model.output_layer.weight.data
+    message["weight"] = output_layer_weight
+
+
+def get_mtp_ckpt(message, models, mtp_layer_id, args):
+    tp_size, _, _, _ = _get_parallel_size(args)
+    assert tp_size == 1, "do not support TP parallel for deepseek v3 currently"
+
+    mtp_layers = []
+    for tp_ep_rank, model in enumerate(models):
+        mtp_layer = model.mtp_predictor.mtp_modules[mtp_layer_id]
+        mtp_layers.append(mtp_layer)
+
+    # get and set transformer weights
+    get_attn_ckpt(message, mtp_layers, 0, args)
+    get_moe_mlp_ckpt(message, mtp_layers, 0, args)
+
+    complete_tp_ranks = []
+    for tp_ep_rank, model in enumerate(models):
+        tp_rank = tp_ep_rank % tp_size
+        if tp_rank in complete_tp_ranks:
+            continue
+        complete_tp_ranks.append(tp_rank)
+
+        mtp_word_embedding_weight = model.mtp_embedding.word_embeddings.weight.data
+        mtp_layer = model.mtp_predictor.mtp_modules[mtp_layer_id]
+        mtp_enorm_weight = mtp_layer.norm1.weight.data
+        mtp_hnorm_weight = mtp_layer.norm2.weight.data
+        mtp_eh_weight = mtp_layer.linear_proj.weight.data
+        mtp_norm_weight = mtp_layer.final_norm.weight.data
+        output_layer_weight = model.output_layer.weight.data
+
+    message["mtp word embeddings weight"] = mtp_word_embedding_weight
+    message["mtp enorm weight"] = mtp_enorm_weight
+    message["mtp hnorm weight"] = mtp_hnorm_weight
+    message["mtp eh weight"] = mtp_eh_weight
+    message["mtp shared head norm weight"] = mtp_norm_weight
+    message["mtp shared head head weight"] = output_layer_weight
+
+
+#### set to huggingface ckpt
+def set_hf_attn_ckpt(message, model, layer_id, md, args):
+    if args.q_lora_rank is not None:
+        q_a_weight = message.pop("q a weight")
+        q_a_norm_weight = message.pop("q a norm weight")
+        q_b_weight = message.pop("q b weight")
+    else:
+        q_weight = message.pop("q weight")
+    kv_a_weight = message.pop("kv a weight")
+    kv_a_norm_weight = message.pop("kv a norm weight")
+    kv_b_weight = message.pop("kv b weight")
+    o_weight = message.pop("o weight")
+    input_norm_weight = message.pop("input norm weight")
+    first_k_dense_replace = args.moe_layer_freq.index(1)
+    if args.total_layer_num >= first_k_dense_replace:
+        post_norm_weight = message.pop("post norm weight")
+
+    tf_layer = model.model.layers[layer_id]
+    if args.q_lora_rank is not None:
+        tf_layer.self_attn.q_a_proj.weight.data.copy_(q_a_weight)
+        tf_layer.self_attn.q_a_layernorm.weight.data.copy_(q_a_norm_weight)
+        tf_layer.self_attn.q_b_proj.weight.data.copy_(q_b_weight)
+    else:
+        tf_layer.self_attn.q_proj.weight.data.copy_(q_weight)
+    tf_layer.self_attn.kv_a_proj_with_mqa.weight.data.copy_(kv_a_weight)
+    tf_layer.self_attn.kv_a_layernorm.weight.data.copy_(kv_a_norm_weight)
+    tf_layer.self_attn.kv_b_proj.weight.data.copy_(kv_b_weight)
+    tf_layer.self_attn.o_proj.weight.data.copy_(o_weight)
+    tf_layer.input_layernorm.weight.data.copy_(input_norm_weight)
+    first_k_dense_replace = args.moe_layer_freq.index(1)
+    if args.total_layer_num >= first_k_dense_replace:
+        tf_layer.post_attention_layernorm.weight.data.copy_(post_norm_weight)
+
+
+def set_hf_mlp_ckpt(message, model, layer_id, md, args):
+    first_k_dense_replace = args.moe_layer_freq.index(1)
+    if args.total_layer_num < first_k_dense_replace:
+        set_hf_dense_mlp_ckpt(message, model, layer_id, md, args)
+    else:
+        set_hf_moe_mlp_ckpt(message, model, layer_id, md, args)
+
+
+def set_hf_dense_mlp_ckpt(message, model, layer_id, md, args):
+    post_norm_weight = message.pop("post norm weight")
+    gate_weight = message.pop("gate weight")
+    up_weight = message.pop("up weight")
+    down_weight = message.pop("down weight")
+
+    tf_layer = model.model.layers[layer_id]
+    tf_layer.post_attention_layernorm.weight.data.copy_(post_norm_weight)
+    tf_layer.mlp.gate_proj.weight.data.copy_(gate_weight)
+    tf_layer.mlp.up_proj.weight.data.copy_(up_weight)
+    tf_layer.mlp.down_proj.weight.data.copy_(down_weight)
+
+
+def set_hf_moe_mlp_ckpt(message, model, layer_id, md, args):
+    tf_layer = model.model.layers[layer_id]
+
+    router_weight = message.pop("router weight")
+    use_router_score_bias = False
+    if "router e score bias" in message.keys():
+        use_router_score_bias = True
+        router_score_bias = message.pop("router e score bias")
+    shared_expert_gate_weight = message.pop("shared expert gate weight")
+    shared_expert_up_weight = message.pop("shared expert up weight")
+    shared_expert_down_weight = message.pop("shared expert down weight")
+
+    tf_layer.mlp.gate.weight.data.copy_(router_weight)
+    if use_router_score_bias:
+        tf_layer.mlp.gate.e_score_correction_bias.data.copy_(router_score_bias)
+    tf_layer.mlp.shared_experts.gate_proj.weight.data.copy_(shared_expert_gate_weight)
+    tf_layer.mlp.shared_experts.up_proj.weight.data.copy_(shared_expert_up_weight)
+    tf_layer.mlp.shared_experts.down_proj.weight.data.copy_(shared_expert_down_weight)
+
+    for global_expert_id in range(args.num_experts):
+        expert_gate_weight = message.pop(f"expert{global_expert_id} gate weight")
+        expert_up_weight = message.pop(f"expert{global_expert_id} up weight")
+        expert_down_weight = message.pop(f"expert{global_expert_id} down weight")
+        tf_layer.mlp.experts[global_expert_id].gate_proj.weight.data.copy_(
+            expert_gate_weight
+        )
+        tf_layer.mlp.experts[global_expert_id].up_proj.weight.data.copy_(
+            expert_up_weight
+        )
+        tf_layer.mlp.experts[global_expert_id].down_proj.weight.data.copy_(
+            expert_down_weight
+        )
+
+
+def set_hf_mtp_ckpt(message, model, mtp_layer_id, md, args):
+    layer_id = args.num_layers + mtp_layer_id
+    set_hf_attn_ckpt(message, model, layer_id, md, args)
+    set_hf_mlp_ckpt(message, model, layer_id, md, args)
+
+    mtp_word_embedding_weight = message.pop("mtp word embeddings weight")
+    print("Warning: saver_transformers will change embedding to be no-padded .")
+    full_word_embed = padding_vocab_size(mtp_word_embedding_weight, md, args)[
+        : args.vocab_size, :
+    ]
+    mtp_enorm_weight = message.pop("mtp enorm weight")
+    mtp_hnorm_weight = message.pop("mtp hnorm weight")
+    mtp_eh_weight = message.pop("mtp eh weight")
+    mtp_norm_weight = message.pop("mtp shared head norm weight")
+    output_layer_weight = message.pop("mtp shared head head weight")
+    print("Warning: saver_transformers will change output_layer to be no-padded .")
+    full_output_layer_weight = padding_vocab_size(output_layer_weight, md, args)[
+        : args.vocab_size, :
+    ]
+
+    tf_layer = model.model.layers[layer_id]
+    tf_layer.embed_tokens.weight.data.copy_(full_word_embed)
+    tf_layer.enorm.weight.data.copy_(mtp_enorm_weight)
+    tf_layer.hnorm.weight.data.copy_(mtp_hnorm_weight)
+    tf_layer.eh_proj.weight.data.copy_(mtp_eh_weight)
+    tf_layer.shared_head.norm.weight.data.copy_(mtp_norm_weight)
+    tf_layer.shared_head.head.weight.data.copy_(full_output_layer_weight)

--- a/tools/checkpoint/deepseek_v3/model.py
+++ b/tools/checkpoint/deepseek_v3/model.py
@@ -1,16 +1,18 @@
 import time
 
+import torch
+
 from megatron.core.enums import ModelType
 
 model_type = ModelType.encoder_or_decoder  # Megatron's model_type
 
 
 def get_hf_model(dtype, model_path=None, config=None):
-    from transformers import AutoModelForCausalLM
+    from .moonlight_deepseek.modeling_deepseek import DeepseekV3ForCausalLM
 
     s_time = time.time()
     if model_path and not config:
-        model = AutoModelForCausalLM.from_pretrained(
+        model = DeepseekV3ForCausalLM.from_pretrained(
             model_path, device_map="cpu", trust_remote_code=True, torch_dtype=dtype
         )
     elif not model_path and config:
@@ -18,9 +20,7 @@ def get_hf_model(dtype, model_path=None, config=None):
         from accelerate.utils import set_module_tensor_to_device
 
         with init_empty_weights():
-            model = AutoModelForCausalLM.from_config(
-                config=config, trust_remote_code=True, torch_dtype=dtype
-            )
+            model = DeepseekV3ForCausalLM(config)
         for name, param in model.named_parameters():
             set_module_tensor_to_device(
                 model, name, "cpu", torch.empty(*param.size(), dtype=dtype)
@@ -32,7 +32,6 @@ def get_hf_model(dtype, model_path=None, config=None):
 
 
 def get_mg_model(dtype, pre_process, post_process):
-    # from pretrain_gpt import model_provider
     from flagscale.train.train_deepseek_v3 import model_provider
 
     s_time = time.time()

--- a/tools/checkpoint/loader_transformers.py
+++ b/tools/checkpoint/loader_transformers.py
@@ -134,6 +134,7 @@ def _load_checkpoint(queue, args):
     md.previous_num_experts = margs.num_experts
     md.previous_tensor_parallel_size = margs.tensor_model_parallel_size
     md.previous_pipeline_parallel_size = margs.pipeline_model_parallel_size
+    md.previous_decoder_first_pipeline_num_layers = margs.decoder_first_pipeline_num_layers
     md.previous_expert_parallel_size = margs.expert_model_parallel_size
     md.previous_virtual_pipeline_parallel_size = margs.virtual_pipeline_model_parallel_size
     md.true_vocab_size = args.true_vocab_size
@@ -175,7 +176,7 @@ def _load_checkpoint(queue, args):
         queue_put("output layer", message)
 
     message = dict()
-    if margs.num_mtp_predictor > 0:
+    if margs.num_mtp_predictor:
         for mtp_layer_id in range(margs.num_mtp_predictor):
             message = dict()
             ckpt_plugin.get_hf_mtp_ckpt(message, hf_model, mtp_layer_id, margs)

--- a/tools/checkpoint/run.sh
+++ b/tools/checkpoint/run.sh
@@ -2,13 +2,26 @@
 
 python convert.py \
     --model-type deepseek_v3 \
+    --loader mcore \
+    --saver transformers \
+    --load-dir bf16_model \
+    --save-dir converted_huggingface_model \
+    --target-tensor-parallel-size 1 \
+    --target-pipeline-parallel-size 1 \
+    --target-expert-parallel-size 1 \
+    --target-params-dtype bf16 \
+    --true-vocab-size 151851 \
+
+python convert.py \
+    --model-type deepseek_v3 \
     --loader transformers \
     --saver mcore \
-    --load-dir deepseek_v3/fake_bf16_model \
-    --save-dir deepseek_v3/converted_fake_bf16_model \
+    --load-dir DeepSeek-V2-Lite  \
+    --save-dir converted_bf16_model \
     --target-tensor-parallel-size 1 \
-    --target-pipeline-parallel-size 8 \
-    --target-expert-parallel-size 1 \
+    --target-pipeline-parallel-size 2 \
+    --target-decoder-first-pipeline-num-layers 13 \
+    --target-expert-parallel-size 2 \
     --target-params-dtype bf16 \
     --true-vocab-size 151851 \
 


### PR DESCRIPTION
- [x] support ckpt converting from megatron to huggingface
- [x] fix ckpt converting bugs from huggingface to megatron
- [x] update deepseek v3 training config to DeepSeek V2 Lite #https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite, a MoE model, which has 16b total parameters and  2.4b activated parameters
- [x] supports ckpt converting for uneven pipeline when using pipeline parallelism, e.g., DeepSeek V2 Lite has 27 hidden layers, unevenly partitioned to 2 pipeline stages, 13+14
- [ ] calculate deepseek training throughput and number of parameters correctly