### PR TITLE
[CI] Update requirements for llava_onevision training

### DIFF
--- a/requirements/train/megatron/requirements-cuda.txt
+++ b/requirements/train/megatron/requirements-cuda.txt
@@ -1,7 +1,9 @@
 git+https://github.com/Dao-AILab/causal-conv1d.git@v1.2.2.post1
 git+https://github.com/fanshiqing/grouped_gemm@v1.1.2
+braceexpand
 mock
 nltk==3.8.1
 s3fs
+webdataset
 
 -r ../../../megatron/requirements/pytorch_24.10/requirements.txt


### PR DESCRIPTION
Split into two parts for merging:
1. First merge: Update the training requirements, add the package required for llava_onevision training, and obtain the commit ID after merge.
2. Second merge: Update the image with the updated requirements, mark the image with the first merge commit ID, and submit the llava_onevision test.