### PR TITLE
Implement Zero Bubble (ZB-1H) scheduling into FlagScale, which splits BW into B and W.

### DIFF
--- a/megatron/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/megatron/core/pipeline_parallel/schedules.py
@@ -18,6 +18,8 @@ from megatron.core.utils import (
     get_model_type,
     get_model_xattn,
 )
+from megatron.core.weight_grad_store import WeightGradStore
+import megatron.training.global_vars as global_vars
 
 # Types
 Shape = Union[List[int], torch.Size]
@@ -1823,14 +1825,27 @@ def forward_backward_pipelining_without_interleaving(
             if num_warmup_microbatches == 0 and last_iteration:
                 if config.grad_sync_func is None or rank == 0:
                     enable_grad_sync()
+            
+            # For BWF pattern or in rank 0, we don't split W and B for reasons below.
+            #   1. to leverage batched p2p op (send_backward_recv_forward)
+            #   2. to overlap grad all-reduce for tensor parallel
+            #   3. to avoid redoing grad all-gather for sequence parallel
+            # Note that the order of grad accumulation is changed by this behavior,
+            # thus causing a minor precision error compared to 1F1B even it's mathematically correct.
+            WeightGradStore.split_bw = (i < rank or last_iteration) and rank > 0
 
             input_tensor_grad = backward_step(
                 input_tensor, output_tensor, output_tensor_grad, model_type, config
             )
 
+            if global_vars.get_args().enable_zero_bubble and WeightGradStore.split_bw:
+                WeightGradStore.flush()
+
             if last_iteration:
                 input_tensor = None
                 send_backward(input_tensor_grad, recv_tensor_shapes, config)
+                if global_vars.get_args().enable_zero_bubble and i >= rank > 0:  # delay W by rank
+                    WeightGradStore.pop()  # W
             else:
                 input_tensor = send_backward_recv_forward(
                     input_tensor_grad, recv_tensor_shapes, config
@@ -1854,12 +1869,19 @@ def forward_backward_pipelining_without_interleaving(
 
             output_tensor_grad = recv_backward(send_tensor_shapes, config)
 
+            WeightGradStore.split_bw = rank > 0
             input_tensor_grad = backward_step(
                 input_tensor, output_tensor, output_tensor_grad, model_type, config
             )
 
             send_backward(input_tensor_grad, recv_tensor_shapes, config)
+            if global_vars.get_args().enable_zero_bubble and WeightGradStore.split_bw:
+                    WeightGradStore.flush()
+                    if num_microbatches_remaining + i >= rank:
+                        WeightGradStore.pop()  # W
 
+        if global_vars.get_args().enable_zero_bubble:
+            WeightGradStore.pop_all()  # W
         # Launch any remaining grad reductions.
         if no_sync_context is not None:
             enable_grad_sync()

--- a/megatron/megatron/core/weight_grad_store.py
+++ b/megatron/megatron/core/weight_grad_store.py
@@ -1,0 +1,60 @@
+import queue
+
+class WeightGradStore:
+
+    cache = []
+    weight_grad_queue = queue.Queue()
+    split_bw = True
+
+    @classmethod
+    def is_supported(cls):
+        return True
+        """If not supported, fallback to original schedule."""
+        # args = get_args()
+        # if args.pipeline_model_parallel_size <= 1:
+        #     return False
+        # if args.virtual_pipeline_model_parallel_size is not None:
+        #     return False
+        # if args.overlap_grad_reduce:
+        #     # the logic of overlapping grad reduce should be changed
+        #     return False
+        # if args.transformer_impl == 'transformer_engine':
+        #     # hard to capture weight gradient computation for transformer_engine
+        #     return False
+        # if args.sequence_parallel:
+        #     # not supported in this commit
+        #     return False
+        # return True
+
+    @classmethod
+    def put(cls, total_input, grad_output, weight, func):
+        if not cls.split_bw or not cls.is_supported():
+            func(total_input, grad_output, weight.main_grad)
+            return
+        # Store the weight gradient computation of linear layers.
+        cls.cache.append((total_input, grad_output, weight, func))
+
+    @classmethod
+    def flush(cls):
+        if not cls.is_supported():
+            return
+        # Collect all stored computations during backward as a W.
+        cls.weight_grad_queue.put(cls.cache)
+        cls.cache = []
+
+    @classmethod
+    def pop(cls):
+        if not cls.is_supported():
+            return
+        # Execute a single W.
+        assert cls.weight_grad_queue.qsize() > 0
+        stored_grads = cls.weight_grad_queue.get()
+        for total_input, grad_output, weight, func in stored_grads:
+            func(total_input, grad_output, weight.main_grad)
+
+    @classmethod
+    def pop_all(cls):
+        # Execute all remaining W.
+        remaining_qsize = cls.weight_grad_queue.qsize()
+        for _ in range(remaining_qsize):
+            cls.pop()

--- a/megatron/megatron/training/arguments.py
+++ b/megatron/megatron/training/arguments.py
@@ -1631,7 +1631,8 @@ def _add_training_args(parser):
                        choices=['nccl', 'ucc'],
                        help='Select a communicator backend for pipeline parallel communication. '
                        'If None, the default backend will be used.')
-
+    group.add_argument('--enable-zero-bubble', action='store_true',
+                       help='Use Zero Bubble (ZB-H1) scheduling, which splits BW into B and W.')
     return parser
 
 


### PR DESCRIPTION
To utilize ZB-H1, these changes need to be specified in the `demo.yaml` file:

\- sequence_parallel: True
\+ sequence_parallel: False

\- transformer_impl: transformer_engine
\+ transformer_impl: local

\+ enable_zero_bubble: True

\- normalization: RMSNorm
\+ normalization: LayerNorm

The figure below shows the profiling result of ZB-H1, where the `weight_grad_store: pop()/pop_all()` kernels indicate the backward process of weight.
![image](https://github.com/user-attachments/assets/bb44a903-24e3-44c3-b571-6aa646ea8402)
