### PR TITLE
[Dev]vllm flagcx 1p1d p2pconnector

### DIFF
--- a/flagscale/inference/backends/vllm/vllm/distributed/device_communicators/flagcx_wrapper.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/device_communicators/flagcx_wrapper.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# reference https://github.com/vllm-project/vllm/blob/main/vllm/distributed/device_communicators/pynccl_wrapper.py
+
+import ctypes
+import platform
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.distributed import ReduceOp
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# === export types and functions from flagcx to Python ===
+# for the original flagcx definition, please check
+# https://github.com/FlagOpen/FlagCX/blob/main/flagcx/include/flagcx.h
+
+flagcxResult_t = ctypes.c_int
+flagcxComm_t = ctypes.c_void_p
+
+class flagcxUniqueId(ctypes.Structure):
+    _fields_ = [("internal", ctypes.c_byte * 128)]
+
+cudaStream_t = ctypes.c_void_p
+flagcxStream_t = ctypes.c_void_p
+buffer_type = ctypes.c_void_p
+
+flagcxDataType_t = ctypes.c_int
+
+
+class flagcxDataTypeEnum:
+    flagcxInt8 = 0
+    flagcxChar = 0
+    flagcxUint8 = 1
+    flagcxInt32 = 2
+    flagcxInt = 2
+    flagcxUint32 = 3
+    flagcxInt64 = 4
+    flagcxUint64 = 5
+    flagcxFloat16 = 6
+    flagcxHalf = 6
+    flagcxFloat32 = 7
+    flagcxFloat = 7
+    flagcxFloat64 = 8
+    flagcxDouble = 8
+    flagcxBfloat16 = 9
+    flagcxNumTypes = 10
+
+    @classmethod
+    def from_torch(cls, dtype: torch.dtype) -> int:
+        if dtype == torch.int8:
+            return cls.flagcxInt8
+        if dtype == torch.uint8:
+            return cls.flagcxUint8
+        if dtype == torch.int32:
+            return cls.flagcxInt32
+        if dtype == torch.int64:
+            return cls.flagcxInt64
+        if dtype == torch.float16:
+            return cls.flagcxFloat16
+        if dtype == torch.float32:
+            return cls.flagcxFloat32
+        if dtype == torch.float64:
+            return cls.flagcxFloat64
+        if dtype == torch.bfloat16:
+            return cls.flagcxBfloat16
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+flagcxRedOp_t = ctypes.c_int
+
+
+class flagcxRedOpTypeEnum:
+    flagcxSum = 0
+    flagcxProd = 1
+    flagcxMax = 2
+    flagcxMin = 3
+    flagcxAvg = 4
+    flagcxNumOps = 5
+
+    @classmethod
+    def from_torch(cls, op: ReduceOp) -> int:
+        if op == ReduceOp.SUM:
+            return cls.flagcxSum
+        if op == ReduceOp.PRODUCT:
+            return cls.flagcxProd
+        if op == ReduceOp.MAX:
+            return cls.flagcxMax
+        if op == ReduceOp.MIN:
+            return cls.flagcxMin
+        if op == ReduceOp.AVG:
+            return cls.flagcxAvg
+        raise ValueError(f"Unsupported op: {op}")
+
+
+@dataclass
+class Function:
+    name: str
+    restype: Any
+    argtypes: List[Any]
+
+
+class FLAGCXLibrary:
+    exported_functions = [
+        # const char *flagcxGetErrorString(flagcxResult_t result);
+        Function("flagcxGetErrorString", ctypes.c_char_p, [flagcxResult_t]),
+        # flagcxResult_t flagcxGetVersion(int *version);
+        Function("flagcxGetVersion", flagcxResult_t,
+                 [ctypes.POINTER(ctypes.c_int)]),
+        # flagcxResult_t flagcxGetUniqueId(flagcxUniqueId_t *uniqueId);
+        Function("flagcxGetUniqueId", flagcxResult_t,
+                [ctypes.POINTER(ctypes.POINTER(flagcxUniqueId))]),
+                #  [ctypes.POINTER(ctypes.POINTER(flagcxUniqueId))]),
+        # flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
+        #                           flagcxUniqueId_t commId, int rank);
+        # note that flagcxComm_t is a pointer type, so the first argument
+        # is a pointer to a pointer
+        Function("flagcxCommInitRank", flagcxResult_t, [
+            ctypes.POINTER(flagcxComm_t), ctypes.c_int, ctypes.POINTER(flagcxUniqueId),
+            ctypes.c_int
+        ]),
+        # flagcxResult_t flagcxAllReduce(const void *sendbuff, void *recvbuff,
+        #                        size_t count, flagcxDataType_t datatype,
+        #                        flagcxRedOp_t op, flagcxComm_t comm,
+        #                        flagcxStream_t stream);
+        # note that flagcxStream_t is a pointer type, so the last argument
+        # is a pointer
+        Function("flagcxAllReduce", flagcxResult_t, [
+            buffer_type, buffer_type, ctypes.c_size_t, flagcxDataType_t,
+            flagcxRedOp_t, flagcxComm_t, flagcxStream_t
+        ]),
+
+        # flagcxResult_t flagcxAllGather(const void *sendbuff, void *recvbuff,
+        #                        size_t sendcount, flagcxDataType_t datatype,
+        #                        flagcxComm_t comm, flagcxStream_t stream);
+        # note that flagcxStream_t is a pointer type, so the last argument
+        # is a pointer
+        Function("flagcxAllGather", flagcxResult_t, [
+            buffer_type, buffer_type, ctypes.c_size_t, flagcxDataType_t,
+            flagcxComm_t, flagcxStream_t
+        ]),
+
+        # flagcxResult_t flagcxReduceScatter(const void *sendbuff, void *recvbuff,
+        #                            size_t recvcount, flagcxDataType_t datatype,
+        #                            flagcxRedOp_t op, flagcxComm_t comm,
+        #                            flagcxStream_t stream);
+        # note that flagcxStream_t is a pointer type, so the last argument
+        # is a pointer
+        Function("flagcxReduceScatter", flagcxResult_t, [
+            buffer_type, buffer_type, ctypes.c_size_t, flagcxDataType_t,
+            flagcxRedOp_t, flagcxComm_t, flagcxStream_t
+        ]),
+
+        # flagcxResult_t flagcxSend(const void *sendbuff, size_t count,
+        #                   flagcxDataType_t datatype, int peer,
+        #                   flagcxComm_t comm, flagcxStream_t stream);
+        Function("flagcxSend", flagcxResult_t, [
+            buffer_type, ctypes.c_size_t, flagcxDataType_t, ctypes.c_int,
+            flagcxComm_t, flagcxStream_t
+        ]),
+
+        # flagcxResult_t flagcxRecv(void *recvbuff, size_t count,
+        #                   flagcxDataType_t datatype, int peer,
+        #                   flagcxComm_t comm, flagcxStream_t stream);
+        Function("flagcxRecv", flagcxResult_t, [
+            buffer_type, ctypes.c_size_t, flagcxDataType_t, ctypes.c_int,
+            flagcxComm_t, flagcxStream_t
+        ]),
+
+        # flagcxResult_t flagcxBroadcast(const void *sendbuff, void *recvbuff,
+        #                        size_t count, flagcxDataType_t datatype,
+        #                        int root, flagcxComm_t comm,
+        #                        flagcxStream_t stream);
+        Function("flagcxBroadcast", flagcxResult_t, [
+            buffer_type, buffer_type, ctypes.c_size_t, flagcxDataType_t,
+            ctypes.c_int, flagcxComm_t, flagcxStream_t
+        ]),
+
+        # be cautious! this is a collective call, it will block until all
+        # processes in the communicator have called this function.
+        # because Python object destruction can happen in random order,
+        # it is better not to call it at all.
+        # flagcxResult_t flagcxCommDestroy(flagcxComm_t comm);
+        Function("flagcxCommDestroy", flagcxResult_t, [flagcxComm_t]),
+
+        # flagcxResult_t cudaAdaptorStreamCopy(flagcxStream_t *newStream,
+        #                              void *oldStream)
+        Function("_Z21cudaAdaptorStreamCopyPP12flagcxStreamPv", flagcxResult_t, [ctypes.POINTER(flagcxStream_t), flagcxStream_t]),
+
+        # flagcxResult_t cudaAdaptorStreamFree(flagcxStream_t stream)
+        Function("_Z21cudaAdaptorStreamFreeP12flagcxStream", flagcxResult_t, [flagcxStream_t]),
+    ]
+
+    # class attribute to store the mapping from the path to the library
+    # to avoid loading the same library multiple times
+    path_to_library_cache: Dict[str, Any] = {}
+
+    # class attribute to store the mapping from library path
+    #  to the corresponding dictionary
+    path_to_dict_mapping: Dict[str, Dict[str, Any]] = {}
+
+    def __init__(self, so_file: Optional[str] = None):
+
+        so_file = so_file #or find_flagcx_library()
+
+        try:
+            if so_file not in FLAGCXLibrary.path_to_dict_mapping:
+                lib = ctypes.CDLL(so_file)
+                FLAGCXLibrary.path_to_library_cache[so_file] = lib
+            self.lib = FLAGCXLibrary.path_to_library_cache[so_file]
+        except Exception as e:
+            logger.error(
+                "Failed to load flagCX library from %s. "
+                "It is expected if you are not running on NVIDIA/AMD GPUs."
+                "Otherwise, the flagcx library might not exist, be corrupted "
+                "or it does not support the current platform %s. "
+                "If you already have the library, please set the "
+                "environment variable VLLM_NCCL_SO_PATH"
+                " to point to the correct flagcx library path.", so_file,
+                platform.platform())
+            raise e
+
+        if so_file not in FLAGCXLibrary.path_to_dict_mapping:
+            _funcs: Dict[str, Any] = {}
+            for func in FLAGCXLibrary.exported_functions:
+                f = getattr(self.lib, func.name)
+                f.restype = func.restype
+                f.argtypes = func.argtypes
+                _funcs[func.name] = f
+            FLAGCXLibrary.path_to_dict_mapping[so_file] = _funcs
+        self._funcs = FLAGCXLibrary.path_to_dict_mapping[so_file]
+
+    def flagcxGetErrorString(self, result: flagcxResult_t) -> str:
+        return self._funcs["flagcxGetErrorString"](result).decode("utf-8")
+
+    def FLAGCX_CHECK(self, result: flagcxResult_t) -> None:
+        if result != 0:
+            error_str = self.flagcxGetErrorString(result)
+            raise RuntimeError(f"FLAGCX error: {error_str}")
+
+    def flagcxGetVersion(self) -> str:
+        version = ctypes.c_int()
+        self.FLAGCX_CHECK(self._funcs["flagcxGetVersion"](ctypes.byref(version)))
+        version_str = str(version.value)
+        # something like 21903 --> "2.19.3"
+        major = version_str[0].lstrip("0")
+        minor = version_str[1:3].lstrip("0")
+        patch = version_str[3:].lstrip("0")
+        return f"{major}.{minor}.{patch}"
+
+    def flagcxGetUniqueId(self) -> flagcxUniqueId:
+        unique_id = ctypes.POINTER(flagcxUniqueId)()
+        self.FLAGCX_CHECK(self._funcs["flagcxGetUniqueId"](
+            ctypes.byref(unique_id)))
+        return unique_id
+    # def flagcxGetUniqueId(self, unique_id: flagcxUniqueId) -> flagcxUniqueId:
+    #     # unique_id = ctypes.POINTER(flagcxUniqueId)()
+    #     self.FLAGCX_CHECK(self._funcs["flagcxGetUniqueId"](
+    #         ctypes.byref(unique_id)))
+    #     return unique_id
+
+    def unique_id_from_bytes(self, data: bytes) -> flagcxUniqueId:
+        """
+        Reconstructs an `ncclUniqueId` object from bytes data.
+        Args:
+            data: Must be a 128-byte data block (matching NCCL's unique_id).
+        Returns:
+            ncclUniqueId: The reconstructed NCCL Unique ID object.
+        Raises:
+            ValueError: If the input data length is not 128 bytes.
+        """
+        if len(data) != 128:
+            raise ValueError(
+                f"Expected 128 bytes for ncclUniqueId, got {len(data)} bytes")
+
+        unique_id = flagcxUniqueId()
+        ctypes.memmove(ctypes.addressof(unique_id.internal), data, 128)
+        return unique_id
+
+    def flagcxCommInitRank(self, world_size: int, unique_id: flagcxUniqueId,
+                         rank: int) -> flagcxComm_t:
+        comm = flagcxComm_t()
+        self.FLAGCX_CHECK(self._funcs["flagcxCommInitRank"](ctypes.byref(comm),
+                                                        world_size, unique_id,
+                                                        rank))
+        return comm
+
+    def flagcxAllReduce(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                      count: int, datatype: int, op: int, comm: flagcxComm_t,
+                      stream: flagcxStream_t) -> None:
+        # `datatype` actually should be `flagcxDataType_t`
+        # and `op` should be `flagcxRedOp_t`
+        # both are aliases of `ctypes.c_int`
+        # when we pass int to a function, it will be converted to `ctypes.c_int`
+        # by ctypes automatically
+        self.FLAGCX_CHECK(self._funcs["flagcxAllReduce"](sendbuff, recvbuff, count,
+                                                     datatype, op, comm,
+                                                     stream))
+
+    def flagcxReduceScatter(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                          count: int, datatype: int, op: int, comm: flagcxComm_t,
+                          stream: flagcxStream_t) -> None:
+        # `datatype` actually should be `flagcxDataType_t`
+        # and `op` should be `flagcxRedOp_t`
+        # both are aliases of `ctypes.c_int`
+        # when we pass int to a function, it will be converted to `ctypes.c_int`
+        # by ctypes automatically
+        self.FLAGCX_CHECK(self._funcs["flagcxReduceScatter"](sendbuff, recvbuff,
+                                                         count, datatype, op,
+                                                         comm, stream))
+
+    def flagcxAllGather(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                      count: int, datatype: int, comm: flagcxComm_t,
+                      stream: flagcxStream_t) -> None:
+        # `datatype` actually should be `flagcxDataType_t`
+        # which is an aliases of `ctypes.c_int`
+        # when we pass int to a function, it will be converted to `ctypes.c_int`
+        # by ctypes automatically
+        self.FLAGCX_CHECK(self._funcs["flagcxAllGather"](sendbuff, recvbuff, count,
+                                                     datatype, comm, stream))
+
+    def flagcxSend(self, sendbuff: buffer_type, count: int, datatype: int,
+                 dest: int, comm: flagcxComm_t, stream: flagcxStream_t) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxSend"](sendbuff, count, datatype,
+                                                dest, comm, stream))
+
+    def flagcxRecv(self, recvbuff: buffer_type, count: int, datatype: int,
+                 src: int, comm: flagcxComm_t, stream: flagcxStream_t) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxRecv"](recvbuff, count, datatype, src,
+                                                comm, stream))
+
+    def flagcxBroadcast(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                      count: int, datatype: int, root: int, comm: flagcxComm_t,
+                      stream: flagcxStream_t) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxBroadcast"](sendbuff, recvbuff, count,
+                                                     datatype, root, comm,
+                                                     stream))
+
+    def flagcxCommDestroy(self, comm: flagcxComm_t) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxCommDestroy"](comm))
+
+    def adaptor_stream_copy(self, old_stream: cudaStream_t):
+        new_stream = flagcxStream_t()
+
+        self.FLAGCX_CHECK(self._funcs["_Z21cudaAdaptorStreamCopyPP12flagcxStreamPv"](ctypes.byref(new_stream), ctypes.byref(old_stream)))
+        return new_stream
+
+    def adaptor_stream_free(stream):
+        self.FLAGCX_CHECK(self._funcs["_Z21cudaAdaptorStreamFreeP12flagcxStream"](stream))
+        result = lib.cudaAdaptorStreamFree(stream)
+
+__all__ = [
+    "FLAGCXLibrary", "flagcxDataTypeEnum", "flagcxRedOpTypeEnum", "flagcxUniqueId",
+    "flagcxComm_t", "flagcxStream_t", "buffer_type", "cudaStream_t"
+]

--- a/flagscale/inference/backends/vllm/vllm/distributed/device_communicators/pyflagcx.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/device_communicators/pyflagcx.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# reference https://github.com/vllm-project/vllm/blob/main/vllm/distributed/device_communicators/pynccl.py
+
+import os
+import ctypes
+from typing import Optional, Union
+
+# ===================== import region =====================
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup, ReduceOp
+
+from vllm.distributed.device_communicators.flagcx_wrapper import (
+    FLAGCXLibrary, buffer_type, flagcxComm_t, flagcxDataTypeEnum,
+    flagcxRedOpTypeEnum, flagcxUniqueId, cudaStream_t)
+from vllm.distributed.utils import StatelessProcessGroup
+from vllm.logger import init_logger
+from vllm.utils import current_stream
+
+logger = init_logger(__name__)
+
+
+class PyFlagcxCommunicator:
+
+    def __init__(
+        self,
+        group: Union[ProcessGroup, StatelessProcessGroup],
+        device: Union[int, str, torch.device],
+        library_path: Optional[str] = None,
+    ):
+        """
+        Args:
+            group: the process group to work on. If None, it will use the
+                default process group.
+            device: the device to bind the PyFlagcxCommunicator to. If None,
+                it will be bind to f"cuda:{local_rank}".
+            library_path: the path to the flagCX library. If None, it will
+                use the default library path.
+        It is the caller's responsibility to make sure each communicator
+        is bind to a unique device.
+        """
+        if not isinstance(group, StatelessProcessGroup):
+            assert dist.is_initialized()
+            assert dist.get_backend(group) != dist.Backend.NCCL, (
+                "PyFlagcxCommunicator should be attached to a non-NCCL group.")
+            # note: this rank is the rank in the group
+            self.rank = dist.get_rank(group)
+            self.world_size = dist.get_world_size(group)
+        else:
+            self.rank = group.rank
+            self.world_size = group.world_size
+
+        self.group = group
+
+        # if world_size == 1, no need to create communicator
+        if self.world_size == 1:
+            self.available = False
+            self.disabled = True
+            return
+        try:
+            self.flagcx = FLAGCXLibrary(library_path)
+        except Exception:
+            # disable because of missing flagCX library
+            # e.g. in a non-GPU environment
+            self.available = False
+            self.disabled = True
+            return
+
+        self.available = True
+        self.disabled = False
+
+        logger.info("vLLM is using flagcx==%s", self.flagcx.flagcxGetVersion())
+
+        if self.rank == 0:
+            # get the unique id from flagCX
+            self.unique_id = self.flagcx.flagcxGetUniqueId().contents
+        else:
+            # construct an empty unique id
+            self.unique_id = flagcxUniqueId()
+
+        if not isinstance(group, StatelessProcessGroup):
+            tensor = torch.ByteTensor(list(self.unique_id.internal))
+            ranks = dist.get_process_group_ranks(group)
+            # arg `src` in `broadcast` is the global rank
+            dist.broadcast(tensor, src=ranks[0], group=group)
+            byte_list = tensor.tolist()
+            for i, byte in enumerate(byte_list):
+                self.unique_id.internal[i] = byte
+        else:
+            self.unique_id = group.broadcast_obj(self.unique_id, src=0)
+        
+        if isinstance(device, int):
+            device = torch.device(f"cuda:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        # now `device` is a `torch.device` object
+        assert isinstance(device, torch.device)
+        self.device = device
+        # flagcx communicator and stream will use this device
+        # `torch.cuda.device` is a context manager that changes the
+        # current cuda device to the specified one
+        with torch.cuda.device(device):
+            self.comm = self.flagcx.flagcxCommInitRank(
+                self.world_size, ctypes.byref(self.unique_id), self.rank)
+            stream = current_stream()
+
+            # A small all_reduce for warmup.
+            data = torch.zeros(1, device=device)
+            self.all_reduce(data)
+
+            stream.synchronize()
+            del data
+
+    def all_reduce(self,
+                   in_tensor: torch.Tensor,
+                   op: ReduceOp = ReduceOp.SUM,
+                   stream=None) -> torch.Tensor:
+        if self.disabled:
+            return None
+        # flagcx communicator created on a specific device
+        # will only work on tensors on the same device
+        # otherwise it will cause "illegal memory access"
+        assert in_tensor.device == self.device, (
+            f"this flagcx communicator is created to work on {self.device}, "
+            f"but the input tensor is on {in_tensor.device}")
+
+        out_tensor = torch.empty_like(in_tensor)
+
+        if stream is None:
+            stream = current_stream()
+        flagcx_stream = self.flagcx.adaptor_stream_copy(cudaStream_t(stream.cuda_stream))
+        self.flagcx.flagcxAllReduce(buffer_type(in_tensor.data_ptr()),
+                                buffer_type(out_tensor.data_ptr()),
+                                in_tensor.numel(),
+                                flagcxDataTypeEnum.from_torch(in_tensor.dtype),
+                                flagcxRedOpTypeEnum.from_torch(op), self.comm,
+                                flagcx_stream)
+        return out_tensor
+
+    def all_gather(self,
+                   output_tensor: torch.Tensor,
+                   input_tensor: torch.Tensor,
+                   stream=None):
+        if self.disabled:
+            return
+        # flagcx communicator created on a specific device
+        # will only work on tensors on the same device
+        # otherwise it will cause "illegal memory access"
+        assert input_tensor.device == self.device, (
+            f"this flagcx communicator is created to work on {self.device}, "
+            f"but the input tensor is on {input_tensor.device}")
+        if stream is None:
+            stream = current_stream()
+        flagcx_stream = self.flagcx.adaptor_stream_copy(cudaStream_t(stream.cuda_stream))
+        self.flagcx.flagcxAllGather(
+            buffer_type(input_tensor.data_ptr()),
+            buffer_type(output_tensor.data_ptr()), input_tensor.numel(),
+            flagcxDataTypeEnum.from_torch(input_tensor.dtype), self.comm,
+            flagcx_stream)
+
+    def reduce_scatter(self,
+                       output_tensor: torch.Tensor,
+                       input_tensor: torch.Tensor,
+                       op: ReduceOp = ReduceOp.SUM,
+                       stream=None):
+        if self.disabled:
+            return
+        # flagcx communicator created on a specific device
+        # will only work on tensors on the same device
+        # otherwise it will cause "illegal memory access"
+        assert input_tensor.device == self.device, (
+            f"this flagcx communicator is created to work on {self.device}, "
+            f"but the input tensor is on {input_tensor.device}")
+        if stream is None:
+            stream = current_stream()
+        flagcx_stream = self.flagcx.adaptor_stream_copy(cudaStream_t(stream.cuda_stream))
+        self.flagcx.flagcxReduceScatter(
+            buffer_type(input_tensor.data_ptr()),
+            buffer_type(output_tensor.data_ptr()), output_tensor.numel(),
+            flagcxDataTypeEnum.from_torch(input_tensor.dtype),
+            flagcxRedOpTypeEnum.from_torch(op), self.comm,
+            flagcx_stream)
+
+    def send(self, tensor: torch.Tensor, dst: int, stream=None):
+        if self.disabled:
+            return
+        assert tensor.device == self.device, (
+            f"this flagcx communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}")
+        if stream is None:
+            stream = current_stream()
+        flagcx_stream = self.flagcx.adaptor_stream_copy(cudaStream_t(stream.cuda_stream))
+        self.flagcx.flagcxSend(buffer_type(tensor.data_ptr()), tensor.numel(),
+                           flagcxDataTypeEnum.from_torch(tensor.dtype), dst,
+                           self.comm, flagcx_stream)
+
+    def recv(self, tensor: torch.Tensor, src: int, stream=None):
+        if self.disabled:
+            return
+        assert tensor.device == self.device, (
+            f"this flagcx communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}")
+        if stream is None:
+            stream = current_stream()
+        flagcx_stream = self.flagcx.adaptor_stream_copy(cudaStream_t(stream.cuda_stream))
+        self.flagcx.flagcxRecv(buffer_type(tensor.data_ptr()), tensor.numel(),
+                           flagcxDataTypeEnum.from_torch(tensor.dtype), src,
+                           self.comm, flagcx_stream)
+
+    def broadcast(self, tensor: torch.Tensor, src: int, stream=None):
+        if self.disabled:
+            return
+        assert tensor.device == self.device, (
+            f"this flagcx communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}")
+        if stream is None:
+            stream = current_stream()
+        if src == self.rank:
+            sendbuff = buffer_type(tensor.data_ptr())
+            # FLAGCX requires the sender also to have a receive buffer
+            recvbuff = buffer_type(tensor.data_ptr())
+        else:
+            sendbuff = buffer_type()
+            recvbuff = buffer_type(tensor.data_ptr())
+        flagcx_stream = self.flagcx.adaptor_stream_copy(cudaStream_t(stream.cuda_stream))
+        self.flagcx.flagcxBroadcast(sendbuff, recvbuff, tensor.numel(),
+                                flagcxDataTypeEnum.from_torch(tensor.dtype), src,
+                                self.comm, flagcx_stream)

--- a/flagscale/inference/backends/vllm/vllm/distributed/device_communicators/pynccl_wrapper.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/device_communicators/pynccl_wrapper.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file is a pure Python wrapper for the NCCL library.
+# The main purpose is to use NCCL combined with CUDA graph.
+# Before writing this script, we tried the following approach:
+# 1. We tried to use `cupy`, it calls NCCL correctly, but `cupy` itself
+#  often gets stuck when initializing the NCCL communicator.
+# 2. We tried to use `torch.distributed`, but `torch.distributed.all_reduce`
+#  contains many other potential cuda APIs, that are not allowed during
+#  capturing the CUDA graph. For further details, please check
+# https://discuss.pytorch.org/t/pytorch-cudagraph-with-nccl-operation-failed/ .
+#
+# Another rejected idea is to write a C/C++ binding for NCCL. It is usually
+# doable, but we often encounter issues related with nccl versions, and need
+# to switch between different versions of NCCL. See
+# https://github.com/NVIDIA/nccl/issues/1234 for more details.
+# A C/C++ binding is not flexible enough to handle this. It requires
+# recompilation of the code every time we want to switch between different
+# versions. This current implementation, with a **pure** Python wrapper, is
+# more flexible. We can easily switch between different versions of NCCL by
+# changing the environment variable `VLLM_NCCL_SO_PATH`, or the `so_file`
+# variable in the code.
+
+import ctypes
+import platform
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.distributed import ReduceOp
+
+from vllm.logger import init_logger
+from vllm.utils import find_nccl_library
+
+logger = init_logger(__name__)
+
+# === export types and functions from nccl to Python ===
+# for the original nccl definition, please check
+# https://github.com/NVIDIA/nccl/blob/master/src/nccl.h.in
+
+ncclResult_t = ctypes.c_int
+ncclComm_t = ctypes.c_void_p
+
+
+class ncclUniqueId(ctypes.Structure):
+    _fields_ = [("internal", ctypes.c_byte * 128)]
+
+
+cudaStream_t = ctypes.c_void_p
+buffer_type = ctypes.c_void_p
+
+ncclDataType_t = ctypes.c_int
+
+
+class ncclDataTypeEnum:
+    ncclInt8 = 0
+    ncclChar = 0
+    ncclUint8 = 1
+    ncclInt32 = 2
+    ncclInt = 2
+    ncclUint32 = 3
+    ncclInt64 = 4
+    ncclUint64 = 5
+    ncclFloat16 = 6
+    ncclHalf = 6
+    ncclFloat32 = 7
+    ncclFloat = 7
+    ncclFloat64 = 8
+    ncclDouble = 8
+    ncclBfloat16 = 9
+    ncclNumTypes = 10
+
+    @classmethod
+    def from_torch(cls, dtype: torch.dtype) -> int:
+        if dtype == torch.int8:
+            return cls.ncclInt8
+        if dtype == torch.uint8:
+            return cls.ncclUint8
+        if dtype == torch.int32:
+            return cls.ncclInt32
+        if dtype == torch.int64:
+            return cls.ncclInt64
+        if dtype == torch.float16:
+            return cls.ncclFloat16
+        if dtype == torch.float32:
+            return cls.ncclFloat32
+        if dtype == torch.float64:
+            return cls.ncclFloat64
+        if dtype == torch.bfloat16:
+            return cls.ncclBfloat16
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+ncclRedOp_t = ctypes.c_int
+
+
+class ncclRedOpTypeEnum:
+    ncclSum = 0
+    ncclProd = 1
+    ncclMax = 2
+    ncclMin = 3
+    ncclAvg = 4
+    ncclNumOps = 5
+
+    @classmethod
+    def from_torch(cls, op: ReduceOp) -> int:
+        if op == ReduceOp.SUM:
+            return cls.ncclSum
+        if op == ReduceOp.PRODUCT:
+            return cls.ncclProd
+        if op == ReduceOp.MAX:
+            return cls.ncclMax
+        if op == ReduceOp.MIN:
+            return cls.ncclMin
+        if op == ReduceOp.AVG:
+            return cls.ncclAvg
+        raise ValueError(f"Unsupported op: {op}")
+
+
+@dataclass
+class Function:
+    name: str
+    restype: Any
+    argtypes: List[Any]
+
+
+class NCCLLibrary:
+    exported_functions = [
+        # const char* ncclGetErrorString(ncclResult_t result)
+        Function("ncclGetErrorString", ctypes.c_char_p, [ncclResult_t]),
+        # ncclResult_t  ncclGetVersion(int *version);
+        Function("ncclGetVersion", ncclResult_t,
+                 [ctypes.POINTER(ctypes.c_int)]),
+        # ncclResult_t ncclGetUniqueId(ncclUniqueId* uniqueId);
+        Function("ncclGetUniqueId", ncclResult_t,
+                 [ctypes.POINTER(ncclUniqueId)]),
+        # ncclResult_t  ncclCommInitRank(
+        #   ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank);
+        # note that ncclComm_t is a pointer type, so the first argument
+        # is a pointer to a pointer
+        Function("ncclCommInitRank", ncclResult_t, [
+            ctypes.POINTER(ncclComm_t), ctypes.c_int, ncclUniqueId,
+            ctypes.c_int
+        ]),
+        # ncclResult_t  ncclAllReduce(
+        #   const void* sendbuff, void* recvbuff, size_t count,
+        #   ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm,
+        #   cudaStream_t stream);
+        # note that cudaStream_t is a pointer type, so the last argument
+        # is a pointer
+        Function("ncclAllReduce", ncclResult_t, [
+            buffer_type, buffer_type, ctypes.c_size_t, ncclDataType_t,
+            ncclRedOp_t, ncclComm_t, cudaStream_t
+        ]),
+
+        # ncclResult_t  ncclAllGather(
+        #   const void* sendbuff, void* recvbuff, size_t count,
+        #   ncclDataType_t datatype, ncclComm_t comm,
+        #   cudaStream_t stream);
+        # note that cudaStream_t is a pointer type, so the last argument
+        # is a pointer
+        Function("ncclAllGather", ncclResult_t, [
+            buffer_type, buffer_type, ctypes.c_size_t, ncclDataType_t,
+            ncclComm_t, cudaStream_t
+        ]),
+
+        # ncclResult_t  ncclReduceScatter(
+        #   const void* sendbuff, void* recvbuff, size_t count,
+        #   ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm,
+        #   cudaStream_t stream);
+        # note that cudaStream_t is a pointer type, so the last argument
+        # is a pointer
+        Function("ncclReduceScatter", ncclResult_t, [
+            buffer_type, buffer_type, ctypes.c_size_t, ncclDataType_t,
+            ncclRedOp_t, ncclComm_t, cudaStream_t
+        ]),
+
+        # ncclResult_t  ncclSend(
+        #   const void* sendbuff, size_t count, ncclDataType_t datatype,
+        #   int dest, ncclComm_t comm, cudaStream_t stream);
+        Function("ncclSend", ncclResult_t, [
+            buffer_type, ctypes.c_size_t, ncclDataType_t, ctypes.c_int,
+            ncclComm_t, cudaStream_t
+        ]),
+
+        # ncclResult_t  ncclRecv(
+        #   void* recvbuff, size_t count, ncclDataType_t datatype,
+        #   int src, ncclComm_t comm, cudaStream_t stream);
+        Function("ncclRecv", ncclResult_t, [
+            buffer_type, ctypes.c_size_t, ncclDataType_t, ctypes.c_int,
+            ncclComm_t, cudaStream_t
+        ]),
+
+        # ncclResult_t ncclBroadcast(
+        #   const void* sendbuff, void* recvbuff, size_t count,
+        #   ncclDataType_t datatype, int root, ncclComm_t comm,
+        #   cudaStream_t stream);
+        Function("ncclBroadcast", ncclResult_t, [
+            buffer_type, buffer_type, ctypes.c_size_t, ncclDataType_t,
+            ctypes.c_int, ncclComm_t, cudaStream_t
+        ]),
+
+        # be cautious! this is a collective call, it will block until all
+        # processes in the communicator have called this function.
+        # because Python object destruction can happen in random order,
+        # it is better not to call it at all.
+        # ncclResult_t  ncclCommDestroy(ncclComm_t comm);
+        Function("ncclCommDestroy", ncclResult_t, [ncclComm_t]),
+    ]
+
+    # class attribute to store the mapping from the path to the library
+    # to avoid loading the same library multiple times
+    path_to_library_cache: Dict[str, Any] = {}
+
+    # class attribute to store the mapping from library path
+    #  to the corresponding dictionary
+    path_to_dict_mapping: Dict[str, Dict[str, Any]] = {}
+
+    def __init__(self, so_file: Optional[str] = None):
+
+        so_file = so_file or find_nccl_library()
+
+        try:
+            if so_file not in NCCLLibrary.path_to_dict_mapping:
+                lib = ctypes.CDLL(so_file)
+                NCCLLibrary.path_to_library_cache[so_file] = lib
+            self.lib = NCCLLibrary.path_to_library_cache[so_file]
+        except Exception as e:
+            logger.error(
+                "Failed to load NCCL library from %s. "
+                "It is expected if you are not running on NVIDIA/AMD GPUs."
+                "Otherwise, the nccl library might not exist, be corrupted "
+                "or it does not support the current platform %s. "
+                "If you already have the library, please set the "
+                "environment variable VLLM_NCCL_SO_PATH"
+                " to point to the correct nccl library path.", so_file,
+                platform.platform())
+            raise e
+
+        if so_file not in NCCLLibrary.path_to_dict_mapping:
+            _funcs: Dict[str, Any] = {}
+            for func in NCCLLibrary.exported_functions:
+                f = getattr(self.lib, func.name)
+                f.restype = func.restype
+                f.argtypes = func.argtypes
+                _funcs[func.name] = f
+            NCCLLibrary.path_to_dict_mapping[so_file] = _funcs
+        self._funcs = NCCLLibrary.path_to_dict_mapping[so_file]
+
+    def ncclGetErrorString(self, result: ncclResult_t) -> str:
+        return self._funcs["ncclGetErrorString"](result).decode("utf-8")
+
+    def NCCL_CHECK(self, result: ncclResult_t) -> None:
+        if result != 0:
+            error_str = self.ncclGetErrorString(result)
+            raise RuntimeError(f"NCCL error: {error_str}")
+
+    def ncclGetVersion(self) -> str:
+        version = ctypes.c_int()
+        self.NCCL_CHECK(self._funcs["ncclGetVersion"](ctypes.byref(version)))
+        version_str = str(version.value)
+        # something like 21903 --> "2.19.3"
+        major = version_str[0].lstrip("0")
+        minor = version_str[1:3].lstrip("0")
+        patch = version_str[3:].lstrip("0")
+        return f"{major}.{minor}.{patch}"
+
+    def ncclGetUniqueId(self) -> ncclUniqueId:
+        unique_id = ncclUniqueId()
+        self.NCCL_CHECK(self._funcs["ncclGetUniqueId"](
+            ctypes.byref(unique_id)))
+        return unique_id
+
+    def unique_id_from_bytes(self, data: bytes) -> ncclUniqueId:
+        """
+        Reconstructs an `ncclUniqueId` object from bytes data.
+
+        Args:
+            data: Must be a 128-byte data block (matching NCCL's unique_id).
+
+        Returns:
+            ncclUniqueId: The reconstructed NCCL Unique ID object.
+
+        Raises:
+            ValueError: If the input data length is not 128 bytes.
+        """
+        if len(data) != 128:
+            raise ValueError(
+                f"Expected 128 bytes for ncclUniqueId, got {len(data)} bytes")
+
+        unique_id = ncclUniqueId()
+        ctypes.memmove(ctypes.addressof(unique_id.internal), data, 128)
+    def ncclCommInitRank(self, world_size: int, unique_id: ncclUniqueId,
+                         rank: int) -> ncclComm_t:
+        comm = ncclComm_t()
+        self.NCCL_CHECK(self._funcs["ncclCommInitRank"](ctypes.byref(comm),
+                                                        world_size, unique_id,
+                                                        rank))
+        return comm
+
+    def ncclAllReduce(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                      count: int, datatype: int, op: int, comm: ncclComm_t,
+                      stream: cudaStream_t) -> None:
+        # `datatype` actually should be `ncclDataType_t`
+        # and `op` should be `ncclRedOp_t`
+        # both are aliases of `ctypes.c_int`
+        # when we pass int to a function, it will be converted to `ctypes.c_int`
+        # by ctypes automatically
+        self.NCCL_CHECK(self._funcs["ncclAllReduce"](sendbuff, recvbuff, count,
+                                                     datatype, op, comm,
+                                                     stream))
+
+    def ncclReduceScatter(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                          count: int, datatype: int, op: int, comm: ncclComm_t,
+                          stream: cudaStream_t) -> None:
+        # `datatype` actually should be `ncclDataType_t`
+        # and `op` should be `ncclRedOp_t`
+        # both are aliases of `ctypes.c_int`
+        # when we pass int to a function, it will be converted to `ctypes.c_int`
+        # by ctypes automatically
+        self.NCCL_CHECK(self._funcs["ncclReduceScatter"](sendbuff, recvbuff,
+                                                         count, datatype, op,
+                                                         comm, stream))
+
+    def ncclAllGather(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                      count: int, datatype: int, comm: ncclComm_t,
+                      stream: cudaStream_t) -> None:
+        # `datatype` actually should be `ncclDataType_t`
+        # which is an aliases of `ctypes.c_int`
+        # when we pass int to a function, it will be converted to `ctypes.c_int`
+        # by ctypes automatically
+        self.NCCL_CHECK(self._funcs["ncclAllGather"](sendbuff, recvbuff, count,
+                                                     datatype, comm, stream))
+
+    def ncclSend(self, sendbuff: buffer_type, count: int, datatype: int,
+                 dest: int, comm: ncclComm_t, stream: cudaStream_t) -> None:
+        self.NCCL_CHECK(self._funcs["ncclSend"](sendbuff, count, datatype,
+                                                dest, comm, stream))
+
+    def ncclRecv(self, recvbuff: buffer_type, count: int, datatype: int,
+                 src: int, comm: ncclComm_t, stream: cudaStream_t) -> None:
+        self.NCCL_CHECK(self._funcs["ncclRecv"](recvbuff, count, datatype, src,
+                                                comm, stream))
+
+    def ncclBroadcast(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                      count: int, datatype: int, root: int, comm: ncclComm_t,
+                      stream: cudaStream_t) -> None:
+        self.NCCL_CHECK(self._funcs["ncclBroadcast"](sendbuff, recvbuff, count,
+                                                     datatype, root, comm,
+                                                     stream))
+
+    def ncclCommDestroy(self, comm: ncclComm_t) -> None:
+        self.NCCL_CHECK(self._funcs["ncclCommDestroy"](comm))
+
+
+__all__ = [
+    "NCCLLibrary", "ncclDataTypeEnum", "ncclRedOpTypeEnum", "ncclUniqueId",
+    "ncclComm_t", "cudaStream_t", "buffer_type"
+]

--- a/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+from typing import TYPE_CHECKING, Callable, Dict, Type
+
+from .base import KVConnectorBase
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+
+class KVConnectorFactory:
+    _registry: Dict[str, Callable[[], Type[KVConnectorBase]]] = {}
+
+    @classmethod
+    def register_connector(cls, name: str, module_path: str,
+                           class_name: str) -> None:
+        """Register a connector with a lazy-loading module and class name."""
+        if name in cls._registry:
+            raise ValueError(f"Connector '{name}' is already registered.")
+
+        def loader() -> Type[KVConnectorBase]:
+            module = importlib.import_module(module_path)
+            return getattr(module, class_name)
+
+        cls._registry[name] = loader
+
+    @classmethod
+    def create_connector(cls, rank: int, local_rank: int,
+                         config: "VllmConfig") -> KVConnectorBase:
+        connector_name = config.kv_transfer_config.kv_connector
+        if connector_name not in cls._registry:
+            raise ValueError(f"Unsupported connector type: {connector_name}")
+
+        connector_cls = cls._registry[connector_name]()
+        return connector_cls(rank, local_rank, config)
+
+
+# Register various connectors here.
+# The registration should not be done in each individual file, as we want to
+# only load the files corresponding to the current connector.
+KVConnectorFactory.register_connector(
+    "PyNcclConnector",
+    "vllm.distributed.kv_transfer.kv_connector.simple_connector",
+    "SimpleConnector")
+
+KVConnectorFactory.register_connector(
+    "P2pConnector", "vllm.distributed.kv_transfer.kv_connector.p2p_connector",
+    "P2pConnector")
+
+KVConnectorFactory.register_connector(
+    "MooncakeConnector",
+    "vllm.distributed.kv_transfer.kv_connector.simple_connector",
+    "SimpleConnector")
+
+KVConnectorFactory.register_connector(
+    "LMCacheConnector",
+    "vllm.distributed.kv_transfer.kv_connector.lmcache_connector",
+    "LMCacheConnector")
+
+KVConnectorFactory.register_connector(
+    "MooncakeStoreConnector",
+    "vllm.distributed.kv_transfer.kv_connector.mooncake_store_connector",
+    "MooncakeStoreConnector")

--- a/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_connector/p2p_connector.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_connector/p2p_connector.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from typing import TYPE_CHECKING, List, Tuple, Union
+
+import torch
+
+import vllm.envs as envs
+from vllm import _custom_ops as ops
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
+from vllm.distributed.kv_transfer.kv_pipe.p2p_nccl_pipe import P2pNcclPipe
+from vllm.logger import init_logger
+from vllm.sequence import IntermediateTensors
+
+if TYPE_CHECKING:
+    from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
+
+logger = init_logger(__name__)
+
+
+class P2pConnector(KVConnectorBase):
+
+    def __init__(
+        self,
+        rank: int,
+        local_rank: int,
+        config: VllmConfig,
+    ):
+        self.rank = rank
+        self.config = config.kv_transfer_config
+        self.tp_size = config.parallel_config.tensor_parallel_size
+        self.is_deepseek_mla = config.model_config.is_deepseek_mla
+        self.use_mla_opt = not envs.VLLM_MLA_DISABLE
+
+        assert self.config.kv_connector == "P2pConnector"
+
+        self.lookup_buffer_size = self.config.kv_buffer_size
+
+        self.p2p_nccl_pipe = P2pNcclPipe(
+            local_rank=local_rank,
+            config=self.config,
+            hostname="",
+            port_offset=rank,
+        )
+
+    def send_kv_caches_and_hidden_states(
+        self,
+        model_executable: torch.nn.Module,
+        model_input: "ModelInputForGPUWithSamplingMetadata",
+        kv_caches: List[torch.Tensor],
+        hidden_or_intermediate_states: Union[torch.Tensor,
+                                             IntermediateTensors],
+    ) -> None:
+
+        # input_tokens_tensor = model_input.input_tokens
+        seq_lens = model_input.attn_metadata.seq_lens
+        slot_mapping_flat = model_input.attn_metadata.slot_mapping.flatten()
+        num_prefill_tokens = model_input.attn_metadata.num_prefill_tokens
+        request_ids = list(model_input.request_ids_to_seq_ids.keys())
+        start_layer = model_executable.model.start_layer
+        end_layer = model_executable.model.end_layer
+
+        model_config = model_executable.model.config
+        num_heads = int(model_config.num_key_value_heads / self.tp_size)
+        hidden_size = model_config.hidden_size
+        num_attention_heads = model_config.num_attention_heads
+
+        # Deepseek's MLA (Multi-head Latent Attention) uses two different
+        # kv_cache shapes based on whether VLLM_MLA_DISABLE is set to 0.
+        # When VLLM_MLA_DISABLE=0 (default), forward absorb is applied,
+        # resulting in a kv_cache shape of [num_blks, blk_size, 1,
+        # kv_lora_rank + qk_rope_head_dim].
+        # When VLLM_MLA_DISABLE=1, standard FA is used instead, leading
+        # to a kv_cache shape of [2, num_blks, blk_size,
+        # num_key_value_heads / tp, qk_nope_head_dim + qk_rope_head_dim].
+        # For more details, see vllm/attention/backends/mla/common.py.
+        if self.is_deepseek_mla and self.use_mla_opt:
+            head_size = model_config.kv_lora_rank + \
+                model_config.qk_rope_head_dim
+            num_heads = 1
+        elif self.is_deepseek_mla and not self.use_mla_opt:
+            head_size = model_config.qk_nope_head_dim + \
+                model_config.qk_rope_head_dim
+        else:
+            head_size = getattr(model_config, "head_dim",
+                                int(hidden_size // num_attention_heads))
+
+        # query_lens contains new KV caches that are added to vLLM.
+        # so we will send them to decode instance
+        # FIXME(Kuntai): This assume that all requests are prefill.
+        for idx, slen in enumerate(seq_lens):
+            start_pos = sum(seq_lens[:idx])
+            end_pos = start_pos + slen
+
+            if start_pos >= num_prefill_tokens:
+                # vllm/worker/model_runner.py::_prepare_model_input_tensors:
+                # - input_tokens[:num_prefill_tokens] contains prefill tokens.
+                # - input_tokens[num_prefill_tokens:] contains decode tokens.
+                logger.warning("You have some decode requests while using "
+                               "SimpleConnector. Their KVCache won't be sent.")
+                break
+
+            # current_tokens = input_tokens_tensor[start_pos:end_pos]
+
+            keys, values = [], []
+
+            for layer_id in range(start_layer, end_layer):
+                kv_cache = kv_caches[layer_id - start_layer]
+
+                if self.is_deepseek_mla and self.use_mla_opt:
+                    key_cache = kv_cache.reshape(-1, num_heads, head_size)
+                    value_cache = kv_cache.reshape(-1, num_heads, head_size)
+                else:
+                    key_cache = kv_cache[0].reshape(-1, num_heads, head_size)
+                    value_cache = kv_cache[1].reshape(-1, num_heads, head_size)
+
+                current_slot_mapping = slot_mapping_flat[start_pos:end_pos]
+
+                keys.append(key_cache[current_slot_mapping].unsqueeze(0))
+                values.append(value_cache[current_slot_mapping].unsqueeze(0))
+
+            keys = torch.cat(keys, dim=0)
+            values = torch.cat(values, dim=0)
+
+            request_id = request_ids[idx]
+            ip, port = self.parse_request_id(request_id, True)
+            remote_address = ip + ":" + str(port + self.rank)
+
+            self.p2p_nccl_pipe.send_tensor(request_id + "keys", keys,
+                                           remote_address)
+            self.p2p_nccl_pipe.send_tensor(request_id + "values", values,
+                                           remote_address)
+            self.p2p_nccl_pipe.send_tensor(
+                request_id + "hidden",
+                hidden_or_intermediate_states[start_pos:end_pos],
+                remote_address)
+
+        logger.debug("[rank%d]: KV send DONE.", torch.distributed.get_rank())
+
+    def recv_kv_caches_and_hidden_states(
+        self, model_executable: torch.nn.Module,
+        model_input: "ModelInputForGPUWithSamplingMetadata",
+        kv_caches: List[torch.Tensor]
+    ) -> Tuple[Union[torch.Tensor, IntermediateTensors], bool,
+               "ModelInputForGPUWithSamplingMetadata"]:
+
+        # When bypass_model_exec is set to False, it means that at least for one
+        # request its corresponding KV cache or hidden state is missing.
+        # In this case we need to do prefilling to recompute missing KV cache
+        # and hidden states.
+        bypass_model_exec = True
+
+        model_config = model_executable.model.config
+
+        input_tokens_tensor = model_input.input_tokens
+        seq_lens = model_input.attn_metadata.seq_lens
+        num_prefill_tokens = model_input.attn_metadata.num_prefill_tokens
+        slot_mapping = model_input.attn_metadata.slot_mapping.flatten()
+        request_ids = list(model_input.request_ids_to_seq_ids.keys())
+
+        hidden_or_intermediate_states_for_one_req = []
+
+        input_tokens_list = []
+        num_computed_tokens_list = []
+        start_pos_list = []
+
+        # enumerate different requests
+        # FIXME(Kuntai): This impl assumes that all requests are prefill.
+        for idx, slen in enumerate(seq_lens):
+            start_pos = sum(seq_lens[:idx])
+            end_pos = start_pos + slen
+
+            if start_pos >= num_prefill_tokens:
+                # This can happen during inflight batching. See:
+                # vllm/worker/model_runner.py::_prepare_model_input_tensors:
+                # - input_tokens[:num_prefill_tokens] contains prefill tokens.
+                # - input_tokens[num_prefill_tokens:] contains decode tokens.
+                logger.warning("You should set --enable_chunked_prefill=False "
+                               "and --max_num_batched_tokens "
+                               "should be equal to --max_seq_len_to_capture")
+                bypass_model_exec = False
+                assert start_pos == num_prefill_tokens
+                break
+
+            current_tokens = input_tokens_tensor[start_pos:end_pos]
+            num_tokens = slen
+
+            # collecting data for rebuilding the input
+            input_tokens_list.append(current_tokens)
+            start_pos_list.append(start_pos)
+
+            request_id = request_ids[idx]
+            ip, port = self.parse_request_id(request_id, False)
+            remote_address = ip + ":" + str(port + self.rank)
+
+            keys = self.p2p_nccl_pipe.recv_tensor(request_id + "keys",
+                                                  remote_address)
+            values = self.p2p_nccl_pipe.recv_tensor(request_id + "values",
+                                                    remote_address)
+            hidden = self.p2p_nccl_pipe.recv_tensor(request_id + "hidden",
+                                                    remote_address)
+
+            num_computed_tokens = current_tokens.shape[0]
+            num_computed_tokens_list.append(num_computed_tokens)
+
+            # check if both KV cache and the hidden states are received
+            # If not, need to redo the forwarding to compute missing states
+            if not all([(num_computed_tokens == num_tokens), keys is not None,
+                        values is not None, hidden is not None]):
+                bypass_model_exec = False
+                break
+
+            # update the end position based on how many tokens are cached.
+            end_pos = start_pos + num_computed_tokens
+
+            # put received KV caches into paged memory
+            for i in range(model_executable.model.start_layer,
+                           model_executable.model.end_layer):
+
+                kv_cache = kv_caches[i - model_executable.model.start_layer]
+                layer = model_executable.model.layers[i]
+
+                if self.is_deepseek_mla and self.use_mla_opt:
+                    layer.self_attn.attn = layer.self_attn.mla_attn
+                    k_c_normed_k_pe = keys[
+                        i - model_executable.model.start_layer].to(
+                            kv_cache.device).squeeze(1)
+                    k_c_normed = k_c_normed_k_pe[:, :model_config.kv_lora_rank]
+                    k_pe = k_c_normed_k_pe[:, model_config.kv_lora_rank:]
+                    ops.concat_and_cache_mla(
+                        k_c_normed,
+                        k_pe,
+                        kv_cache,
+                        slot_mapping[start_pos:end_pos],
+                        layer.self_attn.attn.kv_cache_dtype,
+                        layer.self_attn.attn._k_scale,
+                    )
+                else:
+                    key_cache, value_cache = kv_cache[0], kv_cache[1]
+                    ops.reshape_and_cache_flash(
+                        keys[i - model_executable.model.start_layer].to(
+                            key_cache.device),
+                        values[i - model_executable.model.start_layer].to(
+                            value_cache.device),
+                        key_cache,
+                        value_cache,
+                        slot_mapping[start_pos:end_pos],
+                        layer.self_attn.attn.kv_cache_dtype,
+                        layer.self_attn.attn._k_scale,
+                        layer.self_attn.attn._v_scale,
+                    )
+
+            hidden_or_intermediate_states_for_one_req.append(hidden)
+
+        if not bypass_model_exec:
+            # Some of the KV cache is not retrieved
+            # Here we will fall back to normal model forwarding
+            # But optionally you can adjust model_input so that you only do
+            # prefilling on those tokens that are missing KV caches.
+            logger.warning(
+                "[rank%d]: Failed to receive all KVs and hidden "
+                "states, redo model forwarding.", torch.distributed.get_rank())
+            hidden_or_intermediate_states = None
+
+        else:
+            logger.debug(
+                "[rank%d]: Successfully received all KVs and hidden "
+                "states, skip model forwarding.", torch.distributed.get_rank())
+            hidden_or_intermediate_states = torch.cat(
+                hidden_or_intermediate_states_for_one_req, dim=0)
+
+        return hidden_or_intermediate_states, bypass_model_exec, model_input
+
+    @staticmethod
+    def parse_request_id(request_id: str, is_prefill=True) -> Tuple[str, int]:
+        logger.debug("parse_request_id, request_id: %s, is_prefill: %s",
+                     request_id, is_prefill)
+        # Regular expression to match the string hostname and integer port
+        if is_prefill:
+            pattern = r"___decode_addr_(.*):(\d+)"
+        else:
+            pattern = r"___prefill_addr_(.*):(\d+)___"
+
+        # Use re.search to find the pattern in the request_id
+        match = re.search(pattern, request_id)
+        if match:
+            # Extract the ranks
+            ip = match.group(1)
+            port = int(match.group(2))
+
+            logger.debug("parse_request_id, request_id: %s, ip: %s, port: %s",
+                         request_id, ip, str(port))
+            return ip, port
+        raise ValueError(
+            f"Request id {request_id} does not contain hostname and port")
+
+    def close(self):
+        self.p2p_nccl_pipe.close()

--- a/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe.py
@@ -1,28 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
-"""P2P tensor transport based on FlagCX (NCCL‑compatible)
-This file is a drop‑in replacement for the original *p2p_nccl_pipe.py* that
-shipped with vLLM <https://github.com/FlagOpen/FlagScale>.
-The only runtime dependency is ``flagcx_wrapper`` whose Python/ctypes wrapper
-now returns *structs* (not pointers) from ``flagcxGetUniqueId`` and expects the
-struct *by value* in ``flagcxCommInitRank``.  Make sure you have applied the
-wrapper patch before using this module.
-"""
-
-from __future__ import annotations
 
 import logging
-import os
 import threading
 import time
 import typing
 from collections import deque
 from typing import Any, Deque, Dict, List, Optional
 
-import msgpack  # type: ignore
+import msgpack
 import torch
-import zmq  # type: ignore
+import zmq
+import os
 
 from vllm.config import KVTransferConfig
+
+
 from vllm.distributed.device_communicators.flagcx_wrapper import (
     FLAGCXLibrary,
     buffer_type,
@@ -33,10 +25,6 @@ from vllm.distributed.device_communicators.flagcx_wrapper import (
 from vllm.utils import current_stream, get_ip
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Helper utilities
-# ---------------------------------------------------------------------------
 
 def _resolve_flagcx_library() -> str:
     """Return absolute path to *libflagcx.so*.
@@ -67,98 +55,118 @@ def _resolve_flagcx_library() -> str:
         + "\n  • ".join(candidates)
     )
 
-# ---------------------------------------------------------------------------
-# Main class
-# ---------------------------------------------------------------------------
-
 class P2pNcclPipe:
-    """Point‑to‑point tensor pipe implemented with FlagCX."""
 
-    def __init__(
-        self,
-        local_rank: int,
-        config: KVTransferConfig,
-        hostname: str = "",
-        port_offset: int = 0,
-        library_path: Optional[str] = None,
-    ) -> None:
-        # ---------------------------- basic attributes ------------------------
+    def __init__(self,
+                 local_rank: int,
+                 config: KVTransferConfig,
+                 hostname: str = "",
+                 port_offset: int = 0,
+                 library_path: Optional[str] = None) -> None:
         self.config = config
-        self.rank = port_offset  # pipe‑level rank (0 for producer, 1 for consumer)
+        self.rank = port_offset
         self.local_rank = local_rank
         self.device = torch.device(f"cuda:{self.local_rank}")
+        self.nccl = FLAGCXLibrary(library_path or _resolve_flagcx_library())
 
-        # ------------------------- load FlagCX library -----------------------
-        self.flagcx = FLAGCXLibrary(library_path or _resolve_flagcx_library())
-
-        # ------------------------- address bookkeeping -----------------------
         if not hostname:
             hostname = get_ip()
-        self._hostname = hostname
-
         port = self.config.kv_port + port_offset
         if port == 0:
             raise ValueError("Port cannot be 0")
+        self._hostname = hostname
         self._port = port
 
-        # Each GPU has its own ZMQ socket (ROUTER / DEALER pattern)
+        # Each card corresponds to a ZMQ address.
         self.zmq_address = f"{self._hostname}:{self._port}"
-        self.http_address = (
-            f"{self._hostname}:{self.config.kv_connector_extra_config['http_port']}"
-        )
 
+        # The `http_port` must be consistent with the port of OpenAI.
+        self.http_address = (
+            f"{self._hostname}:"
+            f"{self.config.kv_connector_extra_config['http_port']}")
+
+        # If `proxy_ip` or `proxy_port` is `""`,
+        # then the ping thread will not be enabled.
         proxy_ip = self.config.get_from_extra_config("proxy_ip", "")
         proxy_port = self.config.get_from_extra_config("proxy_port", "")
-        self.proxy_address = f"{proxy_ip}:{proxy_port}" if proxy_ip and proxy_port else ""
+        if proxy_ip == "" or proxy_port == "":
+            self.proxy_address = ""
+        else:
+            self.proxy_address = proxy_ip + ":" + proxy_port
 
-        # -------------------- ZeroMQ context & sockets -----------------------
-        self.context = zmq.Context.instance()
+        self.context = zmq.Context()
         self.router_socket = self.context.socket(zmq.ROUTER)
         self.router_socket.bind(f"tcp://{self.zmq_address}")
 
         self.poller = zmq.Poller()
         self.poller.register(self.router_socket, zmq.POLLIN)
 
-        # ------------------------------- state -------------------------------
         self.send_store_cv = threading.Condition()
         self.send_queue_cv = threading.Condition()
         self.recv_store_cv = threading.Condition()
         self.comm_cv = threading.Condition()
 
+        # The sending type includes tree mutually exclusive options:
+        # PUT, GET, PUT_ASYNC.
         self.send_type = self.config.get_from_extra_config("send_type", "PUT")
         if self.send_type == "GET":
-            self.send_store: Dict[str, torch.Tensor] = {}
-        else:  # PUT or PUT_ASYNC
-            self.send_queue: Deque[List[Any]] = deque()
+            self.send_store: Dict[str,
+                                  torch.Tensor] = {}  # tensor_id: torch.Tensor
+        else:
+            # PUT or PUT_ASYNC
+            self.send_queue: Deque[
+                List[Any]] = deque()  # tensor_id: torch.Tensor
             if self.send_type == "PUT_ASYNC":
-                self._send_thread = threading.Thread(
-                    target=self._send_async, daemon=True, name="p2p‑send‑async"
-                )
+                self._send_thread = threading.Thread(target=self._send_async,
+                                                     daemon=True)
                 self._send_thread.start()
 
-        self.recv_store: Dict[str, torch.Tensor] = {}
-        self.socks: Dict[str, Any] = {}
-        self.comms: Dict[str, Any] = {}
+        self.recv_store: Dict[str,
+                              torch.Tensor] = {}  # tensor_id: torch.Tensor
+        self.socks: Dict[str, Any] = {}  # remote_address: client socket
+        self.comms: Dict[str, Any] = {}  # remote_address: (flagcxComm_t, rank)
 
         self.buffer_size = 0
         self.buffer_size_threshold = self.config.kv_buffer_size
 
-        # ------------------------- background threads ------------------------
         self._listener_thread = threading.Thread(
-            target=self._listen_for_requests, daemon=True, name="p2p‑listener"
-        )
+            target=self._listen_for_requests, daemon=True)
         self._listener_thread.start()
 
-        self._ping_thread: Optional[threading.Thread] = None
-        if port_offset == 0 and self.proxy_address:
-            self._ping_thread = threading.Thread(
-                target=self._ping, daemon=True, name="p2p‑ping"
-            )
+        self._ping_thread = None
+        if port_offset == 0 and self.proxy_address != "":
+            self._ping_thread = threading.Thread(target=self._ping,
+                                                 daemon=True)
             self._ping_thread.start()
 
-    # ---------------------------------------------------------------------
-    # Public API (send / recv)
-    # ---------------------------------------------------------------------
+    def _create_connect(self, remote_address: typing.Optional[str] = None):
+        assert remote_address is not None
+        if remote_address not in self.socks:
+            sock = self.context.socket(zmq.DEALER)
+            sock.setsockopt_string(zmq.IDENTITY, self.zmq_address)
+            sock.connect(f"tcp://{remote_address}")
+            self.socks[remote_address] = sock
+            if remote_address in self.comms:
+                logger.info("��comm exists, remote_address:%s, comms:%s",
+                            remote_address, self.comms)
+                return sock, self.comms[remote_address]
+
+            # unique_id = self.nccl.flagcxGetUniqueId()
+            # data = {"cmd": "NEW", "unique_id": bytes(unique_id.internal)}
+            unique_id_ptr = self.nccl.flagcxGetUniqueId()
+            uid = unique_id_ptr.contents if hasattr(unique_id_ptr, "contents") else unique_id_ptr
+            data = {"cmd": "NEW", "unique_id": bytes(uid.internal)}
+            sock.send(msgpack.dumps(data))
+
+            with torch.cuda.device(self.device):
+                rank = 0
+                comm: flagcxComm_t = self.nccl.flagcxCommInitRank(
+                    2, uid, rank) # cz unique_id -->  uid
+                self.comms[remote_address] = (comm, rank)
+                logger.info("🤝flagcxCommInitRank Success, %s👉%s, MyRank: %s",
+                            self.zmq_address, remote_address, rank)
+
+        return self.socks[remote_address], self.comms[remote_address]
 
     def send_tensor(
         self,
@@ -166,87 +174,203 @@ class P2pNcclPipe:
         tensor: torch.Tensor,
         remote_address: typing.Optional[str] = None,
     ) -> bool:
-        """Send *tensor* to *remote_address* (or loopback if ``None``)."""
         if remote_address is None:
             with self.recv_store_cv:
                 self.recv_store[tensor_id] = tensor
                 self.recv_store_cv.notify()
             return True
+        else:
+            if self.send_type == "PUT":
+                return self._send_sync(tensor_id, tensor, remote_address)
+            elif self.send_type == "PUT_ASYNC":
+                with self.send_queue_cv:
+                    self.send_queue.append([tensor_id, remote_address, tensor])
+                    self.send_queue_cv.notify()
+            else:  # GET
+                with self.send_store_cv:
+                    tensor_size = tensor.element_size() * tensor.numel()
+                    while (self.buffer_size + tensor_size
+                           > self.buffer_size_threshold):
+                        oldest_tenser_id = next(iter(self.send_store))
+                        oldest_tenser = self.send_store.pop(oldest_tenser_id)
+                        oldest_tenser_size = oldest_tenser.element_size(
+                        ) * oldest_tenser.numel()
+                        self.buffer_size -= oldest_tenser_size
+                        logger.info(
+                            "⛔[GET]Send to %s, tensor_id:%s, tensor_size:%d,"
+                            " buffer_size:%d, oldest_tenser_size:%d, rank:%d",
+                            remote_address, tensor_id, tensor_size,
+                            self.buffer_size, oldest_tenser_size, self.rank)
 
-        if self.send_type == "PUT":
-            return self._send_sync(tensor_id, tensor, remote_address)
-        elif self.send_type == "PUT_ASYNC":
-            with self.send_queue_cv:
-                self.send_queue.append([tensor_id, remote_address, tensor])
-                self.send_queue_cv.notify()
-            return True
-        else:  # GET mode
-            return self._enqueue_for_get(tensor_id, tensor)
+                    self.send_store[tensor_id] = tensor
+                    self.buffer_size += tensor_size
+                    logger.info(
+                        "🔵[GET]Send to %s, tensor_id:%s, tensor_size:%d, "
+                        "shape:%s, rank:%d, buffer_size:%d(%.2f%%)",
+                        remote_address, tensor_id, tensor_size, tensor.shape,
+                        self.rank, self.buffer_size,
+                        self.buffer_size / self.buffer_size_threshold * 100)
+
+        return True
 
     def recv_tensor(
         self,
         tensor_id: str,
         remote_address: typing.Optional[str] = None,
-    ) -> Optional[torch.Tensor]:
-        """Blocking receive of the tensor *tensor_id* from *remote_address*."""
-        if self.send_type in {"PUT", "PUT_ASYNC"}:
-            return self._recv_blocking(tensor_id, remote_address)
-        else:  # GET mode
-            return self._recv_via_get(tensor_id, remote_address)
+    ) -> torch.Tensor:
+        if self.send_type == "PUT" or self.send_type == "PUT_ASYNC":
+            start_time = time.time()
+            with self.recv_store_cv:
+                while tensor_id not in self.recv_store:
+                    self.recv_store_cv.wait()
+                # TODO:Abatom, To avoid an overly large dictionary.
+                # tensor = self.recv_store.pop(tensor_id)
+                tensor = self.recv_store[tensor_id]
+                self.recv_store[tensor_id] = None
+            duration = time.time() - start_time
+            if tensor is not None:
+                self.buffer_size -= (tensor.element_size() * tensor.numel())
+                logger.info(
+                    "🔵[PUT]Recv From %s, tensor_id:%s, shape:%s, "
+                    "duration:%.3fms, size:%.3fGB, rank:%d", remote_address,
+                    tensor_id, tensor.shape, duration * 1000,
+                    tensor.element_size() * tensor.numel() / 1024**3,
+                    self.rank)
+            else:
+                logger.warning(
+                    "🔴[PUT]Recv From %s, tensor_id:%s, duration:%.3fms, "
+                    "rank:%d", remote_address, tensor_id, duration * 1000,
+                    self.rank)
+            return tensor
 
-    # ---------------------------------------------------------------------
-    # Internal helpers (connection management)
-    # ---------------------------------------------------------------------
+        # GET
+        if remote_address is None:
+            return None
 
-    def _create_connect(self, remote_address: str):
-        if remote_address in self.socks:
-            return self.socks[remote_address], self.comms[remote_address]
+        if remote_address not in self.socks:
+            self._create_connect(remote_address)
 
-        # 1. ZMQ DEALER socket ---------------------------------------------
-        sock = self.context.socket(zmq.DEALER)
-        sock.setsockopt_string(zmq.IDENTITY, self.zmq_address)
-        sock.connect(f"tcp://{remote_address}")
-        self.socks[remote_address] = sock
+        sock = self.socks[remote_address]
+        comm, rank = self.comms[remote_address]
 
-        # 2. FlagCX communicator -------------------------------------------
-        #unique_id = self.flagcx.flagcxGetUniqueId()
-        unique_id_ptr = self.flagcx.flagcxGetUniqueId()
-        uid = unique_id_ptr.contents if hasattr(unique_id_ptr, "contents") else unique_id_ptr
-        data = {"cmd": "NEW", "unique_id": bytes(uid.internal)}
-#        data = {"cmd": "NEW", "unique_id": bytes(unique_id.internal)}
+        data = {"cmd": "GET", "tensor_id": tensor_id}
         sock.send(msgpack.dumps(data))
 
-        with torch.cuda.device(self.device):
-            rank = 0  # side that initiates the connection
-            comm: flagcxComm_t = self.flagcx.flagcxCommInitRank(2, uid, rank) # cz unique_id --> uid
-        self.comms[remote_address] = (comm, rank)
-        logger.info("🤝 flagcxCommInitRank established %s → %s (rank=%d)",
-                    self.zmq_address, remote_address, rank)
-        return sock, self.comms[remote_address]
+        message = sock.recv()
+        data = msgpack.loads(message)
+        if data["ret"] != 0:
+            logger.warning("🔴[GET]Recv From %s, tensor_id: %s, ret: %d",
+                           remote_address, tensor_id, data["ret"])
+            return None
 
-    # ---------------------------------------------------------------------
-    # Internal helpers (send / recv implementations)
-    # ---------------------------------------------------------------------
+        tensor = torch.empty(data["shape"],
+                             dtype=getattr(torch, data["dtype"]),
+                             device=self.device)
 
-    def _send_sync(
-        self, tensor_id: str, tensor: torch.Tensor, remote_address: str
-    ) -> bool:
-        sock, (comm, rank) = self._create_connect(remote_address)
-        hdr = {
-            "cmd": "PUT",
-            "tensor_id": tensor_id,
-            "shape": tensor.shape,
-            "dtype": str(tensor.dtype).replace("torch.", ""),
-        }
-        sock.send(msgpack.dumps(hdr))
-        if sock.recv() != b"0":
-            logger.warning("Peer OOM/threshold hit — defer send of %s", tensor_id)
-            return False
+        start_time = time.time()
+        self._recv(comm, tensor, rank ^ 1)
+        duration = time.time() - start_time
+        logger.info(
+            "🔵[GET]Recv From %s, tensor_id:%s, shape:%s, duration:%.3fms, "
+            "size:%.3fGB, rank:%d", remote_address, tensor_id, tensor.shape,
+            duration * 1000,
+            tensor.element_size() * tensor.numel() / 1024**3, self.rank)
 
-        self._flagcx_send(comm, tensor.to(self.device), rank ^ 1)
-        logger.debug("Sent tensor %s → %s (%s)", tensor_id, remote_address, tensor.shape)
-        return True
+        return tensor
 
+    def _listen_for_requests(self):
+        while True:
+            socks = dict(self.poller.poll())
+            if self.router_socket in socks:
+                remote_address, message = self.router_socket.recv_multipart()
+                data = msgpack.loads(message)
+                logger.debug("Received message from %s, data:%s",
+                             remote_address.decode(), data)
+                if data["cmd"] == "NEW":
+                    unique_id = self.nccl.unique_id_from_bytes(
+                        bytes(data["unique_id"]))
+                    with torch.cuda.device(self.device):
+                        rank = 1
+                        comm: flagcxComm_t = self.nccl.flagcxCommInitRank(
+                            2, unique_id, rank)
+                        self.comms[remote_address.decode()] = (comm, rank)
+                        logger.info(
+                            "🤝flagcxCommInitRank Success, %s👈%s, MyRank:%s",
+                            self.zmq_address, remote_address.decode(), rank)
+                elif data["cmd"] == "PUT":
+                    try:
+                        tensor = torch.empty(data["shape"],
+                                             dtype=getattr(
+                                                 torch, data["dtype"]),
+                                             device=self.device)
+
+                        tensor_size = tensor.element_size() * tensor.numel()
+                        if (self.buffer_size + tensor_size
+                                > self.buffer_size_threshold):
+                            self.router_socket.send_multipart(
+                                [remote_address, b"2"])
+                            logger.warning(
+                                "🔴[PUT]Recv Tensor, Out Of Threshold, "
+                                "%s👈%s, data:%s", self.zmq_address,
+                                remote_address.decode(), data)
+                            tensor = None
+                        else:
+                            self.buffer_size += tensor_size
+                            self.router_socket.send_multipart(
+                                [remote_address, b"0"])
+                            comm, rank = self.comms[remote_address.decode()]
+                            self._recv(comm, tensor, rank ^ 1)
+                            logger.info(
+                                "🔵[PUT]Recv Tensor, %s👈%s, MyRank:%s, data:%s, "
+                                "shape:%s", self.zmq_address,
+                                remote_address.decode(), rank, data, tensor.shape)
+
+                        tensor_id = data["tensor_id"]
+                        with self.recv_store_cv:
+                            self.recv_store[tensor_id] = tensor
+                            self.recv_store_cv.notify()
+
+                    except torch.cuda.OutOfMemoryError:
+                        self.router_socket.send_multipart(
+                            [remote_address, b"1"])
+                        logger.warning(
+                            "🔴[PUT]Recv Tensor, Out Of Memory, %s👈%s, "
+                            "data:%s", self.zmq_address,
+                            remote_address.decode(), data)
+
+                elif data["cmd"] == "GET":
+                    tensor_id = data["tensor_id"]
+                    with self.send_store_cv:
+                        tensor = self.send_store.pop(tensor_id, None)
+                        if tensor is not None:
+                            data = {
+                                "ret": 0,
+                                "shape": tensor.shape,
+                                "dtype":
+                                str(tensor.dtype).replace("torch.", "")
+                            }
+                            # LRU
+                            self.send_store[tensor_id] = tensor
+                        else:
+                            data = {"ret": 1}
+
+                    self.router_socket.send_multipart(
+                        [remote_address, msgpack.dumps(data)])
+
+                    if data["ret"] == 0:
+                        self._send(comm, tensor.to(self.device), rank ^ 1)
+
+                    logger.info(
+                        "🔵[GET]Send Tensor, %s👉%s, "
+                        "MyRank:%s, data:%s", self.zmq_address,
+                        remote_address.decode(), rank, data)
+                else:
+                    logger.warning(
+                        "🚧Unexpected, Received message from %s, data:%s",
+                        remote_address, data)
+
+    # Asynchronous sending may cause conflicts between P2P FLAGCX and
+    # FLAGCX used in TP/PP, which can lead to deadlock issues.
     def _send_async(self):
         while True:
             with self.send_queue_cv:
@@ -255,165 +379,86 @@ class P2pNcclPipe:
                 tensor_id, remote_address, tensor = self.send_queue.popleft()
             self._send_sync(tensor_id, tensor, remote_address)
 
-    def _enqueue_for_get(self, tensor_id: str, tensor: torch.Tensor) -> bool:
-        tensor_size = tensor.element_size() * tensor.numel()
-        with self.send_store_cv:
-            while (self.buffer_size + tensor_size) > self.buffer_size_threshold:
-                # Drop LRU tensor
-                old_id, old_tensor = self.send_store.popitem(last=False)
-                self.buffer_size -= old_tensor.element_size() * old_tensor.numel()
-                logger.debug("Dropped cached tensor %s to free space", old_id)
-            self.send_store[tensor_id] = tensor
-            self.buffer_size += tensor_size
+    def _send_sync(
+        self,
+        tensor_id: str,
+        tensor: torch.Tensor,
+        remote_address: typing.Optional[str] = None,
+    ) -> bool:
+        if remote_address is None:
+            return False
+        if remote_address not in self.socks:
+            self._create_connect(remote_address)
+
+        sock = self.socks[remote_address]
+        comm, rank = self.comms[remote_address]
+        data = {
+            "cmd": "PUT",
+            "tensor_id": tensor_id,
+            "shape": tensor.shape,
+            "dtype": str(tensor.dtype).replace("torch.", "")
+        }
+        sock.send(msgpack.dumps(data))
+
+        response = sock.recv()
+        if response != b"0":
+            # with self.send_queue_cv:
+            #     self.send_queue.append([tensor_id, remote_address, tensor])
+            #     self.send_queue_cv.notify()
+            logger.warning(
+                "🔴Send Tensor, Peer Out Of Memory/Threshold, %s 👉 %s, "
+                "MyRank:%s, data:%s, tensor:%s, size:%fGB, response:%s",
+                self.zmq_address, remote_address, rank, data, tensor.shape,
+                tensor.element_size() * tensor.numel() / 1024**3,
+                response.decode())
+            return False
+
+        self._send(comm, tensor.to(self.device), rank ^ 1)
+        logger.info("🔵Send Tensor, %s👉%s, MyRank:%s, data:%s, tensor:%s",
+                    self.zmq_address, remote_address, rank, data, tensor.shape)
         return True
-
-    def _recv_blocking(
-        self, tensor_id: str, remote_address: Optional[str]
-    ) -> Optional[torch.Tensor]:
-        start = time.time()
-        with self.recv_store_cv:
-            while tensor_id not in self.recv_store:
-                self.recv_store_cv.wait()
-            tensor = self.recv_store.pop(tensor_id)
-        duration_ms = (time.time() - start) * 1e3
-        logger.debug("Received tensor %s from %s in %.2f ms", tensor_id, remote_address, duration_ms)
-        return tensor
-
-    def _recv_via_get(
-        self, tensor_id: str, remote_address: str
-    ) -> Optional[torch.Tensor]:
-        sock, (comm, rank) = self._create_connect(remote_address)
-        sock.send(msgpack.dumps({"cmd": "GET", "tensor_id": tensor_id}))
-        meta = msgpack.loads(sock.recv())
-        if meta["ret"] != 0:
-            logger.warning("Peer lacked tensor %s", tensor_id)
-            return None
-
-        tensor = torch.empty(meta["shape"], dtype=getattr(torch, meta["dtype"]), device=self.device)
-        self._flagcx_recv(comm, tensor, rank ^ 1)
-        return tensor
-
-    # ---------------------------------------------------------------------
-    # Background threads
-    # ---------------------------------------------------------------------
-
-    def _listen_for_requests(self):
-        while True:
-            for sock, _ in self.poller.poll():
-                if sock is self.router_socket:
-                    remote_address, payload = self.router_socket.recv_multipart()
-                    self._handle_router_message(remote_address, payload)
-
-    def _handle_router_message(self, remote_address: bytes, payload: bytes):
-        data = msgpack.loads(payload)
-        raddr = remote_address.decode()
-        cmd = data["cmd"]
-
-        if cmd == "NEW":
-            unique_id = self.flagcx.unique_id_from_bytes(bytes(data["unique_id"]))
-            with torch.cuda.device(self.device):
-                rank = 1  # the *acceptor* side of the connection
-                comm: flagcxComm_t = self.flagcx.flagcxCommInitRank(2, unique_id, rank)
-            self.comms[raddr] = (comm, rank)
-            logger.info("Established reverse connection %s ← %s", self.zmq_address, raddr)
-            return
-
-        if cmd == "PUT":
-            self._handle_put(raddr, data)
-        elif cmd == "GET":
-            self._handle_get(raddr, data)
-        else:
-            logger.warning("Unknown command %s from %s", cmd, raddr)
-
-    def _handle_put(self, raddr: str, data: dict[str, Any]):
-        tensor = torch.empty(
-            data["shape"], dtype=getattr(torch, data["dtype"]), device=self.device
-        )
-        tensor_size = tensor.element_size() * tensor.numel()
-        if (self.buffer_size + tensor_size) > self.buffer_size_threshold:
-            self.router_socket.send_multipart([raddr.encode(), b"2"])  # threshold hit
-            return
-        self.router_socket.send_multipart([raddr.encode(), b"0"])  # OK
-        comm, rank = self.comms[raddr]
-        self._flagcx_recv(comm, tensor, rank ^ 1)
-        tensor_id = data["tensor_id"]
-        with self.recv_store_cv:
-            self.recv_store[tensor_id] = tensor
-            self.recv_store_cv.notify()
-        self.buffer_size += tensor_size
-
-    def _handle_get(self, raddr: str, data: dict[str, Any]):
-        tensor_id = data["tensor_id"]
-        with self.send_store_cv:
-            tensor = self.send_store.pop(tensor_id, None)
-            if tensor is None:
-                self.router_socket.send_multipart([raddr.encode(), msgpack.dumps({"ret": 1})])
-                return
-            meta = {
-                "ret": 0,
-                "shape": tensor.shape,
-                "dtype": str(tensor.dtype).replace("torch.", ""),
-            }
-            self.router_socket.send_multipart([raddr.encode(), msgpack.dumps(meta)])
-        comm, rank = self.comms[raddr]
-        self._flagcx_send(comm, tensor.to(self.device), rank ^ 1)
-
-    # ---------------------------------------------------------------------
-    # Low‑level FlagCX wrappers (thread‑safe)
-    # ---------------------------------------------------------------------
-
-    def _flagcx_send(self, comm: flagcxComm_t, tensor: torch.Tensor, dst: int):
-        assert tensor.device == self.device
-        stream = current_stream()
-        with self.comm_cv:
-            self.flagcx.flagcxSend(
-                buffer_type(tensor.data_ptr()),
-                tensor.numel(),
-                flagcxDataTypeEnum.from_torch(tensor.dtype),
-                dst,
-                comm,
-                cudaStream_t(stream.cuda_stream),
-            )
-
-    def _flagcx_recv(self, comm: flagcxComm_t, tensor: torch.Tensor, src: int):
-        assert tensor.device == self.device
-        stream = current_stream()
-        with self.comm_cv:
-            self.flagcx.flagcxRecv(
-                buffer_type(tensor.data_ptr()),
-                tensor.numel(),
-                flagcxDataTypeEnum.from_torch(tensor.dtype),
-                src,
-                comm,
-                cudaStream_t(stream.cuda_stream),
-            )
-
-    # ---------------------------------------------------------------------
-    # Ping for proxy registration
-    # ---------------------------------------------------------------------
 
     def _ping(self):
         sock = self.context.socket(zmq.DEALER)
         sock.setsockopt_string(zmq.IDENTITY, self.zmq_address)
+        logger.debug("ping start, zmq_address:%s", self.zmq_address)
         sock.connect(f"tcp://{self.proxy_address}")
-        payload = {
+        data = {
             "type": "P" if self.config.is_kv_producer else "D",
             "http_address": self.http_address,
-            "zmq_address": self.zmq_address,
+            "zmq_address": self.zmq_address
         }
         while True:
-            sock.send(msgpack.dumps(payload))
+            sock.send(msgpack.dumps(data))
             time.sleep(3)
 
-    # ---------------------------------------------------------------------
-    # Teardown
-    # ---------------------------------------------------------------------
+    def _send(self, comm, tensor: torch.Tensor, dst: int, stream=None):
+        assert tensor.device == self.device, (
+            f"this flagcx communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}")
+        if stream is None:
+            stream = current_stream()
+
+        with self.comm_cv:
+            self.nccl.flagcxSend(buffer_type(tensor.data_ptr()), tensor.numel(),
+                               flagcxDataTypeEnum.from_torch(tensor.dtype), dst,
+                               comm, cudaStream_t(stream.cuda_stream))
+
+    def _recv(self, comm, tensor: torch.Tensor, src: int, stream=None):
+        assert tensor.device == self.device, (
+            f"this flagcx communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}")
+        if stream is None:
+            stream = current_stream()
+
+        with self.comm_cv:
+            self.nccl.flagcxRecv(buffer_type(tensor.data_ptr()), tensor.numel(),
+                               flagcxDataTypeEnum.from_torch(tensor.dtype), src,
+                               comm, cudaStream_t(stream.cuda_stream))
 
     def close(self) -> None:
-        """Join background threads and close ZMQ context."""
         self._listener_thread.join()
         if self.send_type == "PUT_ASYNC":
             self._send_thread.join()
         if self._ping_thread is not None:
             self._ping_thread.join()
-        self.context.destroy(linger=0)

--- a/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe.py
@@ -1,0 +1,419 @@
+# SPDX-License-Identifier: Apache-2.0
+"""P2P tensor transport based on FlagCX (NCCL‑compatible)
+This file is a drop‑in replacement for the original *p2p_nccl_pipe.py* that
+shipped with vLLM <https://github.com/FlagOpen/FlagScale>.
+The only runtime dependency is ``flagcx_wrapper`` whose Python/ctypes wrapper
+now returns *structs* (not pointers) from ``flagcxGetUniqueId`` and expects the
+struct *by value* in ``flagcxCommInitRank``.  Make sure you have applied the
+wrapper patch before using this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+import typing
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional
+
+import msgpack  # type: ignore
+import torch
+import zmq  # type: ignore
+
+from vllm.config import KVTransferConfig
+from vllm.distributed.device_communicators.flagcx_wrapper import (
+    FLAGCXLibrary,
+    buffer_type,
+    cudaStream_t,
+    flagcxComm_t,
+    flagcxDataTypeEnum,
+)
+from vllm.utils import current_stream, get_ip
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+def _resolve_flagcx_library() -> str:
+    """Return absolute path to *libflagcx.so*.
+
+    Users can point ``FLAGCX_PATH`` to either the build directory or the
+    installation root (containing *build/lib/libflagcx.so*).  A politely
+    worded ``RuntimeError`` is raised when the library cannot be located.
+    """
+
+    env_path = os.getenv("FLAGCX_PATH")
+    if not env_path:
+        raise RuntimeError(
+            "Environment variable FLAGCX_PATH is not set — cannot locate "
+            "libflagcx.so.  Either install FlagCX system‑wide or export the "
+            "build directory, e.g. \n    export FLAGCX_PATH=/path/to/FlagCX")
+
+    # Accept both $FLAGCX_PATH/build/lib and $FLAGCX_PATH
+    candidates = [
+        os.path.join(env_path, "build/lib/libflagcx.so"),
+        os.path.join(env_path, "libflagcx.so"),
+    ]
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+
+    raise RuntimeError(
+        "Could not find libflagcx.so.  Checked:\n  • "
+        + "\n  • ".join(candidates)
+    )
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+class P2pNcclPipe:
+    """Point‑to‑point tensor pipe implemented with FlagCX."""
+
+    def __init__(
+        self,
+        local_rank: int,
+        config: KVTransferConfig,
+        hostname: str = "",
+        port_offset: int = 0,
+        library_path: Optional[str] = None,
+    ) -> None:
+        # ---------------------------- basic attributes ------------------------
+        self.config = config
+        self.rank = port_offset  # pipe‑level rank (0 for producer, 1 for consumer)
+        self.local_rank = local_rank
+        self.device = torch.device(f"cuda:{self.local_rank}")
+
+        # ------------------------- load FlagCX library -----------------------
+        self.flagcx = FLAGCXLibrary(library_path or _resolve_flagcx_library())
+
+        # ------------------------- address bookkeeping -----------------------
+        if not hostname:
+            hostname = get_ip()
+        self._hostname = hostname
+
+        port = self.config.kv_port + port_offset
+        if port == 0:
+            raise ValueError("Port cannot be 0")
+        self._port = port
+
+        # Each GPU has its own ZMQ socket (ROUTER / DEALER pattern)
+        self.zmq_address = f"{self._hostname}:{self._port}"
+        self.http_address = (
+            f"{self._hostname}:{self.config.kv_connector_extra_config['http_port']}"
+        )
+
+        proxy_ip = self.config.get_from_extra_config("proxy_ip", "")
+        proxy_port = self.config.get_from_extra_config("proxy_port", "")
+        self.proxy_address = f"{proxy_ip}:{proxy_port}" if proxy_ip and proxy_port else ""
+
+        # -------------------- ZeroMQ context & sockets -----------------------
+        self.context = zmq.Context.instance()
+        self.router_socket = self.context.socket(zmq.ROUTER)
+        self.router_socket.bind(f"tcp://{self.zmq_address}")
+
+        self.poller = zmq.Poller()
+        self.poller.register(self.router_socket, zmq.POLLIN)
+
+        # ------------------------------- state -------------------------------
+        self.send_store_cv = threading.Condition()
+        self.send_queue_cv = threading.Condition()
+        self.recv_store_cv = threading.Condition()
+        self.comm_cv = threading.Condition()
+
+        self.send_type = self.config.get_from_extra_config("send_type", "PUT")
+        if self.send_type == "GET":
+            self.send_store: Dict[str, torch.Tensor] = {}
+        else:  # PUT or PUT_ASYNC
+            self.send_queue: Deque[List[Any]] = deque()
+            if self.send_type == "PUT_ASYNC":
+                self._send_thread = threading.Thread(
+                    target=self._send_async, daemon=True, name="p2p‑send‑async"
+                )
+                self._send_thread.start()
+
+        self.recv_store: Dict[str, torch.Tensor] = {}
+        self.socks: Dict[str, Any] = {}
+        self.comms: Dict[str, Any] = {}
+
+        self.buffer_size = 0
+        self.buffer_size_threshold = self.config.kv_buffer_size
+
+        # ------------------------- background threads ------------------------
+        self._listener_thread = threading.Thread(
+            target=self._listen_for_requests, daemon=True, name="p2p‑listener"
+        )
+        self._listener_thread.start()
+
+        self._ping_thread: Optional[threading.Thread] = None
+        if port_offset == 0 and self.proxy_address:
+            self._ping_thread = threading.Thread(
+                target=self._ping, daemon=True, name="p2p‑ping"
+            )
+            self._ping_thread.start()
+
+    # ---------------------------------------------------------------------
+    # Public API (send / recv)
+    # ---------------------------------------------------------------------
+
+    def send_tensor(
+        self,
+        tensor_id: str,
+        tensor: torch.Tensor,
+        remote_address: typing.Optional[str] = None,
+    ) -> bool:
+        """Send *tensor* to *remote_address* (or loopback if ``None``)."""
+        if remote_address is None:
+            with self.recv_store_cv:
+                self.recv_store[tensor_id] = tensor
+                self.recv_store_cv.notify()
+            return True
+
+        if self.send_type == "PUT":
+            return self._send_sync(tensor_id, tensor, remote_address)
+        elif self.send_type == "PUT_ASYNC":
+            with self.send_queue_cv:
+                self.send_queue.append([tensor_id, remote_address, tensor])
+                self.send_queue_cv.notify()
+            return True
+        else:  # GET mode
+            return self._enqueue_for_get(tensor_id, tensor)
+
+    def recv_tensor(
+        self,
+        tensor_id: str,
+        remote_address: typing.Optional[str] = None,
+    ) -> Optional[torch.Tensor]:
+        """Blocking receive of the tensor *tensor_id* from *remote_address*."""
+        if self.send_type in {"PUT", "PUT_ASYNC"}:
+            return self._recv_blocking(tensor_id, remote_address)
+        else:  # GET mode
+            return self._recv_via_get(tensor_id, remote_address)
+
+    # ---------------------------------------------------------------------
+    # Internal helpers (connection management)
+    # ---------------------------------------------------------------------
+
+    def _create_connect(self, remote_address: str):
+        if remote_address in self.socks:
+            return self.socks[remote_address], self.comms[remote_address]
+
+        # 1. ZMQ DEALER socket ---------------------------------------------
+        sock = self.context.socket(zmq.DEALER)
+        sock.setsockopt_string(zmq.IDENTITY, self.zmq_address)
+        sock.connect(f"tcp://{remote_address}")
+        self.socks[remote_address] = sock
+
+        # 2. FlagCX communicator -------------------------------------------
+        #unique_id = self.flagcx.flagcxGetUniqueId()
+        unique_id_ptr = self.flagcx.flagcxGetUniqueId()
+        uid = unique_id_ptr.contents if hasattr(unique_id_ptr, "contents") else unique_id_ptr
+        data = {"cmd": "NEW", "unique_id": bytes(uid.internal)}
+#        data = {"cmd": "NEW", "unique_id": bytes(unique_id.internal)}
+        sock.send(msgpack.dumps(data))
+
+        with torch.cuda.device(self.device):
+            rank = 0  # side that initiates the connection
+            comm: flagcxComm_t = self.flagcx.flagcxCommInitRank(2, uid, rank) # cz unique_id --> uid
+        self.comms[remote_address] = (comm, rank)
+        logger.info("🤝 flagcxCommInitRank established %s → %s (rank=%d)",
+                    self.zmq_address, remote_address, rank)
+        return sock, self.comms[remote_address]
+
+    # ---------------------------------------------------------------------
+    # Internal helpers (send / recv implementations)
+    # ---------------------------------------------------------------------
+
+    def _send_sync(
+        self, tensor_id: str, tensor: torch.Tensor, remote_address: str
+    ) -> bool:
+        sock, (comm, rank) = self._create_connect(remote_address)
+        hdr = {
+            "cmd": "PUT",
+            "tensor_id": tensor_id,
+            "shape": tensor.shape,
+            "dtype": str(tensor.dtype).replace("torch.", ""),
+        }
+        sock.send(msgpack.dumps(hdr))
+        if sock.recv() != b"0":
+            logger.warning("Peer OOM/threshold hit — defer send of %s", tensor_id)
+            return False
+
+        self._flagcx_send(comm, tensor.to(self.device), rank ^ 1)
+        logger.debug("Sent tensor %s → %s (%s)", tensor_id, remote_address, tensor.shape)
+        return True
+
+    def _send_async(self):
+        while True:
+            with self.send_queue_cv:
+                while not self.send_queue:
+                    self.send_queue_cv.wait()
+                tensor_id, remote_address, tensor = self.send_queue.popleft()
+            self._send_sync(tensor_id, tensor, remote_address)
+
+    def _enqueue_for_get(self, tensor_id: str, tensor: torch.Tensor) -> bool:
+        tensor_size = tensor.element_size() * tensor.numel()
+        with self.send_store_cv:
+            while (self.buffer_size + tensor_size) > self.buffer_size_threshold:
+                # Drop LRU tensor
+                old_id, old_tensor = self.send_store.popitem(last=False)
+                self.buffer_size -= old_tensor.element_size() * old_tensor.numel()
+                logger.debug("Dropped cached tensor %s to free space", old_id)
+            self.send_store[tensor_id] = tensor
+            self.buffer_size += tensor_size
+        return True
+
+    def _recv_blocking(
+        self, tensor_id: str, remote_address: Optional[str]
+    ) -> Optional[torch.Tensor]:
+        start = time.time()
+        with self.recv_store_cv:
+            while tensor_id not in self.recv_store:
+                self.recv_store_cv.wait()
+            tensor = self.recv_store.pop(tensor_id)
+        duration_ms = (time.time() - start) * 1e3
+        logger.debug("Received tensor %s from %s in %.2f ms", tensor_id, remote_address, duration_ms)
+        return tensor
+
+    def _recv_via_get(
+        self, tensor_id: str, remote_address: str
+    ) -> Optional[torch.Tensor]:
+        sock, (comm, rank) = self._create_connect(remote_address)
+        sock.send(msgpack.dumps({"cmd": "GET", "tensor_id": tensor_id}))
+        meta = msgpack.loads(sock.recv())
+        if meta["ret"] != 0:
+            logger.warning("Peer lacked tensor %s", tensor_id)
+            return None
+
+        tensor = torch.empty(meta["shape"], dtype=getattr(torch, meta["dtype"]), device=self.device)
+        self._flagcx_recv(comm, tensor, rank ^ 1)
+        return tensor
+
+    # ---------------------------------------------------------------------
+    # Background threads
+    # ---------------------------------------------------------------------
+
+    def _listen_for_requests(self):
+        while True:
+            for sock, _ in self.poller.poll():
+                if sock is self.router_socket:
+                    remote_address, payload = self.router_socket.recv_multipart()
+                    self._handle_router_message(remote_address, payload)
+
+    def _handle_router_message(self, remote_address: bytes, payload: bytes):
+        data = msgpack.loads(payload)
+        raddr = remote_address.decode()
+        cmd = data["cmd"]
+
+        if cmd == "NEW":
+            unique_id = self.flagcx.unique_id_from_bytes(bytes(data["unique_id"]))
+            with torch.cuda.device(self.device):
+                rank = 1  # the *acceptor* side of the connection
+                comm: flagcxComm_t = self.flagcx.flagcxCommInitRank(2, unique_id, rank)
+            self.comms[raddr] = (comm, rank)
+            logger.info("Established reverse connection %s ← %s", self.zmq_address, raddr)
+            return
+
+        if cmd == "PUT":
+            self._handle_put(raddr, data)
+        elif cmd == "GET":
+            self._handle_get(raddr, data)
+        else:
+            logger.warning("Unknown command %s from %s", cmd, raddr)
+
+    def _handle_put(self, raddr: str, data: dict[str, Any]):
+        tensor = torch.empty(
+            data["shape"], dtype=getattr(torch, data["dtype"]), device=self.device
+        )
+        tensor_size = tensor.element_size() * tensor.numel()
+        if (self.buffer_size + tensor_size) > self.buffer_size_threshold:
+            self.router_socket.send_multipart([raddr.encode(), b"2"])  # threshold hit
+            return
+        self.router_socket.send_multipart([raddr.encode(), b"0"])  # OK
+        comm, rank = self.comms[raddr]
+        self._flagcx_recv(comm, tensor, rank ^ 1)
+        tensor_id = data["tensor_id"]
+        with self.recv_store_cv:
+            self.recv_store[tensor_id] = tensor
+            self.recv_store_cv.notify()
+        self.buffer_size += tensor_size
+
+    def _handle_get(self, raddr: str, data: dict[str, Any]):
+        tensor_id = data["tensor_id"]
+        with self.send_store_cv:
+            tensor = self.send_store.pop(tensor_id, None)
+            if tensor is None:
+                self.router_socket.send_multipart([raddr.encode(), msgpack.dumps({"ret": 1})])
+                return
+            meta = {
+                "ret": 0,
+                "shape": tensor.shape,
+                "dtype": str(tensor.dtype).replace("torch.", ""),
+            }
+            self.router_socket.send_multipart([raddr.encode(), msgpack.dumps(meta)])
+        comm, rank = self.comms[raddr]
+        self._flagcx_send(comm, tensor.to(self.device), rank ^ 1)
+
+    # ---------------------------------------------------------------------
+    # Low‑level FlagCX wrappers (thread‑safe)
+    # ---------------------------------------------------------------------
+
+    def _flagcx_send(self, comm: flagcxComm_t, tensor: torch.Tensor, dst: int):
+        assert tensor.device == self.device
+        stream = current_stream()
+        with self.comm_cv:
+            self.flagcx.flagcxSend(
+                buffer_type(tensor.data_ptr()),
+                tensor.numel(),
+                flagcxDataTypeEnum.from_torch(tensor.dtype),
+                dst,
+                comm,
+                cudaStream_t(stream.cuda_stream),
+            )
+
+    def _flagcx_recv(self, comm: flagcxComm_t, tensor: torch.Tensor, src: int):
+        assert tensor.device == self.device
+        stream = current_stream()
+        with self.comm_cv:
+            self.flagcx.flagcxRecv(
+                buffer_type(tensor.data_ptr()),
+                tensor.numel(),
+                flagcxDataTypeEnum.from_torch(tensor.dtype),
+                src,
+                comm,
+                cudaStream_t(stream.cuda_stream),
+            )
+
+    # ---------------------------------------------------------------------
+    # Ping for proxy registration
+    # ---------------------------------------------------------------------
+
+    def _ping(self):
+        sock = self.context.socket(zmq.DEALER)
+        sock.setsockopt_string(zmq.IDENTITY, self.zmq_address)
+        sock.connect(f"tcp://{self.proxy_address}")
+        payload = {
+            "type": "P" if self.config.is_kv_producer else "D",
+            "http_address": self.http_address,
+            "zmq_address": self.zmq_address,
+        }
+        while True:
+            sock.send(msgpack.dumps(payload))
+            time.sleep(3)
+
+    # ---------------------------------------------------------------------
+    # Teardown
+    # ---------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Join background threads and close ZMQ context."""
+        self._listener_thread.join()
+        if self.send_type == "PUT_ASYNC":
+            self._send_thread.join()
+        if self._ping_thread is not None:
+            self._ping_thread.join()
+        self.context.destroy(linger=0)

--- a/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe_origin.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe_origin.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import threading
+import time
+import typing
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional
+
+import msgpack
+import torch
+import zmq
+
+from vllm.config import KVTransferConfig
+from vllm.distributed.device_communicators.pynccl_wrapper import (
+    NCCLLibrary, buffer_type, cudaStream_t, ncclComm_t, ncclDataTypeEnum)
+from vllm.utils import current_stream, get_ip
+
+logger = logging.getLogger(__name__)
+
+
+class P2pNcclPipe:
+
+    def __init__(self,
+                 local_rank: int,
+                 config: KVTransferConfig,
+                 hostname: str = "",
+                 port_offset: int = 0,
+                 library_path: Optional[str] = None) -> None:
+        self.config = config
+        self.rank = port_offset
+        self.local_rank = local_rank
+        self.device = torch.device(f"cuda:{self.local_rank}")
+        self.nccl = NCCLLibrary(library_path)
+
+        if not hostname:
+            hostname = get_ip()
+        port = self.config.kv_port + port_offset
+        if port == 0:
+            raise ValueError("Port cannot be 0")
+        self._hostname = hostname
+        self._port = port
+
+        # Each card corresponds to a ZMQ address.
+        self.zmq_address = f"{self._hostname}:{self._port}"
+
+        # The `http_port` must be consistent with the port of OpenAI.
+        self.http_address = (
+            f"{self._hostname}:"
+            f"{self.config.kv_connector_extra_config['http_port']}")
+
+        # If `proxy_ip` or `proxy_port` is `""`,
+        # then the ping thread will not be enabled.
+        proxy_ip = self.config.get_from_extra_config("proxy_ip", "")
+        proxy_port = self.config.get_from_extra_config("proxy_port", "")
+        if proxy_ip == "" or proxy_port == "":
+            self.proxy_address = ""
+        else:
+            self.proxy_address = proxy_ip + ":" + proxy_port
+
+        self.context = zmq.Context()
+        self.router_socket = self.context.socket(zmq.ROUTER)
+        self.router_socket.bind(f"tcp://{self.zmq_address}")
+
+        self.poller = zmq.Poller()
+        self.poller.register(self.router_socket, zmq.POLLIN)
+
+        self.send_store_cv = threading.Condition()
+        self.send_queue_cv = threading.Condition()
+        self.recv_store_cv = threading.Condition()
+        self.comm_cv = threading.Condition()
+
+        # The sending type includes tree mutually exclusive options:
+        # PUT, GET, PUT_ASYNC.
+        self.send_type = self.config.get_from_extra_config("send_type", "PUT")
+        if self.send_type == "GET":
+            self.send_store: Dict[str,
+                                  torch.Tensor] = {}  # tensor_id: torch.Tensor
+        else:
+            # PUT or PUT_ASYNC
+            self.send_queue: Deque[
+                List[Any]] = deque()  # tensor_id: torch.Tensor
+            if self.send_type == "PUT_ASYNC":
+                self._send_thread = threading.Thread(target=self._send_async,
+                                                     daemon=True)
+                self._send_thread.start()
+
+        self.recv_store: Dict[str,
+                              torch.Tensor] = {}  # tensor_id: torch.Tensor
+        self.socks: Dict[str, Any] = {}  # remote_address: client socket
+        self.comms: Dict[str, Any] = {}  # remote_address: (ncclComm_t, rank)
+
+        self.buffer_size = 0
+        self.buffer_size_threshold = self.config.kv_buffer_size
+
+        self._listener_thread = threading.Thread(
+            target=self._listen_for_requests, daemon=True)
+        self._listener_thread.start()
+
+        self._ping_thread = None
+        if port_offset == 0 and self.proxy_address != "":
+            self._ping_thread = threading.Thread(target=self._ping,
+                                                 daemon=True)
+            self._ping_thread.start()
+
+    def _create_connect(self, remote_address: typing.Optional[str] = None):
+        assert remote_address is not None
+        if remote_address not in self.socks:
+            sock = self.context.socket(zmq.DEALER)
+            sock.setsockopt_string(zmq.IDENTITY, self.zmq_address)
+            sock.connect(f"tcp://{remote_address}")
+            self.socks[remote_address] = sock
+            if remote_address in self.comms:
+                logger.info("��comm exists, remote_address:%s, comms:%s",
+                            remote_address, self.comms)
+                return sock, self.comms[remote_address]
+
+            unique_id = self.nccl.ncclGetUniqueId()
+            data = {"cmd": "NEW", "unique_id": bytes(unique_id.internal)}
+            sock.send(msgpack.dumps(data))
+
+            with torch.cuda.device(self.device):
+                rank = 0
+                comm: ncclComm_t = self.nccl.ncclCommInitRank(
+                    2, unique_id, rank)
+                self.comms[remote_address] = (comm, rank)
+                logger.info("🤝ncclCommInitRank Success, %s👉%s, MyRank: %s",
+                            self.zmq_address, remote_address, rank)
+
+        return self.socks[remote_address], self.comms[remote_address]
+
+    def send_tensor(
+        self,
+        tensor_id: str,
+        tensor: torch.Tensor,
+        remote_address: typing.Optional[str] = None,
+    ) -> bool:
+        if remote_address is None:
+            with self.recv_store_cv:
+                self.recv_store[tensor_id] = tensor
+                self.recv_store_cv.notify()
+            return True
+        else:
+            if self.send_type == "PUT":
+                return self._send_sync(tensor_id, tensor, remote_address)
+            elif self.send_type == "PUT_ASYNC":
+                with self.send_queue_cv:
+                    self.send_queue.append([tensor_id, remote_address, tensor])
+                    self.send_queue_cv.notify()
+            else:  # GET
+                with self.send_store_cv:
+                    tensor_size = tensor.element_size() * tensor.numel()
+                    while (self.buffer_size + tensor_size
+                           > self.buffer_size_threshold):
+                        oldest_tenser_id = next(iter(self.send_store))
+                        oldest_tenser = self.send_store.pop(oldest_tenser_id)
+                        oldest_tenser_size = oldest_tenser.element_size(
+                        ) * oldest_tenser.numel()
+                        self.buffer_size -= oldest_tenser_size
+                        logger.info(
+                            "⛔[GET]Send to %s, tensor_id:%s, tensor_size:%d,"
+                            " buffer_size:%d, oldest_tenser_size:%d, rank:%d",
+                            remote_address, tensor_id, tensor_size,
+                            self.buffer_size, oldest_tenser_size, self.rank)
+
+                    self.send_store[tensor_id] = tensor
+                    self.buffer_size += tensor_size
+                    logger.info(
+                        "🔵[GET]Send to %s, tensor_id:%s, tensor_size:%d, "
+                        "shape:%s, rank:%d, buffer_size:%d(%.2f%%)",
+                        remote_address, tensor_id, tensor_size, tensor.shape,
+                        self.rank, self.buffer_size,
+                        self.buffer_size / self.buffer_size_threshold * 100)
+
+        return True
+
+    def recv_tensor(
+        self,
+        tensor_id: str,
+        remote_address: typing.Optional[str] = None,
+    ) -> torch.Tensor:
+        if self.send_type == "PUT" or self.send_type == "PUT_ASYNC":
+            start_time = time.time()
+            with self.recv_store_cv:
+                while tensor_id not in self.recv_store:
+                    self.recv_store_cv.wait()
+                # TODO:Abatom, To avoid an overly large dictionary.
+                # tensor = self.recv_store.pop(tensor_id)
+                tensor = self.recv_store[tensor_id]
+                self.recv_store[tensor_id] = None
+            duration = time.time() - start_time
+            if tensor is not None:
+                self.buffer_size -= (tensor.element_size() * tensor.numel())
+                logger.info(
+                    "🔵[PUT]Recv From %s, tensor_id:%s, shape:%s, "
+                    "duration:%.3fms, size:%.3fGB, rank:%d", remote_address,
+                    tensor_id, tensor.shape, duration * 1000,
+                    tensor.element_size() * tensor.numel() / 1024**3,
+                    self.rank)
+            else:
+                logger.warning(
+                    "🔴[PUT]Recv From %s, tensor_id:%s, duration:%.3fms, "
+                    "rank:%d", remote_address, tensor_id, duration * 1000,
+                    self.rank)
+            return tensor
+
+        # GET
+        if remote_address is None:
+            return None
+
+        if remote_address not in self.socks:
+            self._create_connect(remote_address)
+
+        sock = self.socks[remote_address]
+        comm, rank = self.comms[remote_address]
+
+        data = {"cmd": "GET", "tensor_id": tensor_id}
+        sock.send(msgpack.dumps(data))
+
+        message = sock.recv()
+        data = msgpack.loads(message)
+        if data["ret"] != 0:
+            logger.warning("🔴[GET]Recv From %s, tensor_id: %s, ret: %d",
+                           remote_address, tensor_id, data["ret"])
+            return None
+
+        tensor = torch.empty(data["shape"],
+                             dtype=getattr(torch, data["dtype"]),
+                             device=self.device)
+
+        start_time = time.time()
+        self._recv(comm, tensor, rank ^ 1)
+        duration = time.time() - start_time
+        logger.info(
+            "🔵[GET]Recv From %s, tensor_id:%s, shape:%s, duration:%.3fms, "
+            "size:%.3fGB, rank:%d", remote_address, tensor_id, tensor.shape,
+            duration * 1000,
+            tensor.element_size() * tensor.numel() / 1024**3, self.rank)
+
+        return tensor
+
+    def _listen_for_requests(self):
+        while True:
+            socks = dict(self.poller.poll())
+            if self.router_socket in socks:
+                remote_address, message = self.router_socket.recv_multipart()
+                data = msgpack.loads(message)
+                logger.debug("Received message from %s, data:%s",
+                             remote_address.decode(), data)
+                if data["cmd"] == "NEW":
+                    unique_id = self.nccl.unique_id_from_bytes(
+                        bytes(data["unique_id"]))
+                    with torch.cuda.device(self.device):
+                        rank = 1
+                        comm: ncclComm_t = self.nccl.ncclCommInitRank(
+                            2, unique_id, rank)
+                        self.comms[remote_address.decode()] = (comm, rank)
+                        logger.info(
+                            "🤝ncclCommInitRank Success, %s👈%s, MyRank:%s",
+                            self.zmq_address, remote_address.decode(), rank)
+                elif data["cmd"] == "PUT":
+                    try:
+                        tensor = torch.empty(data["shape"],
+                                             dtype=getattr(
+                                                 torch, data["dtype"]),
+                                             device=self.device)
+
+                        tensor_size = tensor.element_size() * tensor.numel()
+                        if (self.buffer_size + tensor_size
+                                > self.buffer_size_threshold):
+                            self.router_socket.send_multipart(
+                                [remote_address, b"2"])
+                            logger.warning(
+                                "🔴[PUT]Recv Tensor, Out Of Threshold, "
+                                "%s👈%s, data:%s", self.zmq_address,
+                                remote_address.decode(), data)
+                            tensor = None
+                        else:
+                            self.buffer_size += tensor_size
+                            self.router_socket.send_multipart(
+                                [remote_address, b"0"])
+                            comm, rank = self.comms[remote_address.decode()]
+                            self._recv(comm, tensor, rank ^ 1)
+                            logger.info(
+                                "🔵[PUT]Recv Tensor, %s👈%s, MyRank:%s, data:%s, "
+                                "shape:%s", self.zmq_address,
+                                remote_address.decode(), rank, data, tensor.shape)
+
+                        tensor_id = data["tensor_id"]
+                        with self.recv_store_cv:
+                            self.recv_store[tensor_id] = tensor
+                            self.recv_store_cv.notify()
+
+                    except torch.cuda.OutOfMemoryError:
+                        self.router_socket.send_multipart(
+                            [remote_address, b"1"])
+                        logger.warning(
+                            "🔴[PUT]Recv Tensor, Out Of Memory, %s👈%s, "
+                            "data:%s", self.zmq_address,
+                            remote_address.decode(), data)
+
+                elif data["cmd"] == "GET":
+                    tensor_id = data["tensor_id"]
+                    with self.send_store_cv:
+                        tensor = self.send_store.pop(tensor_id, None)
+                        if tensor is not None:
+                            data = {
+                                "ret": 0,
+                                "shape": tensor.shape,
+                                "dtype":
+                                str(tensor.dtype).replace("torch.", "")
+                            }
+                            # LRU
+                            self.send_store[tensor_id] = tensor
+                        else:
+                            data = {"ret": 1}
+
+                    self.router_socket.send_multipart(
+                        [remote_address, msgpack.dumps(data)])
+
+                    if data["ret"] == 0:
+                        self._send(comm, tensor.to(self.device), rank ^ 1)
+
+                    logger.info(
+                        "🔵[GET]Send Tensor, %s👉%s, "
+                        "MyRank:%s, data:%s", self.zmq_address,
+                        remote_address.decode(), rank, data)
+                else:
+                    logger.warning(
+                        "🚧Unexpected, Received message from %s, data:%s",
+                        remote_address, data)
+
+    # Asynchronous sending may cause conflicts between P2P NCCL and
+    # NCCL used in TP/PP, which can lead to deadlock issues.
+    def _send_async(self):
+        while True:
+            with self.send_queue_cv:
+                while not self.send_queue:
+                    self.send_queue_cv.wait()
+                tensor_id, remote_address, tensor = self.send_queue.popleft()
+            self._send_sync(tensor_id, tensor, remote_address)
+
+    def _send_sync(
+        self,
+        tensor_id: str,
+        tensor: torch.Tensor,
+        remote_address: typing.Optional[str] = None,
+    ) -> bool:
+        if remote_address is None:
+            return False
+        if remote_address not in self.socks:
+            self._create_connect(remote_address)
+
+        sock = self.socks[remote_address]
+        comm, rank = self.comms[remote_address]
+        data = {
+            "cmd": "PUT",
+            "tensor_id": tensor_id,
+            "shape": tensor.shape,
+            "dtype": str(tensor.dtype).replace("torch.", "")
+        }
+        sock.send(msgpack.dumps(data))
+
+        response = sock.recv()
+        if response != b"0":
+            # with self.send_queue_cv:
+            #     self.send_queue.append([tensor_id, remote_address, tensor])
+            #     self.send_queue_cv.notify()
+            logger.warning(
+                "🔴Send Tensor, Peer Out Of Memory/Threshold, %s 👉 %s, "
+                "MyRank:%s, data:%s, tensor:%s, size:%fGB, response:%s",
+                self.zmq_address, remote_address, rank, data, tensor.shape,
+                tensor.element_size() * tensor.numel() / 1024**3,
+                response.decode())
+            return False
+
+        self._send(comm, tensor.to(self.device), rank ^ 1)
+        logger.info("🔵Send Tensor, %s👉%s, MyRank:%s, data:%s, tensor:%s",
+                    self.zmq_address, remote_address, rank, data, tensor.shape)
+        return True
+
+    def _ping(self):
+        sock = self.context.socket(zmq.DEALER)
+        sock.setsockopt_string(zmq.IDENTITY, self.zmq_address)
+        logger.debug("ping start, zmq_address:%s", self.zmq_address)
+        sock.connect(f"tcp://{self.proxy_address}")
+        data = {
+            "type": "P" if self.config.is_kv_producer else "D",
+            "http_address": self.http_address,
+            "zmq_address": self.zmq_address
+        }
+        while True:
+            sock.send(msgpack.dumps(data))
+            time.sleep(3)
+
+    def _send(self, comm, tensor: torch.Tensor, dst: int, stream=None):
+        assert tensor.device == self.device, (
+            f"this nccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}")
+        if stream is None:
+            stream = current_stream()
+
+        with self.comm_cv:
+            self.nccl.ncclSend(buffer_type(tensor.data_ptr()), tensor.numel(),
+                               ncclDataTypeEnum.from_torch(tensor.dtype), dst,
+                               comm, cudaStream_t(stream.cuda_stream))
+
+    def _recv(self, comm, tensor: torch.Tensor, src: int, stream=None):
+        assert tensor.device == self.device, (
+            f"this nccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}")
+        if stream is None:
+            stream = current_stream()
+
+        with self.comm_cv:
+            self.nccl.ncclRecv(buffer_type(tensor.data_ptr()), tensor.numel(),
+                               ncclDataTypeEnum.from_torch(tensor.dtype), src,
+                               comm, cudaStream_t(stream.cuda_stream))
+
+    def close(self) -> None:
+        self._listener_thread.join()
+        if self.send_type == "PUT_ASYNC":
+            self._send_thread.join()
+        if self._ping_thread is not None:
+            self._ping_thread.join()

--- a/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_pipe/pynccl_pipe.py
+++ b/flagscale/inference/backends/vllm/vllm/distributed/kv_transfer/kv_pipe/pynccl_pipe.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+    This module implements a PyNccl pipe for sending and receiving
+    Optional[torch.Tensor] between distributed ranks with advanced
+    communication features.
+
+    Key Features:
+    - Supports sending and receiving tensors with metadata
+    - Handles both CUDA and CPU device communications
+    - Implements a non-blocking tensor transfer mechanism
+    - Manages buffer size and provides backpressure control
+    - Supports distributed process groups with configurable parameters
+"""
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Dict, Optional, Tuple
+import os
+
+import torch
+
+from vllm.config import KVTransferConfig
+from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+from vllm.distributed.device_communicators.pyflagcx import PyFlagcxCommunicator
+from vllm.distributed.kv_transfer.kv_pipe.base import KVPipeBase
+from vllm.distributed.utils import StatelessProcessGroup
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class BrokenPipeException(Exception):
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+Metadata = Dict[str, Optional[torch.Tensor]]
+
+
+class PyNcclPipe(KVPipeBase):
+
+    METADATA_LENGTH = 16
+    MAX_TENSOR_DIMENSIONS = 14
+    METADATA_DTYPE = torch.int64
+
+    def __init__(self,
+                 local_rank: int,
+                 config: KVTransferConfig,
+                 device: Optional[str] = None,
+                 port_offset: int = 0):
+        self.config = config
+        self.local_rank = local_rank
+        self.kv_rank = self.config.kv_rank
+        self.kv_parallel_size = self.config.kv_parallel_size
+        if device is None:
+            self.device = self._select_device(self.config.kv_buffer_device)
+        else:
+            self.device = self._select_device(device)
+
+        # build distributed connection and send/recv implementation
+        store_timeout = self.config.get_from_extra_config("store_timeout", 300)
+        self.group = StatelessProcessGroup.create(
+            host=self.config.kv_ip,
+            port=self.config.kv_port + port_offset,
+            rank=self.kv_rank,
+            world_size=self.kv_parallel_size,
+            store_timeout=store_timeout,
+        )
+        # add a barrier to make sure the connection is initiated properly
+        self.group.barrier()
+        impl = self._get_device_send_recv_impl(self.group)
+        self.device_send_func, self.device_recv_func = impl
+        # set target rank
+        self.target_rank_for_send = (self.kv_rank + 1) % self.kv_parallel_size
+        self.target_rank_for_recv = (self.kv_rank - 1) % self.kv_parallel_size
+
+        # transportation-related variables
+        self.transport_thread: Optional[ThreadPoolExecutor] = None
+        self.buffer_size = 0
+        self.buffer_size_lock = threading.Lock()
+        self.buffer_size_thresh = self.config.kv_buffer_size
+
+    def _get_device_send_recv_impl(
+        self, group: StatelessProcessGroup
+    ) -> Tuple[Callable[[torch.Tensor, int], None], Callable[
+        [torch.Tensor, int], None]]:
+
+        send: Callable[[torch.Tensor, int], None]
+        recv: Callable[[torch.Tensor, int], None]
+        if self.device.type == "cuda":
+            try:
+                flagcx_path = os.getenv('FLAGCX_PATH')
+                comm = PyFlagcxCommunicator(group, device=self.local_rank, library_path=os.path.join(flagcx_path, "build/lib/libflagcx.so"))
+                comm.disabled = False
+                send, recv = comm.send, comm.recv  # type: ignore
+            except:
+                # use PyNCCL for send / recv
+                comm = PyNcclCommunicator(group, device=self.local_rank)
+                comm.disabled = False
+                send, recv = comm.send, comm.recv  # type: ignore
+        else:
+            # This send / recv implementation here is NOT intended to transfer
+            # KV caches (and should NOT be repurposed to transfer KV caches).
+            # Currently it is only used to transmit control-plane messages
+            # for PyNcclBuffer.
+            send = group.send_obj
+
+            def my_recv(x, src):
+                x[...] = group.recv_obj(src)
+
+            recv = my_recv
+
+        return send, recv
+
+    def _select_device(self, device: str):
+        logger.info("Selecting device: %s", device)
+        if device == "cuda":
+            return torch.device(f"cuda:{self.local_rank}")
+        else:
+            return torch.device("cpu")
+
+    def _make_metadata(self, tensor: Optional[torch.Tensor]) -> Metadata:
+        """
+        Create the metadata as a dictionary based on the input tensor.
+
+        Parameters:
+            - tensor: The input tensor or None if no tensor is provided.
+
+        Returns:
+            - metadata: A dictionary with the following keys:
+                - "dtype": The data type of the tensor or None.
+                - "shape": The shape of the tensor or None.
+        """
+        if tensor is None:
+            return {"dtype": None, "shape": None}
+        else:
+            return {"dtype": tensor.dtype, "shape": tensor.shape}
+
+    def _prepare_recv_buffer(self, metadata: Metadata) -> torch.Tensor:
+        """
+        Create a buffer to receive the tensor based on the provided metadata.
+
+        Parameters:
+            - metadata: A dictionary with keys "dtype" and "shape", describing
+              the tensor's data type and shape.
+
+        Returns:
+            - buffer: A tensor of the specified type and shape, allocated on
+              self.device.
+        """
+        return torch.empty(metadata["shape"],
+                           dtype=metadata["dtype"],
+                           device=self.device)
+
+    def _send_metadata(self, metadata: Metadata):
+        """
+        Send the metadata dictionary to the target rank.
+
+        Parameters:
+            - metadata: A dictionary with keys "dtype" and "shape".
+        """
+        self.group.send_obj(metadata, self.target_rank_for_send)
+
+    def _recv_metadata(self) -> Metadata:
+        """
+        Receive the metadata dictionary from the target rank.
+
+        Returns:
+            - metadata: A dictionary with keys "dtype" and "shape" describing
+              the tensor.
+        """
+        return self.group.recv_obj(self.target_rank_for_recv)
+
+    def _send_impl(self, tensor: Optional[torch.Tensor]) -> None:
+        """
+        The actual implementation of sending the tensor and its metadata to the
+        target rank.
+
+        Parameters:
+            - tensor: The input tensor to be sent, or None if no tensor is
+              being sent.
+        """
+        metadata = self._make_metadata(tensor)
+        self._send_metadata(metadata)
+        if tensor is not None:
+            self.device_send_func(tensor.to(self.device),
+                                  self.target_rank_for_send)
+
+    def _recv_impl(self) -> Optional[torch.Tensor]:
+        """
+        The actual implementation of receiving a tensor and its metadata from
+        the target rank.
+
+        Returns:
+            - buffer: The received tensor, or None if no tensor is received.
+        """
+        metadata = self._recv_metadata()
+        if metadata["dtype"] is None:
+            return None
+        buffer = self._prepare_recv_buffer(metadata)
+        self.device_recv_func(buffer, self.target_rank_for_recv)
+
+        return buffer
+
+    def send_tensor_wrapper(self, tensor: Optional[torch.Tensor],
+                            tensor_size: int) -> None:
+        """
+        Wrapper for _send_impl to handle exceptions and update buffer size.
+        """
+        try:
+            self._send_impl(tensor)
+
+            with self.buffer_size_lock:
+                self.buffer_size -= tensor_size
+        except Exception as e:
+            logger.error("[rank%d]: Exception when trying to send %s, msg: %s",
+                         torch.distributed.get_rank(), str(tensor), str(e))
+            import traceback
+            traceback.print_exc()
+
+    def block_if_full(self):
+        """
+        Block the current thread if the buffer size is larger than the
+        threshold.
+        """
+        while self.buffer_size > self.buffer_size_thresh:
+            logger.debug("KV cache transfer pipe is full. Waiting...")
+            time.sleep(0.05)
+
+    def send_tensor(self, tensor: Optional[torch.Tensor]) -> None:
+        """
+        Sends a tensor and its metadata to the destination rank in a
+        non-blocking way.
+
+        Parameters:
+            - tensor: The tensor to send, or None if no tensor is being sent.
+        """
+        if self.transport_thread is None:
+            self.transport_thread = ThreadPoolExecutor(max_workers=1)
+
+        if tensor is not None:
+            tensor_size = tensor.element_size() * tensor.numel()
+        else:
+            tensor_size = 0
+
+        self.block_if_full()
+
+        with self.buffer_size_lock:
+            self.buffer_size += tensor_size
+
+        self.transport_thread.submit(self.send_tensor_wrapper, tensor,
+                                     tensor_size)
+
+    def recv_tensor(self) -> Optional[torch.Tensor]:
+        """
+        Receives a tensor and its metadata from the source rank. Blocking call.
+
+        Returns:
+            - tensor: The received tensor, or None if no tensor is received.
+        """
+        if self.transport_thread is None:
+            self.transport_thread = ThreadPoolExecutor(max_workers=1)
+
+        future = self.transport_thread.submit(self._recv_impl)
+
+        try:
+            tensor = future.result()
+        except Exception as e:
+            logger.error("Encountering exception in KV receiving thread")
+            logger.error("%s", e)
+            logger.error("My device: %s", self.device)
+            import traceback
+            traceback.print_exc()
+            raise e
+
+        return tensor
+
+    def close(self):
+        """
+        Close the pipe and release associated resources.
+        """
+        if hasattr(self,
+                   "transport_thread") and self.transport_thread is not None:
+            self.transport_thread.shutdown()

--- a/tests/pd_dissag/call.sh
+++ b/tests/pd_dissag/call.sh
@@ -1,0 +1,8 @@
+curl -X POST -s http://localhost:10001/v1/completions \
+-H "Content-Type: application/json" \
+-d '{
+"model": "base_model",
+"prompt": "Introduce Bruce Lee in details",
+"max_tokens": 100,
+"temperature": 0
+}'

--- a/tests/pd_dissag/disagg_prefill_1p1d.sh
+++ b/tests/pd_dissag/disagg_prefill_1p1d.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -xe
+export NCCL_SOCKET_IFNAME=bond0 && export FLAGCX_SOCKET_IFNAME=bond0 && export VLLM_USE_V1=0 && export FLAGCX_PATH=/mine/ip122/tune_qwen/FlagCX/ && export FLAGCX_DEBUG=TRACE && export FLAGCX_DEBUG_SUBSYS=ALL && export NCCL_DEBUG=TRACE && export NCCL_DEBUG_SUBSYS=ALL
+# Trap the SIGINT signal (triggered by Ctrl+C)
+trap 'cleanup' INT
+
+# Cleanup function
+cleanup() {
+    echo "Caught Ctrl+C, cleaning up..."
+    # Cleanup commands
+    pgrep python | xargs kill -9
+    pkill -f python
+    echo "Cleanup complete. Exiting."
+    exit 0
+}
+
+export VLLM_HOST_IP=$(hostname -I | awk '{print $1}')
+
+python3 disagg_prefill_proxy_xpyd.py &
+
+#MODEL_NAME=${HF_MODEL_NAME:-meta-llama/Meta-Llama-3.1-8B-Instruct}
+
+MODEL_NAME=/models/Qwen2.5-0.5B-Instruct
+
+## 2P2D, TP=1
+## prefilling instance, which is the KV producer
+#CUDA_VISIBLE_DEVICES=4 vllm serve $MODEL_NAME \
+#    --host 0.0.0.0 \
+#    --port 20001 \
+#    --served-model-name base_model \
+#    --max-model-len 8192 \
+#    --gpu-memory-utilization 0.8 \
+#    --kv-transfer-config \
+#    '{"kv_connector":"P2pConnector","kv_role":"kv_producer","kv_port":"21001","kv_connector_extra_config":{"proxy_ip":"0.0.0.0","proxy_port":"30001","http_port":"20001"}}' &
+#
+## prefilling instance, which is the KV producer
+#CUDA_VISIBLE_DEVICES=5 vllm serve $MODEL_NAME \
+#    --host 0.0.0.0 \
+#    --port 20002 \
+#    --served-model-name base_model \
+#    --max-model-len 8192 \
+#    --gpu-memory-utilization 0.8 \
+#    --kv-transfer-config \
+#    '{"kv_connector":"P2pConnector","kv_role":"kv_producer","kv_port":"22001","kv_connector_extra_config":{"proxy_ip":"0.0.0.0","proxy_port":"30001","http_port":"20002"}}' &
+#
+## decoding instance, which is the KV consumer
+#CUDA_VISIBLE_DEVICES=6 vllm serve $MODEL_NAME \
+#    --host 0.0.0.0 \
+#    --port 20003 \
+#    --served-model-name base_model \
+#    --max-model-len 8192 \
+#    --gpu-memory-utilization 0.8 \
+#    --kv-transfer-config \
+#    '{"kv_connector":"P2pConnector","kv_role":"kv_consumer","kv_port":"23001","kv_connector_extra_config":{"proxy_ip":"0.0.0.0","proxy_port":"30001","http_port":"20003"}}' &
+#
+## decoding instance, which is the KV consumer
+#CUDA_VISIBLE_DEVICES=7 vllm serve $MODEL_NAME \
+#    --host 0.0.0.0 \
+#    --port 20004 \
+#    --served-model-name base_model \
+#    --max-model-len 8192 \
+#    --gpu-memory-utilization 0.8 \
+#    --kv-transfer-config \
+#    '{"kv_connector":"P2pConnector","kv_role":"kv_consumer","kv_port":"24001","kv_connector_extra_config":{"proxy_ip":"0.0.0.0","proxy_port":"30001","http_port":"20004"}}' &
+
+
+# 2P2D, TP=2
+# prefilling instance, which is the KV producer
+CUDA_VISIBLE_DEVICES=0 vllm serve $MODEL_NAME \
+    --host 0.0.0.0 \
+    --port 20001 \
+    --tensor-parallel-size 1 \
+    --served-model-name base_model \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config \
+    '{"kv_connector":"P2pConnector","kv_role":"kv_producer","kv_port":"21001","kv_connector_extra_config":{"proxy_ip":"0.0.0.0","proxy_port":"30001","http_port":"20001"}}' &
+
+# decoding instance, which is the KV consumer
+CUDA_VISIBLE_DEVICES=2 vllm serve $MODEL_NAME \
+    --host 0.0.0.0 \
+    --port 20003 \
+    --tensor-parallel-size 1 \
+    --served-model-name base_model \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config \
+    '{"kv_connector":"P2pConnector","kv_role":"kv_consumer","kv_port":"23001","kv_connector_extra_config":{"proxy_ip":"0.0.0.0","proxy_port":"30001","http_port":"20003"}}' &

--- a/tests/pd_dissag/disagg_prefill_proxy_xpyd.py
+++ b/tests/pd_dissag/disagg_prefill_proxy_xpyd.py
@@ -1,0 +1,154 @@
+import os
+import random
+import socket
+import threading
+import uuid
+
+import aiohttp
+import msgpack
+import zmq
+from quart import Quart, make_response, request
+
+prefill_instances: dict[str, str] = {}  # http_address: zmq_address
+decode_instances: dict[str, str] = {}  # http_address: zmq_address
+
+prefill_cv = threading.Condition()
+decode_cv = threading.Condition()
+
+
+def _listen_for_register(poller, router_socket):
+    while True:
+        socks = dict(poller.poll())
+        if router_socket in socks:
+            remote_address, message = router_socket.recv_multipart()
+            # data: {"type": "P", "http_address": "ip:port",
+            #        "zmq_address": "ip:port"}
+            data = msgpack.loads(message)
+            # print("Received message from %s, data: %s",
+            #              remote_address.decode(), data)
+            if data["type"] == "P":
+                global prefill_instances
+                global prefill_cv
+                with prefill_cv:
+                    prefill_instances[data["http_address"]] = data["zmq_address"]
+            elif data["type"] == "D":
+                global decode_instances
+                global decode_cv
+                with decode_cv:
+                    decode_instances[data["http_address"]] = data["zmq_address"]
+            else:
+                print(
+                    "Unexpected, Received message from %s, data: %s",
+                    remote_address,
+                    data,
+                )
+
+
+def start_service_discovery(hostname, port):
+    if not hostname:
+        hostname = socket.gethostname()
+    if port == 0:
+        raise ValueError("Port cannot be 0")
+
+    context = zmq.Context()
+    router_socket = context.socket(zmq.ROUTER)
+    router_socket.bind(f"tcp://{hostname}:{port}")
+
+    poller = zmq.Poller()
+    poller.register(router_socket, zmq.POLLIN)
+
+    _listener_thread = threading.Thread(
+        target=_listen_for_register, args=[poller, router_socket], daemon=True
+    )
+    _listener_thread.start()
+    return _listener_thread
+
+
+AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
+
+app = Quart(__name__)
+
+
+def random_uuid() -> str:
+    return str(uuid.uuid4().hex)
+
+
+async def forward_request(url, data, request_id):
+    async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+        headers = {
+            "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+            "X-Request-Id": request_id,
+        }
+        async with session.post(url=url, json=data, headers=headers) as response:
+            if response.status == 200:
+                # if response.headers.get('Transfer-Encoding') == 'chunked':
+                if True:
+                    async for chunk_bytes in response.content.iter_chunked(1024):
+                        yield chunk_bytes
+                else:
+                    content = await response.read()
+                    yield content
+
+
+@app.route("/v1/completions", methods=["POST"])
+async def handle_request():
+    try:
+        original_request_data = await request.get_json()
+
+        prefill_request = original_request_data.copy()
+        # change max_tokens = 1 to let it only do prefill
+        prefill_request["max_tokens"] = 1
+
+        global prefill_instances
+        global prefill_cv
+        with prefill_cv:
+            prefill_addr, prefill_zmq_addr = random.choice(
+                list(prefill_instances.items())
+            )
+            print(
+                "handle_request, prefill_addr: %s, zmq_addr: %s",
+                prefill_addr,
+                prefill_zmq_addr,
+            )
+
+        global decode_instances
+        global decode_cv
+        with decode_cv:
+            decode_addr, decode_zmq_addr = random.choice(list(decode_instances.items()))
+            print(
+                "handle_request, decode_addr: %s, zmq_addr: %s",
+                decode_addr,
+                decode_zmq_addr,
+            )
+
+        request_id = f"___prefill_addr_{prefill_zmq_addr}___decode_addr_{decode_zmq_addr}_{random_uuid()}"
+
+        # finish prefill
+        async for _ in forward_request(
+            f"http://{prefill_addr}/v1/completions", prefill_request, request_id
+        ):
+            continue
+
+        # return decode
+        generator = forward_request(
+            f"http://{decode_addr}/v1/completions", original_request_data, request_id
+        )
+        response = await make_response(generator)
+        response.timeout = None
+
+        return response
+
+    except Exception as e:
+        import sys
+        import traceback
+
+        exc_info = sys.exc_info()
+        print("Error occurred in disagg prefill proxy server")
+        print(e)
+        print("".join(traceback.format_exception(*exc_info)))
+
+
+if __name__ == "__main__":
+    t = start_service_discovery("0.0.0.0", 30001)
+    app.run(host="0.0.0.0", port=10001)
+    t.join()


### PR DESCRIPTION
**p2pconnector_1p1d**
```
bash disagg_prefill_1p1d.sh
bash call.sh
```
```
baai-flagscale-2:805330:805330 [0] FLAGCX INFO rank = 0, nranks = 2, nclusters = 1, cluster_id = 0, cluster_size = 2, cluster_inter_rank = -1, homo_rank = 0, homo_root_rank = 0, homo_inter_rank = -1, homo_ranks = 2, has_single_rank_homo_comm = 0, support_multi_nic = -1
baai-flagscale-2:805402:805555 [0] FLAGCX INFO rank = 1, nranks = 2, nclusters = 1, cluster_id = 0, cluster_size = 2, cluster_inter_rank = -1, homo_rank = 1, homo_root_rank = 0, homo_inter_rank = -1, homo_ranks = 2, has_single_rank_homo_comm = 0, support_multi_nic = -1
baai-flagscale-2:805330:805330 [0] NCCL INFO NCCL_SOCKET_IFNAME set by environment to bond0
baai-flagscale-2:805330:805330 [0] NCCL INFO NCCL_SOCKET_IFNAME set to bond0
baai-flagscale-2:805330:805330 [0] NCCL INFO Bootstrap : Using bond0:10.1.1.122<0>
baai-flagscale-2:805330:805330 [0] NCCL INFO NET/Plugin: No plugin found (libnccl-net.so)
baai-flagscale-2:805330:805330 [0] NCCL INFO NET/Plugin: Plugin load returned 2 : libnccl-net.so: cannot open shared object file: No such file or directory : when loading libnccl-net.so
baai-flagscale-2:805330:805330 [0] NCCL INFO NET/Plugin: Using internal network plugin.
baai-flagscale-2:805330:805330 NCCL CALL ncclGetUniqueId(0x76343cae386b1299)
baai-flagscale-2:805330:805330 [0] 40.328052 bootstrapAllGather:467 FLAGCX TRACE rank 0 nranks 2 size 256

baai-flagscale-2:805330:805330 [0] flagcx/core/socket.cc:55 FLAGCX WARN socketProgress: Connection closed by remote peer 10.1.1.122<43180>
baai-flagscale-2:805330:805330 [0] FLAGCX INFO flagcx/core/socket.cc:810 -> 6
baai-flagscale-2:805330:805330 [0] FLAGCX INFO flagcx/service/bootstrap.cc:86 -> 6
baai-flagscale-2:805330:805330 [0] FLAGCX INFO flagcx/service/bootstrap.cc:431 -> 6
baai-flagscale-2:805330:805330 [0] FLAGCX INFO flagcx/service/bootstrap.cc:469 -> 6
baai-flagscale-2:805330:805330 [0] FLAGCX INFO flagcx/flagcx.cc:332 -> 6
CRITICAL 04-24 11:55:59 [launcher.py:116] MQLLMEngine is already dead, terminating server process
INFO:     10.14.4.45:59090 - "POST /v1/completions HTTP/1.1" 500 Internal Server Error
ERROR 04-24 11:55:59 [engine.py:160] RuntimeError('FLAGCX error: Not implemented.')
ERROR 04-24 11:55:59 [engine.py:160] Traceback (most recent call last):
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 158, in start
ERROR 04-24 11:55:59 [engine.py:160]     self.run_engine_loop()
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 221, in run_engine_loop
ERROR 04-24 11:55:59 [engine.py:160]     request_outputs = self.engine_step()
ERROR 04-24 11:55:59 [engine.py:160]                       ^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 247, in engine_step
ERROR 04-24 11:55:59 [engine.py:160]     raise e
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 230, in engine_step
ERROR 04-24 11:55:59 [engine.py:160]     return self.engine.step()
ERROR 04-24 11:55:59 [engine.py:160]            ^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/engine/llm_engine.py", line 1431, in step
ERROR 04-24 11:55:59 [engine.py:160]     outputs = self.model_executor.execute_model(
ERROR 04-24 11:55:59 [engine.py:160]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/executor/executor_base.py", line 140, in execute_model
ERROR 04-24 11:55:59 [engine.py:160]     output = self.collective_rpc("execute_model",
ERROR 04-24 11:55:59 [engine.py:160]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/executor/uniproc_executor.py", line 56, in collective_rpc
ERROR 04-24 11:55:59 [engine.py:160]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 04-24 11:55:59 [engine.py:160]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/utils.py", line 2378, in run_method
ERROR 04-24 11:55:59 [engine.py:160]     return func(*args, **kwargs)
ERROR 04-24 11:55:59 [engine.py:160]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/worker/worker_base.py", line 420, in execute_model
ERROR 04-24 11:55:59 [engine.py:160]     output = self.model_runner.execute_model(
ERROR 04-24 11:55:59 [engine.py:160]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 04-24 11:55:59 [engine.py:160]     return func(*args, **kwargs)
ERROR 04-24 11:55:59 [engine.py:160]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/worker/model_runner.py", line 1787, in execute_model
ERROR 04-24 11:55:59 [engine.py:160]     get_kv_transfer_group().send_kv_caches_and_hidden_states(
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_transfer_agent.py", line 61, in send_kv_caches_and_hidden_states
ERROR 04-24 11:55:59 [engine.py:160]     self.connector.send_kv_caches_and_hidden_states(
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/p2p_connector.py", line 130, in send_kv_caches_and_hidden_states
ERROR 04-24 11:55:59 [engine.py:160]     self.p2p_nccl_pipe.send_tensor(request_id + "keys", keys,
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe.py", line 177, in send_tensor
ERROR 04-24 11:55:59 [engine.py:160]     return self._send_sync(tensor_id, tensor, remote_address)
ERROR 04-24 11:55:59 [engine.py:160]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe.py", line 234, in _send_sync
ERROR 04-24 11:55:59 [engine.py:160]     sock, (comm, rank) = self._create_connect(remote_address)
ERROR 04-24 11:55:59 [engine.py:160]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_pipe/p2p_nccl_pipe.py", line 221, in _create_connect
ERROR 04-24 11:55:59 [engine.py:160]     comm: flagcxComm_t = self.flagcx.flagcxCommInitRank(2, uid, rank) # cz unique_id --> uid
ERROR 04-24 11:55:59 [engine.py:160]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/distributed/device_communicators/flagcx_wrapper.py", line 285, in flagcxCommInitRank
ERROR 04-24 11:55:59 [engine.py:160]     self.FLAGCX_CHECK(self._funcs["flagcxCommInitRank"](ctypes.byref(comm),
ERROR 04-24 11:55:59 [engine.py:160]   File "/root/miniconda3/envs/flagscale-inference/lib/python3.12/site-packages/vllm/distributed/device_communicators/flagcx_wrapper.py", line 241, in FLAGCX_CHECK
ERROR 04-24 11:55:59 [engine.py:160]     raise RuntimeError(f"FLAGCX error: {error_str}")
ERROR 04-24 11:55:59 [engine.py:160] RuntimeError: FLAGCX error: Not implemented.
INFO 04-24 11:55:59 [logger.py:39] Received request cmpl-___prefill_addr_10.14.4.45:21001___decode_addr_10.14.4.45:23001_be5c991640544d5999f63c2aacd27082-0: prompt: 'Introduce Bruce Lee in details', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.1, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=100, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: [1072, 47845, 23845, 12066, 304, 3565], lora_request: None, prompt_adapter_request: None.
INFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [805031]
```


**offline_pynccl_1p1d**
```
export VLLM_USE_V1=0 && export FLAGCX_PATH=/path/to/FlagCX/ && export FLAGCX_DEBUG=INFO && export FLAGCX_DEBUG_SUBSYS=INIT && python offline_pynccl_1p1d.py
```