### PR TITLE
[Tools] Add patch encryption and enhance patch usability

### DIFF
--- a/flagscale/backends/Megatron-LM/megatron/training/checkpointing.py
+++ b/flagscale/backends/Megatron-LM/megatron/training/checkpointing.py
@@ -637,9 +637,7 @@ def maybe_save_dataloader_state(train_iterator, iteration, dataloader_save_path)
 
     torch.distributed.barrier(group=mpu.get_data_parallel_group())
 
-    if mpu.get_data_parallel_rank() == 0:
-        ensure_directory_exists(data_state_save_path)
-
+    ensure_directory_exists(data_state_save_path)
     torch.distributed.barrier(group=mpu.get_data_parallel_group())
 
     dataloader_save_dict = {}

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -57,6 +57,7 @@ Parameter explanation:
 - `task`: Task scenario(s). Supports multiple tasks separated by space.
 - `device-type`: Chip model, named as `Vendor_Model`, with Vendor capitalized.
 - `commit`: The FlagScale commit this adaptation is based on.
+- `key-path`: If encryption of the patch file is required, specify the path to the key file. If no key file exists at the specified path, one will be generated automatically.
 
 You’ll be prompted to enter 4 interactive inputs: backend version, adapted model, commit message (used for git commit), and contact info (optional).
 
@@ -82,7 +83,8 @@ python tools/patch/unpatch.py --backend Megatron-LM FlagScale --task train --dev
 ```
 The unpatched FlagScale will be under `build/<Chip_Vendor>`.
 
-(Insert screenshots here)
+To decrypt an encrypted patch, refer to the contact information in the corresponding YAML file of the patch and contact the vendor to obtain the key file. When running `unpatch`, you must specify the key file path using `key-path`.
+
 
 ## Q&A
 **Q1: How to manage patches for multiple commits?**  

--- a/hardware/README_CN.md
+++ b/hardware/README_CN.md
@@ -58,7 +58,7 @@ FlagScale 在 **0.8.0** 开始启用新的后端管理方式，不同后端皆�
 
    ```bash
    cd FlagScale
-   python tools/patch/patch.py --backend Megatron-LM FlagScale --task train --device-type Chip_Vendor --commit <commit>>
+   python tools/patch/patch.py --backend Megatron-LM FlagScale --task train --device-type Chip_Vendor --commit <commit>
    ```
 
    **参数解释：**
@@ -67,6 +67,7 @@ FlagScale 在 **0.8.0** 开始启用新的后端管理方式，不同后端皆�
    - `task`：任务场景。支持多场景输入，如果该修改支持多个场景，可输入如 `train post_train`。目前仅支持 `{train, inference, post_train}`
    - `device-type`：芯片型号。以 `厂商名_具体型号` 为命名，厂商名开头需要大写。
    - `commit`：基于 FlagScale 某个 `commit` 进行的适配。
+   - `key-path`：如果需要对patch文件进行加密，指定密钥文件路径，如果该路径下没有密钥文件，则会自动产生。
 
    执行该命令后，需要交互式输入以下四个信息，分别是：后端版本、适配的模型、`commit message`（将自动 `add patch` 文件，并以此 `message` 进行 `commit`）、联系方式（可选，适用于需要加密场景）  
 
@@ -98,6 +99,8 @@ python tools/patch/unpatch.py --backend Megatron-LM FlagScale --task train --dev
 ```
 
 `unpatch` 出的 FlagScale 就在 `build/<Chip_Vendor>` 目录中。
+
+如果需要对加密后的patch进行解密，需要参考patch文件对应的yaml文件中对应的联系方式，联系厂商获取密钥文件，`unpatch`时需要指定密钥文件路径`key-path`。
 
 ## 五、Q&A
 

--- a/tools/patch/encryption_utils.py
+++ b/tools/patch/encryption_utils.py
@@ -1,0 +1,140 @@
+import os
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+
+def generate_rsa_keypair(key_path):
+    """
+    Generate RSA key pair and save them to the specified directory.
+    Args:
+        key_path (str): The path where the generated keys will be saved.
+    Returns:
+        tuple: A tuple containing the paths to the private and public keys respectively.
+    """
+    private_key_path = os.path.join(key_path, "private_key.pem")
+    public_key_path = os.path.join(key_path, "public_key.pem")
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=4096, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+    with open(private_key_path, "wb") as private_file:
+        private_file.write(
+            private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+    with open(public_key_path, "wb") as public_file:
+        public_file.write(
+            public_key.public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+        )
+    return private_key_path, public_key_path
+
+
+def encrypt_file(file_name, key_path):
+    """
+    Encrypt a file using AES-256-CBC and RSA-OAEP.
+    Args:
+        file_name (str): The name of the file to be encrypted.
+        key_path (str): The path where the generated keys will be saved.
+    Returns:
+        encrypted_file_path: The path to the encrypted file.
+    """
+    # Create the directory if it does not exist
+    os.makedirs(key_path, exist_ok=True)
+    # Check if the key files already exist
+    private_key_exists = os.path.exists(os.path.join(key_path, "private_key.pem"))
+    public_key_exists = os.path.exists(os.path.join(key_path, "public_key.pem"))
+    if not private_key_exists or not public_key_exists:
+        # Generate RSA key pair if they do not exist
+        private_key_path, public_key_path = generate_rsa_keypair(key_path)
+        print(
+            f"Generated RSA keys:\nPrivate key: {private_key_path}\nPublic key: {public_key_path}"
+        )
+    else:
+        private_key_path = os.path.join(key_path, "private_key.pem")
+        public_key_path = os.path.join(key_path, "public_key.pem")
+        print("RSA keys already exist.")
+
+    aes_key = os.urandom(32)
+    iv = os.urandom(16)
+    cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv), backend=default_backend())
+    encryptor = cipher.encryptor()
+    with open(file_name, "rb") as file:
+        original_data = file.read()
+    padding_length = 16 - len(original_data) % 16
+    padded_data = original_data + bytes([padding_length] * padding_length)
+    encrypted_data = encryptor.update(padded_data) + encryptor.finalize()
+    with open(public_key_path, "rb") as public_file:
+        public_key = serialization.load_pem_public_key(
+            public_file.read(), backend=default_backend()
+        )
+    encrypted_aes_key = public_key.encrypt(
+        aes_key,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None
+        ),
+    )
+    encrypted_file_path = file_name + ".encrypted"
+    with open(encrypted_file_path, "wb") as encrypted_file:
+        encrypted_file.write(iv + encrypted_aes_key + encrypted_data)
+        os.remove(file_name)
+        print(f"Remove file {file_name} after file encrypted.")
+    return encrypted_file_path
+
+
+def decrypt_file(encrypted_file_name, private_key_path):
+    """
+    Decrypt a file using AES-256-CBC and RSA-OAEP.
+    Args:
+        encrypted_file_name (str): The name of the encrypted file.
+        private_key_path (str): The path to the private key file.
+    Returns:
+        decrypted_file_path: The path to the decrypted file.
+    """
+    with open(private_key_path, "rb") as private_file:
+        private_key = serialization.load_pem_private_key(
+            private_file.read(), password=None, backend=default_backend()
+        )
+    with open(encrypted_file_name, "rb") as encrypted_file:
+        print(encrypted_file_name, encrypted_file)
+        iv = encrypted_file.read(16)
+        encrypted_aes_key = encrypted_file.read(512)
+        encrypted_data = encrypted_file.read()
+
+    aes_key = None
+    try:
+        aes_key = private_key.decrypt(
+            encrypted_aes_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None
+            ),
+        )
+        print("AES key decrypted successfully.")
+    except Exception as e:
+        print(f"Decryption of AES key failed: {e}")
+        return  # Exit the function if decryption fails
+    if aes_key is None:
+        print("AES key could not be decrypted.")
+        return
+    cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv), backend=default_backend())
+    decryptor = cipher.decryptor()
+    try:
+        decrypted_padded_data = decryptor.update(encrypted_data) + decryptor.finalize()
+    except Exception as e:
+        print(f"Decryption of data failed: {e}")
+        return
+    padding_length = decrypted_padded_data[-1]
+    decrypted_data = decrypted_padded_data[:-padding_length]
+    decrypted_file_path = os.path.splitext(encrypted_file_name)[0]
+    with open(decrypted_file_path, "wb") as decrypted_file:
+        decrypted_file.write(decrypted_data)
+
+    return decrypted_file_path

--- a/tools/patch/file_utils.py
+++ b/tools/patch/file_utils.py
@@ -1,0 +1,252 @@
+import os
+import shutil
+
+from logger_utils import get_patch_logger, get_unpatch_logger
+
+
+DELETED_FILE_NAME = "deleted_files.txt"
+
+
+def sync_to_flagscale(file_path, status, src, dst, f=None, mode="symlink"):
+    """
+    Synchronize the file changes between the source and destination directories.
+    Args:
+        file_path (str): The path of the file relative to the root directory.
+        status (list): A list containing the file status information.
+        src (str): The source directory path, e.g., flagscale/backends/Megatron-LM.
+        dst (str): The destination directory path, e.g., third_party/Megatron-LM.
+        f (IOBase or None): An open file object to write the deleted files to.
+        mode (str): The mode used to create the file. Default is "symlink".
+                    if mode == "symlink":
+                        Create a symbolic link from the source file to the destination file.
+                    if mode == "copy":
+                        Copy the source file to the destination file.
+    """
+    logger = get_patch_logger()
+
+    src_file_path = os.path.join(src, file_path)
+    dst_file_path = os.path.join(dst, file_path)
+    change_type = status[0]
+
+    SYMBOLIC_ERROR = "Defining symbolic links in the submodule is not supported except for those defined in FlagScale"
+    TYPECHANGED_ERROR = (
+        "File type changed are not supported in the submodule besides those defined by FlagScale"
+    )
+
+    # Process the file changes based on the change type.
+    # Typechange
+    if change_type == "T":
+        is_symlink = os.path.islink(dst_file_path)
+        if is_symlink:
+            if not os.path.lexists(src_file_path):
+                # The File is a symbolic link, but the source file no longer exists, so the symlink is dangling and has been automatically removed.
+                logger.warning(
+                    f"File {dst_file_path} is a symbolic link, but the source file no longer exists, so the symlink is dangling and has been automatically removed."
+                )
+                os.remove(dst_file_path)
+        else:
+            raise ValueError(f"{TYPECHANGED_ERROR}: {dst_file_path}")
+
+    # New or Untracked
+    elif change_type in ["A", "UT"]:
+        is_symlink = os.path.islink(dst_file_path)
+        if is_symlink:
+            if not os.path.lexists(src_file_path):
+                real_path = os.readlink(dst_file_path)
+                if os.path.lexists(real_path):
+                    os.makedirs(os.path.dirname(src_file_path), exist_ok=True)
+                    shutil.move(real_path, src_file_path)
+                    logger.info(
+                        f"Move {real_path} to {src_file_path} and create symbolic link {dst_file_path} -> {src_file_path}"
+                    )
+                    if os.path.lexists(dst_file_path):
+                        os.remove(dst_file_path)
+                    os.symlink(src_file_path, dst_file_path)
+                else:
+                    raise ValueError(f"{SYMBOLIC_ERROR}: {dst_file_path}")
+        else:
+            create_file(src_file_path, dst_file_path, mode=mode)
+
+    # Deleted
+    elif change_type == "D":
+        if os.path.lexists(src_file_path):
+            os.remove(src_file_path)
+            logger.debug(f"File {src_file_path} has been deleted.")
+        else:
+            assert f
+            f.write(f"{file_path}\n")
+            f.flush()
+
+    # Modified
+    elif change_type == "M":
+        is_symlink = os.path.islink(dst_file_path)
+        if is_symlink:
+            logger.warning(
+                f"The symlink {dst_file_path} can only have a typechange status and it cannot have a modified status."
+            )
+        create_file(src_file_path, dst_file_path, mode=mode)
+
+    # Renamed
+    elif change_type == "R":
+        assert len(status) == 2
+        rel_dst_path = status[1]
+        renamed_dst_file_path = os.path.join(dst, rel_dst_path)
+        is_symlink = os.path.islink(renamed_dst_file_path)
+        renamed_src_file_path = os.path.join(src, rel_dst_path)
+        if is_symlink:
+            real_path = os.readlink(renamed_dst_file_path)
+            os.makedirs(os.path.dirname(renamed_src_file_path), exist_ok=True)
+            if real_path != renamed_src_file_path:
+                shutil.move(real_path, renamed_src_file_path)
+                logger.info(
+                    f"Move {real_path} to {renamed_src_file_path} and create symbolic link {renamed_dst_file_path} -> {renamed_src_file_path}"
+                )
+            if os.path.lexists(renamed_dst_file_path):
+                os.remove(renamed_dst_file_path)
+            os.symlink(renamed_src_file_path, renamed_dst_file_path)
+        else:
+            assert not os.path.lexists(renamed_src_file_path)
+            create_file(renamed_src_file_path, renamed_dst_file_path, mode=mode)
+            assert f
+            f.write(f"{file_path}\n")
+            f.flush()
+
+
+def create_file(source_file, target_file, mode="symlink"):
+    """
+    Create a file by copying or symlinking it from the source to the target.
+    Args:
+        source_file (str): Path of the file in the flagscale/backends/<backend>.
+        target_file (str): Path of the file in the third_party/<submodule>.
+        mode (str): Mode to use when creating the file. Can be either 'symlink' or 'copy'.
+    """
+    logger = get_patch_logger()
+
+    if os.path.lexists(source_file):
+        logger.warning(f"File {source_file} will be covered by {target_file}.")
+    assert os.path.lexists(target_file)
+
+    source_dir = os.path.dirname(source_file)
+    if not os.path.lexists(source_dir):
+        os.makedirs(source_dir, exist_ok=True)
+
+    if os.path.isdir(target_file):
+        logger.warning(f"File {target_file} is a directory.")
+        for root, dirs, files in os.walk(target_file):
+            for file in files:
+                target_file_path = os.path.join(root, file)
+                if ".git" in target_file_path:
+                    logger.warning(f"Skip the .git* file {target_file_path}.")
+                    continue
+                relative_path = os.path.relpath(target_file_path, target_file)
+                source_file_path = os.path.join(source_dir, relative_path)
+                is_symlink = os.path.islink(target_file_path)
+                if is_symlink:
+                    if not os.path.lexists(source_file_path):
+                        real_path = os.readlink(target_file_path)
+                        if os.path.lexists(real_path):
+                            os.makedirs(os.path.dirname(source_file_path), exist_ok=True)
+                            shutil.move(real_path, source_file_path)
+                            logger.info(
+                                f"Move {real_path} to {source_file_path} and create symbolic link {target_file_path} -> {source_file_path}"
+                            )
+                            if os.path.lexists(target_file_path):
+                                os.remove(target_file_path)
+
+                else:
+                    if not os.path.lexists(source_file_path):
+                        os.makedirs(os.path.dirname(source_file_path), exist_ok=True)
+                        shutil.copyfile(target_file_path, source_file_path)
+                    else:
+                        logger.warning(
+                            f"File {source_file_path} will be covered by {target_file_path}."
+                        )
+                        shutil.copyfile(target_file_path, source_file_path)
+                symlink_by_mode(source_file_path, target_file_path, mode=mode)
+    else:
+        shutil.copyfile(target_file, source_file)
+        symlink_by_mode(source_file, target_file, mode=mode)
+
+
+def symlink_by_mode(source_file, target_file, mode="symlink"):
+    """
+    Create a symbolic link from the source file to the target file.
+    Args:
+        source_file (str): Path of the file in the flagscale/backends/<backend>.
+        target_file (str): Path of the file in the third_party/<submodule>.
+        mode (str): Mode to use when creating the file. Can be either 'symlink' or 'copy'.
+    """
+    logger = get_patch_logger()
+
+    if mode == "symlink":
+        if os.path.lexists(target_file):
+            os.remove(target_file)
+        os.symlink(source_file, target_file)
+        logger.info(
+            f"File {target_file} has been copied to {source_file} and Create symbolic link {target_file} -> {source_file}."
+        )
+    elif mode == "copy":
+        logger.info(f"File {source_file} has been copied to {target_file}.")
+    else:
+        raise ValueError(f"Unsupported mode: {mode}.")
+
+
+def copy(src, dst):
+    logger = get_unpatch_logger()
+    for root, dirs, files in os.walk(src):
+        for filename in files:
+            src_file = os.path.join(root, filename)
+            if src_file == os.path.join(src, DELETED_FILE_NAME):
+                continue
+
+            rel_path = os.path.relpath(src_file, src)
+            dst_file = os.path.join(dst, rel_path)
+
+            dst_file_dir = os.path.dirname(dst_file)
+            if not os.path.lexists(dst_file_dir):
+                os.makedirs(dst_file_dir)
+
+            if os.path.lexists(dst_file):
+                os.remove(dst_file)
+            assert not os.path.lexists(dst_file)
+            shutil.copyfile(src_file, dst_file)
+            logger.info(f"Copying file: {dst_file} -> {src_file}")
+
+
+def delete_file(file_path, dst):
+    logger = get_unpatch_logger()
+    with open(file_path, "r", encoding="utf-8") as f:
+        deleted_files = f.readlines()
+        for deleted_file in deleted_files:
+            deleted_file = deleted_file.strip()
+            deleted_file_path = os.path.join(dst, deleted_file)
+            if os.path.lexists(deleted_file_path):
+                os.remove(deleted_file_path)
+                logger.info(f"Deleting file: {deleted_file_path}")
+            else:
+                logger.warning(f"File not found for deletion: {deleted_file_path}")
+
+
+def create_symlinks(src, dst):
+    from unpatch import DELETED_FILE_NAME
+
+    logger = get_unpatch_logger()
+    for root, dirs, files in os.walk(src):
+        for filename in files:
+            src_file = os.path.join(root, filename)
+            if src_file == os.path.join(src, DELETED_FILE_NAME):
+                continue
+
+            rel_path = os.path.relpath(src_file, src)
+            dst_file = os.path.join(dst, rel_path)
+
+            dst_file_dir = os.path.dirname(dst_file)
+            if not os.path.lexists(dst_file_dir):
+                os.makedirs(dst_file_dir)
+
+            if os.path.lexists(dst_file):
+                os.remove(dst_file)
+            assert not os.path.lexists(dst_file)
+            os.symlink(src_file, dst_file)
+
+            logger.info(f"Creating symbolic link: {dst_file} -> {src_file}")

--- a/tools/patch/git_utils.py
+++ b/tools/patch/git_utils.py
@@ -1,0 +1,139 @@
+from logger_utils import get_patch_logger
+
+
+logger = get_patch_logger()
+
+
+def get_diff_between_commit_and_now(repo, commit):
+    """
+    Get the diff between the current state of the repository and a specific commit.
+
+    Args:
+        repo (git.Repo): The Git repository object.
+        commit (str): The commit hash to compare against.
+
+    Returns:
+        diffs: A list of diffs between the current state and the specified commit, including:
+            - Changes in the index (staged changes)
+            - Changes in the working directory (unstaged changes)
+            - Untracked files
+    """
+    commit_obj = repo.commit(commit)
+    tree_obj = commit_obj.tree
+
+    index_obj = repo.index
+    index_tree_hash = index_obj.write_tree()
+
+    staged_diff = tree_obj.diff(index_tree_hash)
+    unstaged_diff = index_obj.diff(None)
+    untracked_files = repo.untracked_files
+
+    return staged_diff, unstaged_diff, untracked_files
+
+
+def get_file_statuses_for_staged_or_unstaged(diffs):
+    """
+    Get the status of files.
+
+    Args:
+        diffs: The diff object containing changes.
+
+    Returns:
+        file_status: A dictionary with file paths as keys and their statuses as values.
+    """
+    file_statuses = {}
+    for diff in diffs:
+        if diff.new_file:
+            status = "A"
+            file_path = diff.b_path
+            file_statuses[file_path] = [status]
+        elif diff.deleted_file:
+            status = "D"
+            file_path = diff.a_path
+            file_statuses[file_path] = [status]
+        elif diff.renamed_file:
+            status = "R"
+            file_path = diff.b_path
+            file_statuses[diff.a_path] = [status, file_path]
+        elif diff.change_type == "M":
+            status = "M"
+            assert diff.a_path == diff.b_path
+            file_path = diff.b_path
+            file_statuses[file_path] = [status]
+        elif diff.change_type == "T":
+            status = "T"
+            assert diff.a_path == diff.b_path
+            file_path = diff.b_path
+            file_statuses[file_path] = [status]
+        elif diff.change_type == "U":
+            raise ValueError(f"Unmerged status is not supported.")
+        else:
+            raise ValueError(f"Unsupported  status: {diff.change_type}.")
+
+    logger.info(f"File statuses: {file_statuses}")
+    return file_statuses
+
+
+def get_file_statuses_for_untracked(untracked_files):
+    """
+    Get the status of untracked files.
+    Args:
+        untracked_files: A list of untracked files.
+    Returns:
+        file_status: A dictionary with file paths as keys and their statuses as values.
+    """
+    file_statuses = {}
+    for file in untracked_files:
+        file_statuses[file] = ["UT"]
+
+    return file_statuses
+
+
+from git import Repo, GitConfigParser
+from pathlib import Path
+
+def check_git_user_info(repo_path='.'):
+    """
+    Retrieve Git user.name and user.email from local config first,
+    falling back to global config if not found. If neither is set,
+    print a message suggesting how to configure them.
+
+    Parameters:
+        repo_path (str): Path to the Git repository (default: current directory).
+
+    Returns:
+        dict: Dictionary with 'name' and 'email' keys.
+    """
+    user_info = {'name': None, 'email': None}
+
+    try:
+        # Attempt to read from the local Git config
+        repo = Repo(repo_path)
+        local_config = repo.config_reader()
+
+        if local_config.has_option('user', 'name'):
+            user_info['name'] = local_config.get_value('user', 'name')
+        if local_config.has_option('user', 'email'):
+            user_info['email'] = local_config.get_value('user', 'email')
+    except Exception as e:
+        logger.warning(f"[local git config] Warning: {e}")
+
+    try:
+        # Fallback to global Git config if needed
+        global_config = GitConfigParser([str(Path.home() / '.gitconfig')], read_only=True)
+
+        if user_info['name'] is None and global_config.has_option('user', 'name'):
+            user_info['name'] = global_config.get_value('user', 'name')
+        if user_info['email'] is None and global_config.has_option('user', 'email'):
+            user_info['email'] = global_config.get_value('user', 'email')
+    except Exception as e:
+        logger.warnin(f"[global git config] Warning: {e}")
+
+    # Show warning if either field is still not set
+    error_messages = ""
+    if user_info['name'] is None:
+        error_messages += "Git user.name is not set. You can set it with:\n  git config --global user.name YourName" + "\n"
+    if user_info['email'] is None:
+        error_messages += "Git user.email is not set. You can set it with:\n  git config --global user.email you@example.com"
+    if error_messages:
+        raise ValueError(error_messages)

--- a/tools/patch/logger_utils.py
+++ b/tools/patch/logger_utils.py
@@ -1,0 +1,43 @@
+import logging
+
+
+def get_patch_logger():
+    """
+    Create a logger for patching operations.
+
+    Returns:
+        logging.Logger: Configured logger instance.
+    """
+    logger = logging.getLogger("FlagScalePatchLogger")
+    logger.setLevel(logging.INFO)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("[FlagScale-Patch] %(levelname)s | %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        # Prevent the logger from propagating messages to the root logger
+        logger.propagate = False
+
+    return logger
+
+
+def get_unpatch_logger():
+    """
+    Create a logger for unpatching operations.
+
+    Returns:
+        logging.Logger: Configured logger instance.
+    """
+    logger = logging.getLogger("FlagScaleUnpatchLogger")
+    logger.setLevel(logging.INFO)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("[FlagScale-Unpatch] %(levelname)s | %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        # Prevent the logger from propagating messages to the root logger
+        logger.propagate = False
+
+    return logger


### PR DESCRIPTION
This PR adds patch encryption, which can be used with the command `python tools/patch/patch.py --key-path`, and for decryption with` python tools/patch/unpatch.py --key-path.` In addition, this PR further improves the usability of the patch mechanism, including: 

- Support for fuzzy matching of backend inputs, for example, Megatron-LM can be entered as megatron or megatron-lm.
- The patch generation process has been enhanced to support modifications involving subtrees.
- When the vendor performs `unpatch`, if neither `patch_history.yaml` is present nor the `commit` parameter is provided, the patch file from the current commit will be used for unpatching by default.
- Automatic check for Git config has been added.