### PR TITLE
[Tools] Support specified submodule commit for hardware patch

### DIFF
--- a/tools/patch/git_utils.py
+++ b/tools/patch/git_utils.py
@@ -1,6 +1,5 @@
 from logger_utils import get_patch_logger
 
-
 logger = get_patch_logger()
 
 
@@ -89,8 +88,10 @@ def get_file_statuses_for_untracked(untracked_files):
     return file_statuses
 
 
-from git import Repo, GitConfigParser
 from pathlib import Path
+
+from git import GitConfigParser, Repo
+
 
 def check_git_user_info(repo_path='.'):
     """
@@ -132,8 +133,35 @@ def check_git_user_info(repo_path='.'):
     # Show warning if either field is still not set
     error_messages = ""
     if user_info['name'] is None:
-        error_messages += "Git user.name is not set. You can set it with:\n  git config --global user.name YourName" + "\n"
+        error_messages += (
+            "Git user.name is not set. You can set it with:\n  git config --global user.name YourName"
+            + "\n"
+        )
     if user_info['email'] is None:
         error_messages += "Git user.email is not set. You can set it with:\n  git config --global user.email you@example.com"
     if error_messages:
         raise ValueError(error_messages)
+
+
+def get_submodule_commit(commit, backend, main_path):
+    """
+    Get the commit hash of a submodule at a specific commit.
+
+    Args:
+        commit (str): The commit hash to check.
+        backend (str): The backend name.
+        main_path (str): The path to the main repository.
+
+    Returns:
+        str: The commit hash of the submodule.
+    """
+
+    repo = Repo(main_path)
+    submodule_path = "third_party" + "/" + backend
+    submodule = repo.submodule(submodule_path)
+    if not commit:
+        return repo.head.commit.tree[submodule_path].hexsha
+
+    submodule_repo = submodule.module()
+    submodule_commit = submodule_repo.commit(commit)
+    return submodule_commit.hexsha


### PR DESCRIPTION
This PR adds the ability to specify a commit for the submodule and optionally apply the FlagScale adaptation. Usage is as follows:
`python tools/patch/unpatch.py --backend vllm --backend-commit <vllm_commit> --no-fs-extension`
`--backend-commit` indicates the commit to which the submodule will automatically reset after a submodule update. The `--no-fs-extension` means the FlagScale adaptation will not be applied, and the submodule will remain in its original state.