### PR TITLE
[Serve] PD Dissagragetion support autotune

### DIFF
--- a/examples/qwen2_5/conf/hostfile.txt
+++ b/examples/qwen2_5/conf/hostfile.txt
@@ -1,5 +1,5 @@
 # ip slots type=xxx[optional]
 # master node
-x.x.x.x slots=8 type=gpu
+10.6.208.15 slots=8 type=gpu
 # worker nodes
-x.x.x.x slots=8 type=gpu
+# 10.6.208.16 slots=8 type=gpu

--- a/examples/qwen2_5/conf/hostfile.txt
+++ b/examples/qwen2_5/conf/hostfile.txt
@@ -2,4 +2,4 @@
 # master node
 10.6.208.15 slots=8 type=gpu
 # worker nodes
-# 10.6.208.16 slots=8 type=gpu
+10.6.208.16 slots=8 type=gpu

--- a/examples/qwen2_5/conf/hostfile.txt
+++ b/examples/qwen2_5/conf/hostfile.txt
@@ -1,5 +1,5 @@
 # ip slots type=xxx[optional]
 # master node
-10.6.208.15 slots=8 type=gpu
+x.x.x.x slots=8 type=gpu
 # worker nodes
-10.6.208.16 slots=8 type=gpu
+x.x.x.x slots=8 type=gpu

--- a/examples/qwen2_5/conf/serve/7b_tune.yaml
+++ b/examples/qwen2_5/conf/serve/7b_tune.yaml
@@ -3,12 +3,8 @@
   engine_args:
     model: /models/Qwen2.5-0.5B-Instruct
     host: 0.0.0.0
-    tensor_parallel_size: 1
-    pipeline_parallel_size: 1
-    gpu_memory_utilization: 0.9
     max_model_len: 32768
     max_num_seqs: 256
-    enforce_eager: true
     trust_remote_code: true
     enable_chunked_prefill: true
   engine_args_specific:

--- a/examples/qwen2_5/conf/serve/7b_tune.yaml
+++ b/examples/qwen2_5/conf/serve/7b_tune.yaml
@@ -1,0 +1,21 @@
+- serve_id: vllm_model
+  engine: vllm
+  engine_args:
+    model: /models/Qwen2.5-0.5B-Instruct
+    host: 0.0.0.0
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.9
+    max_model_len: 32768
+    max_num_seqs: 256
+    enforce_eager: true
+    trust_remote_code: true
+    enable_chunked_prefill: true
+  engine_args_specific:
+    vllm:
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      enforce_eager: true
+      trust_remote_code: true
+      enable_chunked_prefill: true

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -42,6 +42,8 @@ experiment:
     control:
       interval: 20
       run_best: False
+  cmds:
+    before_start: source /root/miniconda3/bin/activate flagscale-inference
 
 action: run
 

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -13,6 +13,8 @@ experiment:
     prefill_decode_disaggregation: true
     prefill_num: 2
     decode_num: 2
+    prefill_address: 10.6.208.15
+    decode_address: 10.6.208.16
   runner:
     hostfile: examples/qwen2_5/conf/hostfile.txt
     docker: cz-dev

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -13,8 +13,8 @@ experiment:
     prefill_decode_disaggregation: true
     prefill_num: 2
     decode_num: 2
-    prefill_address: 10.6.208.15
-    decode_address: 10.6.208.16
+    #prefill_address: 10.6.208.15
+    #decode_address: 10.6.208.16
   runner:
     hostfile: examples/qwen2_5/conf/hostfile.txt
     docker: cz-dev

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -31,7 +31,7 @@ experiment:
       interval: 20
       run_best: False
 
-action: auto_tune
+action: run
 
 hydra:
   run:

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -23,7 +23,7 @@ experiment:
       vllm:
         tensor_model_parallel_size: [1, 2]
         pipeline_model_parallel_size: auto
-        block_size: [16, 32]
+        block_size: [16]
     performance:
       metric: total_token_throughput
       order: descend

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -7,25 +7,23 @@ experiment:
   exp_dir: ./outputs
   task:
     type: serve
-  deploy:
-    port: 6701
-    use_fs_serve: false
-    prefill_decode_disaggregation: true
-    prefill_num: 2
-    decode_num: 2
-    #prefill_address: 10.6.208.15
-    #decode_address: 10.6.208.16
   runner:
     hostfile: examples/qwen2_5/conf/hostfile.txt
-    docker: cz-dev
+    docker: dev
     ssh_port: 22
     nnodes: 1
     nproc_per_node: 1
+    deploy:
+      port: 6701
+      use_fs_serve: false
+      prefill_decode_disaggregation: true
+      prefill_num: 2
+      decode_num: 2
   envs:
     CUDA_DEVICE_MAX_CONNECTIONS: 1
     VLLM_USE_V1: 0
-    FLAGCX_SOCKET_IFNAME: bond0.2208
-    FLAGCX_PATH: /mine/ip16/project/FlagCX/
+    FLAGCX_SOCKET_IFNAME: bond0
+    FLAGCX_PATH: /path/to/FlagCX/
     FLAGCX_DEBUG: TRACE
     FLAGCX_DEBUG_SUBSYS: ALL
     USE_FLAGCX: true

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -20,7 +20,7 @@ experiment:
     engines: [vllm]
     space:
       vllm:
-        tensor_model_parallel_size: [1, 2]
+        tensor_model_parallel_size: [1, 2, 4, 8]
         pipeline_model_parallel_size: [1, 2]
         block_size: [16, 32]
     control:

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -11,12 +11,22 @@ experiment:
     port: 6701
     use_fs_serve: false
     prefill_decode_disaggregation: true
+    prefill_num: 2
+    decode_num: 2
   runner:
-    hostfile: null #examples/qwen2_5/conf/hostfile.txt
+    hostfile: examples/qwen2_5/conf/hostfile.txt
     docker: cz-dev
     ssh_port: 22
     nnodes: 1
     nproc_per_node: 4
+  envs:
+    CUDA_DEVICE_MAX_CONNECTIONS: 1
+    VLLM_USE_V1: 0
+    FLAGCX_SOCKET_IFNAME: bond0.2208
+    FLAGCX_PATH: /mine/ip16/project/FlagCX/
+    FLAGCX_DEBUG: TRACE
+    FLAGCX_DEBUG_SUBSYS: ALL
+    USE_FLAGCX: true
   auto_tuner:
     engines: [vllm]
     space:

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -10,6 +10,7 @@ experiment:
   deploy:
     port: 6701
     use_fs_serve: false
+    prefill_decode_disaggregation: true
   runner:
     hostfile: null #examples/qwen2_5/conf/hostfile.txt
     docker: cz-dev

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -20,7 +20,7 @@ experiment:
     docker: cz-dev
     ssh_port: 22
     nnodes: 1
-    nproc_per_node: 4
+    nproc_per_node: 1
   envs:
     CUDA_DEVICE_MAX_CONNECTIONS: 1
     VLLM_USE_V1: 0
@@ -33,7 +33,7 @@ experiment:
     engines: [vllm]
     space:
       vllm:
-        tensor_model_parallel_size: [1, 2]
+        tensor_model_parallel_size: [1]
         pipeline_model_parallel_size: auto
         block_size: [16]
     performance:

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -15,13 +15,13 @@ experiment:
     docker: cz-dev
     ssh_port: 22
     nnodes: 1
-    nproc_per_node: 8
+    nproc_per_node: 4
   auto_tuner:
     engines: [vllm]
     space:
       vllm:
-        tensor_model_parallel_size: [1, 2, 4, 8]
-        pipeline_model_parallel_size: [1, 2]
+        tensor_model_parallel_size: [1, 2]
+        pipeline_model_parallel_size: auto
         block_size: [16, 32]
     performance:
       metric: token_throughput

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -25,7 +25,7 @@ experiment:
         pipeline_model_parallel_size: auto
         block_size: [16, 32]
     performance:
-      metric: token_throughput
+      metric: total_token_throughput
       order: descend
     control:
       interval: 20

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -25,6 +25,7 @@ experiment:
         block_size: [16, 32]
     performance:
       metric: token_throughput
+      order: descend
     control:
       interval: 20
       run_best: False

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -23,6 +23,8 @@ experiment:
         tensor_model_parallel_size: [1, 2, 4, 8]
         pipeline_model_parallel_size: [1, 2]
         block_size: [16, 32]
+    performance:
+      metric: token_throughput
     control:
       interval: 20
       run_best: False

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -1,6 +1,6 @@
 defaults:
   - _self_
-  - serve: 7b
+  - serve: 7b_tune
 
 experiment:
   exp_name: qwen2.5_7b
@@ -11,20 +11,20 @@ experiment:
     port: 6701
     use_fs_serve: false
   runner:
+    hostfile: null #examples/qwen2_5/conf/hostfile.txt
+    docker: cz-dev
+    ssh_port: 22
     nnodes: 1
-    nproc_per_node: 4
+    nproc_per_node: 8
   auto_tuner:
+    engines: [vllm]
     space:
-      tensor_model_parallel_size: "auto"
-      pipeline_model_parallel_size: [1, 2]
-      # instance: "auto"
-      block_size: [8, 16, 32]
-      max_num_batched_tokens: [512, 1024, 2048]
-      max_num_seqs: [128, 256]
-      # swap_space: [0, 2, 4, 8, 16]
-
+      vllm:
+        tensor_model_parallel_size: [1, 2]
+        pipeline_model_parallel_size: [1, 2]
+        block_size: [16, 32]
     control:
-      interval: 10
+      interval: 20
       run_best: False
 
 action: auto_tune

--- a/flagscale/runner/auto_tuner/generate.py
+++ b/flagscale/runner/auto_tuner/generate.py
@@ -168,7 +168,7 @@ class ServeGenerator(Generator):
         current_pp = model_config.engine_args_specific[engine].get("pipeline_parallel_size", 1)
         model_config.resources["num_gpus"] = current_tp * current_pp
 
-        if not config.experiment.get("deploy", {}).get("use_fs_serve", True):
+        if not config.experiment.get("runner", {}).get("deploy", {}).get("use_fs_serve", True):
             del model_config["resources"]
 
     def gen(self, strategy):

--- a/flagscale/runner/auto_tuner/record/recorder.py
+++ b/flagscale/runner/auto_tuner/record/recorder.py
@@ -333,27 +333,31 @@ class ServeRecorder(Recorder):
     def record(self, strategy, performance):
         strategy["e2e_latency"] = round(performance["mean_e2el_ms"], 2)
         strategy["request_throughput"] = round(performance["request_throughput"], 2)
+        strategy["output_throughput"] = round(performance["output_throughput"], 2)
         strategy["token_throughput"] = round(performance["total_token_throughput"], 2)
         strategy["ttft"] = round(performance["mean_ttft_ms"], 2)
         strategy["itl"] = round(performance["mean_itl_ms"], 2)
         strategy["topt"] = round(performance["mean_tpot_ms"], 2)
         self.cur_strategy = strategy
 
-    def sort(self, history):
+    def sort(self, history, metric=None, sorted_order=None):
+        if sorted_order is None:
+            sorted_order = self.sorted_order
+        if metric is None:
+            metric = self.metric
         sorted_history = None
-        if self.sorted_order == "ascend":
+        if sorted_order == "ascend":
             sorted_history = sorted(
-                history,
-                key=lambda x: (x[self.metric] if x[self.metric] is not None else float("inf")),
+                history, key=lambda x: (x[metric] if x[metric] is not None else float("inf"))
             )
-        elif self.sorted_order == "descend":
+        elif sorted_order == "descend":
             sorted_history = sorted(
                 history,
-                key=lambda x: (x[self.metric] if x[self.metric] is not None else float("-inf")),
+                key=lambda x: (x[metric] if x[metric] is not None else float("-inf")),
                 reverse=True,
             )
         else:
-            raise ValueError(f"The sorted order {self.sorted_order} is not supported.")
+            raise ValueError(f"The sorted order {sorted_order} is not supported.")
         self.logger.info(f"history========: {history}")
         assert sorted_history is not None
         return sorted_history

--- a/flagscale/runner/auto_tuner/record/recorder.py
+++ b/flagscale/runner/auto_tuner/record/recorder.py
@@ -334,7 +334,10 @@ class ServeRecorder(Recorder):
         strategy["e2e_latency"] = round(performance["mean_e2el_ms"], 2)
         strategy["request_throughput"] = round(performance["request_throughput"], 2)
         strategy["output_throughput"] = round(performance["output_throughput"], 2)
-        strategy["token_throughput"] = round(performance["total_token_throughput"], 2)
+        strategy["total_token_throughput"] = round(performance["total_token_throughput"], 2)
+        strategy["prompt_throughput"] = (
+            strategy["total_token_throughput"] - strategy["output_throughput"]
+        )
         strategy["ttft"] = round(performance["mean_ttft_ms"], 2)
         strategy["itl"] = round(performance["mean_itl_ms"], 2)
         strategy["topt"] = round(performance["mean_tpot_ms"], 2)

--- a/flagscale/runner/auto_tuner/record/recorder.py
+++ b/flagscale/runner/auto_tuner/record/recorder.py
@@ -316,23 +316,17 @@ class Recorder:
 class ServeRecorder(Recorder):
     def __init__(self, config):
         self.config = config
-        if (
-            "auto_tuner" in self.config.experiment
-            and "performance" in self.config.experiment.auto_tuner
-        ):
-            self.metric = self.config.experiment.auto_tuner.performance.get("metric", "itl")
-        else:
-            self.metric = "itl"
+        self.logger = logging.getLogger("FlagScale-AutoTuner")
+        self.metric = (
+            self.config.experiment.get("auto_tuner", {}).get("performance", {}).get("metric", "itl")
+        )
 
         # Sort order of performance, order just in [ascend, and descend], default ascend
-        if (
-            "auto_tuner" in self.config.experiment
-            and "performance" in self.config.experiment.auto_tuner
-        ):
-            self.sorted_order = self.config.experiment.auto_tuner.performance.get("order", "ascend")
-        else:
-            self.sorted_order = "ascend"
-        self.logger = logging.getLogger("FlagScale-AutoTuner")
+        self.sorted_order = (
+            self.config.experiment.get("auto_tuner", {})
+            .get("performance", {})
+            .get("order", "ascend")
+        )
         self.cur_strategy = None
         self.path = os.path.join(config.experiment.exp_dir, "auto_tuner", "history.csv")
 
@@ -360,5 +354,6 @@ class ServeRecorder(Recorder):
             )
         else:
             raise ValueError(f"The sorted order {self.sorted_order} is not supported.")
+        self.logger.info(f"history========: {history}")
         assert sorted_history is not None
         return sorted_history

--- a/flagscale/runner/auto_tuner/search/searcher.py
+++ b/flagscale/runner/auto_tuner/search/searcher.py
@@ -557,6 +557,7 @@ class ServeSearcher(Searcher):
 
         # Build search space
         start_time = time.time()
+        self.config.experiment.auto_tuner.cards = 1
         self.space = self.build_space(self.config)
         end_time = time.time()
         self.logger.info(
@@ -568,6 +569,8 @@ class ServeSearcher(Searcher):
         # Build strategies by Cartesian product search space
         start_time = time.time()
         self.strategies = self.build_strategies(self.space, self.config)
+        print(self.strategies)
+        breakpoint()
         end_time = time.time()
         self.logger.info(
             "Searcher: build {} candidate strategies in {:.2f} seconds.".format(

--- a/flagscale/runner/auto_tuner/search/searcher.py
+++ b/flagscale/runner/auto_tuner/search/searcher.py
@@ -556,7 +556,8 @@ class ServeSearcher(Searcher):
         self.config = config
 
         start_time = time.time()
-        cards = config.experiment.auto_tuner.cards
+        # cards = config.experiment.auto_tuner.cards
+        cards = 16
         max_cards_per_instance = config.experiment.runner.get("nproc_per_node", 1)
         space_bak = copy.deepcopy(getattr(config.experiment.auto_tuner, "space", {}))
         if self.config.experiment.get("deploy", {}).get("prefill_decode_disaggregation", False):

--- a/flagscale/runner/auto_tuner/search/searcher.py
+++ b/flagscale/runner/auto_tuner/search/searcher.py
@@ -558,6 +558,7 @@ class ServeSearcher(Searcher):
         start_time = time.time()
         cards = config.experiment.auto_tuner.cards
         max_cards_per_instance = config.experiment.runner.get("nproc_per_node", 1)
+        space_bak = copy.deepcopy(getattr(config.experiment.auto_tuner, "space", {}))
         if self.config.experiment.get("deploy", {}).get("prefill_decode_disaggregation", False):
             self.strategies = []
             cards_per_instance = 1
@@ -571,6 +572,7 @@ class ServeSearcher(Searcher):
                     strategy["cards_per_instance"] = cards_per_instance
                 self.strategies = self.strategies + strategies
                 cards_per_instance *= 2
+                config.experiment.auto_tuner.space = space_bak
             config.experiment.auto_tuner.cards = cards
             self.config.experiment.deploy.prefill_decode_disaggregation = True
             self.space = self.build_space(self.config)

--- a/flagscale/runner/auto_tuner/search/searcher.py
+++ b/flagscale/runner/auto_tuner/search/searcher.py
@@ -590,7 +590,6 @@ class ServeSearcher(Searcher):
             self.space = self.build_space(self.config)
             # Build strategies by Cartesian product search space
             self.strategies = self.build_strategies(self.space, self.config)
-            self.strategies = self.strategies + strategies
         self.logger.warning(f"ServeSearcher init self.strategies==== {self.strategies}")
 
         end_time = time.time()

--- a/flagscale/runner/auto_tuner/search/searcher.py
+++ b/flagscale/runner/auto_tuner/search/searcher.py
@@ -659,6 +659,9 @@ class ServeSearcher(Searcher):
 
     def build_strategies(self, space_all, config):
         """Build strategies by Cartesian product search space."""
+        enable_prefill_decode_disaggregation = config.experiment.get("deploy", {}).get(
+            "prefill_decode_disaggregation", False
+        )
         strategies_all = []
         for engine in self.engines:
             space = space_all[engine]
@@ -688,6 +691,8 @@ class ServeSearcher(Searcher):
             ]
             for i in strategies:
                 i["engine"] = engine
+                if enable_prefill_decode_disaggregation:
+                    i['prefill_decode_disaggregation'] = True
             strategies_all.extend(strategies)
 
         self.logger.info("================== grid search space: ================== \n")

--- a/flagscale/runner/auto_tuner/search/searcher.py
+++ b/flagscale/runner/auto_tuner/search/searcher.py
@@ -586,8 +586,8 @@ class ServeSearcher(Searcher):
             # Build strategies by Cartesian product search space
             self.strategies = self.build_strategies(self.space, self.config)
             self.strategies = self.strategies + strategies
-        print(self.strategies)
-        breakpoint()
+        self.logger.warning(f"ServeSearcher init self.strategies==== {self.strategies}")
+
         end_time = time.time()
         self.logger.info(
             "Searcher: build search space in {:.2f} seconds and space is {}".format(

--- a/flagscale/runner/auto_tuner/search/searcher.py
+++ b/flagscale/runner/auto_tuner/search/searcher.py
@@ -560,12 +560,16 @@ class ServeSearcher(Searcher):
         cards = 16
         max_cards_per_instance = config.experiment.runner.get("nproc_per_node", 1)
         space_bak = copy.deepcopy(getattr(config.experiment.auto_tuner, "space", {}))
-        if self.config.experiment.get("deploy", {}).get("prefill_decode_disaggregation", False):
+        if (
+            self.config.experiment.get("runner", {})
+            .get("deploy", {})
+            .get("prefill_decode_disaggregation", False)
+        ):
             self.strategies = []
             cards_per_instance = 1
             while cards_per_instance <= max_cards_per_instance:
                 self.config.experiment.auto_tuner.cards = cards_per_instance
-                self.config.experiment.deploy.prefill_decode_disaggregation = False
+                self.config.experiment.runner.deploy.prefill_decode_disaggregation = False
                 self.space = self.build_space(self.config)
                 strategies = self.build_strategies(self.space, self.config)
                 for strategy in strategies:
@@ -575,7 +579,7 @@ class ServeSearcher(Searcher):
                 cards_per_instance *= 2
                 config.experiment.auto_tuner.space = space_bak
             config.experiment.auto_tuner.cards = cards
-            self.config.experiment.deploy.prefill_decode_disaggregation = True
+            self.config.experiment.runner.deploy.prefill_decode_disaggregation = True
             self.space = self.build_space(self.config)
             strategies = self.build_pd_strategies(max_cards_per_instance, cards)
             for strategy in strategies:

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -410,21 +410,23 @@ class ServeAutoTunner(AutoTuner):
 
             if self.enable_prefill_decode_disaggregation:
                 # get best strategy of prefill and decode type
+                prefill_metric = "prompt_throughput"
                 self.prefill_best_strategy = self.get_best(
-                    metric="token_throughput", sorted_order="descend"
+                    metric=prefill_metric, sorted_order="descend"
                 )
                 if self.prefill_best_strategy:
                     self.logger.info(
-                        f"Best prefill strategy tuned so far: {self.prefill_best_strategy}, and {self.recorder.metric} is {self.prefill_best_strategy[self.recorder.metric]}."
+                        f"Best prefill strategy tuned so far: {self.prefill_best_strategy}, and {prefill_metric} is {self.prefill_best_strategy[prefill_metric]}."
                     )
                 else:
                     self.logger.info(f"No prefill strategy can run so far.")
+                decode_metric = "output_throughput"
                 self.decode_best_strategy = self.get_best(
-                    metric="request_throughput", sorted_order="descend"
+                    metric=decode_metric, sorted_order="descend"
                 )
                 if self.decode_best_strategy:
                     self.logger.info(
-                        f"Best decode strategy tuned so far: {self.decode_best_strategy}, and {self.recorder.metric} is {self.decode_best_strategy[self.recorder.metric]}."
+                        f"Best decode strategy tuned so far: {self.decode_best_strategy}, and {decode_metric} is {self.decode_best_strategy[decode_metric]}."
                     )
                 else:
                     self.logger.info(f"No decode strategy can run so far.")

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -408,7 +408,7 @@ class ServeAutoTunner(AutoTuner):
             self.logger.info(f"Record task_{self.idx}:")
             self.record()
 
-            if self.enable_prefill_decode_disaggregation:
+            if self.cur_strategy.get("tune_pd_instance", False):
                 # get best strategy of prefill and decode type
                 prefill_metric = "prompt_throughput"
                 self.prefill_best_strategy = self.get_best(

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -557,6 +557,7 @@ class ServeAutoTunner(AutoTuner):
     def record(self):
         self.recorder.record(self.cur_strategy, self.cur_result)
         self.history.append(self.recorder.cur_strategy)
+        self.logger.warning(f"add history ====================== {self.history} ========= ")
         self.recorder.save(self.history)
 
     def get_best(self, metric=None, sorted_order=None):

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -464,12 +464,17 @@ class ServeAutoTunner(AutoTuner):
         self.logger.warning(
             f"self.prefill_best_strategy: ---------------- {self.prefill_best_strategy}"
         )
+        self.logger.warning(
+            f"tune_pd_instance: {strategy.get("tune_pd_instance", False)} ---------------- prefill_decode_disaggregation: {strategy.get("prefill_decode_disaggregation", False)}"
+        )
         if strategy.get("tune_pd_instance", False):
             self.config.experiment.deploy.prefill_decode_disaggregation = False
         elif strategy.get("prefill_decode_disaggregation", False):
+            self.logger.warning(f"before update config {self.config}--------------")
             self.config.experiment.deploy.prefill_decode_disaggregation = True
             self.config.experiment.deploy.prefill_num = strategy.get("prefill_num", 1)
             self.config.experiment.deploy.decode_num = strategy.get("decode_num", 1)
+            self.logger.warning(f"after update config {self.config}--------------")
             if self.prefill_best_strategy:
                 strategy.update(self.prefill_best_strategy)
         while strategy and (self.pruner is not None and self.pruner.prune(strategy, self.history)):

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -468,6 +468,8 @@ class ServeAutoTunner(AutoTuner):
             self.config.experiment.deploy.prefill_decode_disaggregation = False
         elif strategy.get("prefill_decode_disaggregation", False):
             self.config.experiment.deploy.prefill_decode_disaggregation = True
+            self.config.experiment.deploy.prefill_num = strategy.get("prefill_num", 1)
+            self.config.experiment.deploy.decode_num = strategy.get("decode_num", 1)
             if self.prefill_best_strategy:
                 strategy.update(self.prefill_best_strategy)
         while strategy and (self.pruner is not None and self.pruner.prune(strategy, self.history)):

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -468,8 +468,8 @@ class ServeAutoTunner(AutoTuner):
             self.config.experiment.deploy.prefill_decode_disaggregation = False
         elif strategy.get("prefill_decode_disaggregation", False):
             self.config.experiment.deploy.prefill_decode_disaggregation = True
-        if self.prefill_best_strategy:
-            strategy.update(self.prefill_best_strategy)
+            if self.prefill_best_strategy:
+                strategy.update(self.prefill_best_strategy)
         while strategy and (self.pruner is not None and self.pruner.prune(strategy, self.history)):
             strategy = self.searcher.search()
         if strategy:
@@ -490,8 +490,7 @@ class ServeAutoTunner(AutoTuner):
             self.logger.info(f"Generate task_{self.idx}")
             self.cur_strategy = strategy
             self.cur_task = self.generator.gen(strategy)
-            print(self.cur_task)
-            breakpoint()
+            self.logger.warning(f"self.cur_task******* {self.cur_task} **********")
         else:
             self.cur_strategy = None
 

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -439,8 +439,7 @@ class ServeAutoTunner(AutoTuner):
                     )
                 else:
                     self.logger.info(f"No strategy can run so far.")
-
-        if self.enable_prefill_decode_disaggregation:
+        if self.tune_single_pd_instance:
             self.config.experiment.deploy.prefill_decode_disaggregation = True
 
             while not self.need_stop():

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -415,16 +415,16 @@ class ServeAutoTunner(AutoTuner):
                 )
                 if self.prefill_best_strategy:
                     self.logger.info(
-                        f"Best strategy tuned so far: {self.prefill_best_strategy}, and {self.recorder.metric} is {self.prefill_best_strategy[self.recorder.metric]}."
+                        f"Best prefill strategy tuned so far: {self.prefill_best_strategy}, and {self.recorder.metric} is {self.prefill_best_strategy[self.recorder.metric]}."
                     )
                 else:
                     self.logger.info(f"No prefill strategy can run so far.")
-                decode_best_strategy = self.get_best(
+                self.decode_best_strategy = self.get_best(
                     metric="request_throughput", sorted_order="descend"
                 )
-                if decode_best_strategy:
+                if self.decode_best_strategy:
                     self.logger.info(
-                        f"Best strategy tuned so far: {decode_best_strategy}, and {self.recorder.metric} is {decode_best_strategy[self.recorder.metric]}."
+                        f"Best decode strategy tuned so far: {self.decode_best_strategy}, and {self.recorder.metric} is {self.decode_best_strategy[self.recorder.metric]}."
                     )
                 else:
                     self.logger.info(f"No decode strategy can run so far.")

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -380,9 +380,6 @@ class ServeAutoTunner(AutoTuner):
         self.enable_prefill_decode_disaggregation = self.config.experiment.get("deploy", {}).get(
             "prefill_decode_disaggregation", False
         )
-        self.tune_single_pd_instance = None
-        if self.enable_prefill_decode_disaggregation:
-            self.tune_single_pd_instance = True
 
     def tune(self):
         """

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -443,6 +443,27 @@ class ServeAutoTunner(AutoTuner):
         if self.enable_prefill_decode_disaggregation:
             self.config.experiment.deploy.prefill_decode_disaggregation = True
 
+            while not self.need_stop():
+                self.logger.addHandler(self.handler)
+                self.gen()
+                if not self.cur_strategy:
+                    break
+                self.logger.info(f"Run task_{self.idx}: {self.cur_strategy}")
+                self.run()
+                self.logger.info(f"Monitor task_{self.idx}:")
+                self.monitor()
+                self.logger.info(f"Record task_{self.idx}:")
+                self.record()
+
+                # get best strategy
+                best_strategy = self.get_best()
+                if best_strategy:
+                    self.logger.info(
+                        f"Best strategy tuned so far: {best_strategy}, and {self.recorder.metric} is {best_strategy[self.recorder.metric]}."
+                    )
+                else:
+                    self.logger.info(f"No strategy can run so far.")
+
         tuner_end_time = time.time()
         self.logger.info(f"AutoTuner Ended in {tuner_end_time - tuner_start_time} seconds.")
 

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -380,6 +380,9 @@ class ServeAutoTunner(AutoTuner):
         self.enable_prefill_decode_disaggregation = self.config.experiment.get("deploy", {}).get(
             "prefill_decode_disaggregation", False
         )
+        self.tune_single_pd_instance = None
+        if self.enable_prefill_decode_disaggregation:
+            self.tune_single_pd_instance = True
 
     def tune(self):
         """
@@ -391,6 +394,8 @@ class ServeAutoTunner(AutoTuner):
             Step5. Run the best task
         """
         tuner_start_time = time.time()
+        if self.tune_single_pd_instance:
+            self.config.experiment.deploy.prefill_decode_disaggregation = False
         while not self.need_stop():
             self.logger.addHandler(self.handler)
             self.gen()
@@ -432,6 +437,10 @@ class ServeAutoTunner(AutoTuner):
                     )
                 else:
                     self.logger.info(f"No strategy can run so far.")
+
+        if self.enable_prefill_decode_disaggregation:
+            self.config.experiment.deploy.prefill_decode_disaggregation = True
+
         tuner_end_time = time.time()
         self.logger.info(f"AutoTuner Ended in {tuner_end_time - tuner_start_time} seconds.")
 

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -392,14 +392,14 @@ class ServeAutoTunner(AutoTuner):
         """
         tuner_start_time = time.time()
         while not self.need_stop():
-            if self.cur_strategy.get("tune_pd_instance", False):
-                self.config.experiment.deploy.prefill_decode_disaggregation = False
-            elif self.cur_strategy.get("prefill_decode_disaggregation", False):
-                self.config.experiment.deploy.prefill_decode_disaggregation = True
             self.logger.addHandler(self.handler)
             self.gen()
             if not self.cur_strategy:
                 break
+            if self.cur_strategy.get("tune_pd_instance", False):
+                self.config.experiment.deploy.prefill_decode_disaggregation = False
+            elif self.cur_strategy.get("prefill_decode_disaggregation", False):
+                self.config.experiment.deploy.prefill_decode_disaggregation = True
             self.logger.info(f"Run task_{self.idx}: {self.cur_strategy}")
             self.run()
             self.logger.info(f"Monitor task_{self.idx}:")
@@ -464,6 +464,10 @@ class ServeAutoTunner(AutoTuner):
         self.logger.warning(
             f"self.prefill_best_strategy: ---------------- {self.prefill_best_strategy}"
         )
+        if strategy.get("tune_pd_instance", False):
+            self.config.experiment.deploy.prefill_decode_disaggregation = False
+        elif strategy.get("prefill_decode_disaggregation", False):
+            self.config.experiment.deploy.prefill_decode_disaggregation = True
         if self.prefill_best_strategy:
             strategy.update(self.prefill_best_strategy)
         while strategy and (self.pruner is not None and self.pruner.prune(strategy, self.history)):
@@ -486,6 +490,8 @@ class ServeAutoTunner(AutoTuner):
             self.logger.info(f"Generate task_{self.idx}")
             self.cur_strategy = strategy
             self.cur_task = self.generator.gen(strategy)
+            print(self.cur_task)
+            breakpoint()
         else:
             self.cur_strategy = None
 

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -830,7 +830,7 @@ class SSHServeRunner(RunnerBase):
         prefix_len = profile_args.get("prefix_len", 0)
         input_len = profile_args.get("input_len", 1024)
         output_len = profile_args.get("output_len", 1024)
-        num_prompts = profile_args.get("num_prompts", 200)
+        num_prompts = profile_args.get("num_prompts", 2)
         range_ratio = profile_args.get("range_ratio", 0.5)
         dummy_input_requests = dummy_random_input(
             tokenizer=tokenizer,

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -830,7 +830,7 @@ class SSHServeRunner(RunnerBase):
         prefix_len = profile_args.get("prefix_len", 0)
         input_len = profile_args.get("input_len", 1024)
         output_len = profile_args.get("output_len", 1024)
-        num_prompts = profile_args.get("num_prompts", 2)
+        num_prompts = profile_args.get("num_prompts", 200)
         range_ratio = profile_args.get("range_ratio", 0.5)
         dummy_input_requests = dummy_random_input(
             tokenizer=tokenizer,

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -133,7 +133,7 @@ def _update_config_serve(config: DictConfig):
 
     OmegaConf.set_struct(config, False)
 
-    if deploy_config.get("prefill_decode_disaggregation", False):
+    if deploy_config.get("prefill_decode_disaggregation", False) and config.action != "stop":
         deploy_config["pd_proxy_port"] = get_free_port()
 
     if config.get("logging", None) is None:

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -66,7 +66,7 @@ def _get_args_vllm(config: DictConfig):
 
 def _reset_serve_port(config):
     model_port = None
-    deploy_port = config.experiment.get("deploy", {}).get("port", None)
+    deploy_port = config.experiment.get("runner", {}).get("deploy", {}).get("port", None)
     OmegaConf.set_struct(config, False)
 
     for item in config.serve:
@@ -124,7 +124,7 @@ def _get_profile_args(config, model="vllm_model"):
 
 
 def _update_config_serve(config: DictConfig):
-    deploy_config = config.experiment.get("deploy", {})
+    deploy_config = config.experiment.get("runner", {}).get("deploy", {})
 
     exp_dir = os.path.abspath(config.experiment.exp_dir)
     if not os.path.isdir(exp_dir):
@@ -182,7 +182,7 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
         vllm_path = os.path.dirname(vllm.__path__[0])
     except Exception as e:
         vllm_path = f"{root_dir}/vllm"
-    deploy_config = config.experiment.get("deploy", {})
+    deploy_config = config.experiment.get("runner", {}).get("deploy", {})
     envs = config.experiment.get("envs", {})
     with open(host_run_script_file, "w") as f:
         f.write("#!/bin/bash\n\n")
@@ -509,7 +509,7 @@ def _generate_stop_script(config, host, node_rank):
     else:
         before_start_cmd = ""
 
-    deploy_config = config.experiment.get("deploy", {})
+    deploy_config = config.experiment.get("runner", {}).get("deploy", {})
     envs = config.experiment.get("envs", {})
     with open(host_stop_script_file, "w") as f:
         f.write("#!/bin/bash\n\n")
@@ -604,7 +604,7 @@ class SSHServeRunner(RunnerBase):
         super().__init__(config)
         self.task_type = getattr(self.config.experiment.task, "type", None)
         assert self.task_type == "serve", f"Unsupported task type: {self.task_type}"
-        self.deploy_config = self.config.experiment.get("deploy", {})
+        self.deploy_config = self.config.experiment.get("runner", {}).get("deploy", {})
         if not self.config.experiment.task.get("entrypoint", None):
             self.inference_engine = _get_inference_engine(self.config)
             self.port = _reset_serve_port(config)
@@ -622,7 +622,12 @@ class SSHServeRunner(RunnerBase):
         self.user_envs = self.config.experiment.get("envs", {})
         entrypoint = self.config.experiment.task.get("entrypoint", None)
         if self.inference_engine:
-            if self.config.experiment.get("deploy", {}).get("prefill_decode_disaggregation", False):
+            prefill_decode_disaggregation = (
+                self.config.experiment.get("runner", {})
+                .get("deploy", {})
+                .get("prefill_decode_disaggregation", False)
+            )
+            if prefill_decode_disaggregation:
                 self.user_script = "flagscale/serve/run_disagg_xpyd_router.py"
             elif not self.use_fs_serve:
                 self.user_script = "flagscale/serve/run_inference_engine.py"

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -275,7 +275,7 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
                     logger.info(
                         f"============= prefill instance {i}, p_kv_config: {p_kv_config} ============="
                     )
-                    card_ids = resource_manager.get_available_card_ids(
+                    card_ids, update_p_address = resource_manager.get_available_card_ids(
                         address=p_address, num=each_instance_card_num
                     )
                     card_ids_str = ",".join(map(str, card_ids))
@@ -284,13 +284,13 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
                     p_kv_config_json = json.dumps(p_kv_config)
                     p_instance_log_path = os.path.join(default_log_dir, f"prefill_{i}.log")
 
-                    if p_address != master_ip:
+                    if update_p_address != master_ip:
                         p_kv_config_formate_json = p_kv_config_json.replace('"', '\\"')
                         node_cmd = f"{ids_env} && {vllm_command} --port {http_port} --kv-transfer-config '\\''{p_kv_config_formate_json}'\\''"
                         if docker_name:
-                            ssh_cmd = f"ssh -f -n -p {ssh_port} {p_address} \"docker exec {docker_name} /bin/bash -c '{node_cmd} > {p_instance_log_path} 2>&1 &'\""
+                            ssh_cmd = f"ssh -f -n -p {ssh_port} {update_p_address} \"docker exec {docker_name} /bin/bash -c '{node_cmd} > {p_instance_log_path} 2>&1 &'\""
                         else:
-                            ssh_cmd = f'ssh -f -n -p {ssh_port} {p_address} "{node_cmd} > {p_instance_log_path} 2>&1 &"'
+                            ssh_cmd = f'ssh -f -n -p {ssh_port} {update_p_address} "{node_cmd} > {p_instance_log_path} 2>&1 &"'
                         f.write(f"{ssh_cmd}\n\n")
                     else:
                         p_cmd = f"{ids_env} && {vllm_command} --port {http_port} --kv-transfer-config '\\''{p_kv_config_json}'\\''"
@@ -318,7 +318,7 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
                     logger.info(
                         f"============= decode instance {j}, d_kv_config: {d_kv_config} ============="
                     )
-                    card_ids = resource_manager.get_available_card_ids(
+                    card_ids, update_d_address = resource_manager.get_available_card_ids(
                         address=d_address, num=each_instance_card_num
                     )
                     card_ids_str = ",".join(map(str, card_ids))
@@ -327,13 +327,13 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
                     d_kv_config_json = json.dumps(d_kv_config)
                     d_instance_log_path = os.path.join(default_log_dir, f"decode_{j}.log")
 
-                    if d_address != master_ip:
+                    if update_d_address != master_ip:
                         d_kv_config_formate_json = d_kv_config_json.replace('"', '\\"')
                         node_cmd = f"{ids_env} && {vllm_command} --port {http_port} --kv-transfer-config '\\''{d_kv_config_formate_json}'\\''"
                         if docker_name:
-                            ssh_cmd = f"ssh -f -n -p {ssh_port} {d_address} \"docker exec {docker_name} /bin/bash -c '{node_cmd} > {d_instance_log_path} 2>&1 &'\""
+                            ssh_cmd = f"ssh -f -n -p {ssh_port} {update_d_address} \"docker exec {docker_name} /bin/bash -c '{node_cmd} > {d_instance_log_path} 2>&1 &'\""
                         else:
-                            ssh_cmd = f'ssh -f -n -p {ssh_port} {d_address} "{node_cmd} > {d_instance_log_path} 2>&1 &"'
+                            ssh_cmd = f'ssh -f -n -p {ssh_port} {update_d_address} "{node_cmd} > {d_instance_log_path} 2>&1 &"'
                         f.write(f"{ssh_cmd}\n\n")
                     else:
                         d_cmd = f"{ids_env} && {vllm_command} --port {http_port} --kv-transfer-config '\\''{d_kv_config_json}'\\''"

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -288,9 +288,9 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
                         p_kv_config_formate_json = p_kv_config_json.replace('"', '\\"')
                         node_cmd = f"{ids_env} && {vllm_command} --port {http_port} --kv-transfer-config '\\''{p_kv_config_formate_json}'\\''"
                         if docker_name:
-                            ssh_cmd = f"ssh -f -n -p {ssh_port} {ip} \"docker exec {docker_name} /bin/bash -c '{node_cmd} > {p_instance_log_path} 2>&1 &'\""
+                            ssh_cmd = f"ssh -f -n -p {ssh_port} {p_address} \"docker exec {docker_name} /bin/bash -c '{node_cmd} > {p_instance_log_path} 2>&1 &'\""
                         else:
-                            ssh_cmd = f'ssh -f -n -p {ssh_port} {d_address} "{node_cmd} > {p_instance_log_path} 2>&1 &"'
+                            ssh_cmd = f'ssh -f -n -p {ssh_port} {p_address} "{node_cmd} > {p_instance_log_path} 2>&1 &"'
                         f.write(f"{ssh_cmd}\n\n")
                     else:
                         p_cmd = f"{ids_env} && {vllm_command} --port {http_port} --kv-transfer-config '\\''{p_kv_config_json}'\\''"
@@ -331,7 +331,7 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
                         d_kv_config_formate_json = d_kv_config_json.replace('"', '\\"')
                         node_cmd = f"{ids_env} && {vllm_command} --port {http_port} --kv-transfer-config '\\''{d_kv_config_formate_json}'\\''"
                         if docker_name:
-                            ssh_cmd = f"ssh -f -n -p {ssh_port} {ip} \"docker exec {docker_name} /bin/bash -c '{node_cmd} > {d_instance_log_path} 2>&1 &'\""
+                            ssh_cmd = f"ssh -f -n -p {ssh_port} {d_address} \"docker exec {docker_name} /bin/bash -c '{node_cmd} > {d_instance_log_path} 2>&1 &'\""
                         else:
                             ssh_cmd = f'ssh -f -n -p {ssh_port} {d_address} "{node_cmd} > {d_instance_log_path} 2>&1 &"'
                         f.write(f"{ssh_cmd}\n\n")

--- a/flagscale/runner/utils.py
+++ b/flagscale/runner/utils.py
@@ -666,7 +666,7 @@ class ResourceManager:
                 raise ValueError("Insufficient resources")
             allocated_ids = list(range(node_found["used"], node_found["used"] + num))
             node_found["used"] += num
-            return allocated_ids
+            return allocated_ids, address
 
         # For address == "auto", traverse all nodes (master node first, then worker nodes)
         for node in self.nodes:
@@ -675,7 +675,7 @@ class ResourceManager:
                 if free >= num:
                     allocated_ids = list(range(node["used"], node["used"] + num))
                     node["used"] += num
-                    return allocated_ids
+                    return allocated_ids, node["address"]
 
         # If no node satisfies the allocation request, raise an error.
         resource_status = self.get_status()

--- a/flagscale/serve/run_disagg_xpyd_router.py
+++ b/flagscale/serve/run_disagg_xpyd_router.py
@@ -219,7 +219,7 @@ async def handle_request():
     try:
         original_data = await request.get_json()
         endpoint = request.path  # this will be '/v1/completions' or '/v1/chat/completions'
-
+        logger.info(f"========== input origin data {original_data}==========")
         # calculate tokens num
         prompt_tokens_num = 0
         if SCHEDULING_STRATEGY == "slo":

--- a/flagscale/serve/run_disagg_xpyd_router.py
+++ b/flagscale/serve/run_disagg_xpyd_router.py
@@ -36,7 +36,9 @@ TASK_CONFIG = serve.task_config
 MODEL_PATH = TASK_CONFIG.serve[0].get("engine_args", {}).get("model", None)
 
 # Scheduling strategy: 'random', 'robin', 'slo'
-SCHEDULING_STRATEGY = TASK_CONFIG.experiment.get("deploy", {}).get("prefill_decode_strategy", "slo")
+SCHEDULING_STRATEGY = (
+    TASK_CONFIG.experiment.get("runner", {}).get("deploy", {}).get("prefill_decode_strategy", "slo")
+)
 
 
 @lru_cache(maxsize=32)
@@ -283,7 +285,7 @@ async def handle_request():
 
 
 def main():
-    deploy_config = TASK_CONFIG.experiment.get("deploy", {})
+    deploy_config = TASK_CONFIG.experiment.get("runner", {}).get("deploy", {})
     serve_port = deploy_config.get("port", None)
     # Used to register with the pd service discovery
     pd_proxy_port = deploy_config.get("pd_proxy_port", None)

--- a/flagscale/serve/run_disagg_xpyd_router.py
+++ b/flagscale/serve/run_disagg_xpyd_router.py
@@ -227,7 +227,7 @@ async def handle_request():
     try:
         original_data = await request.get_json()
         endpoint = request.path  # this will be '/v1/completions' or '/v1/chat/completions'
-        logger.info(f"========== input origin data {original_data}==========")
+        # logger.info(f"========== input origin data {original_data}==========")
         # calculate tokens num
         prompt_tokens_num = 0
         if SCHEDULING_STRATEGY == "slo":

--- a/flagscale/serve/run_disagg_xpyd_router.py
+++ b/flagscale/serve/run_disagg_xpyd_router.py
@@ -46,7 +46,15 @@ def load_hf_tokenizer(model_path: str):
 
 def count_chat_tokens(messages: List[Dict[str, Any]]) -> int:
     tokenizer = load_hf_tokenizer(MODEL_PATH)
-    text = tokenizer.apply_chat_template(messages, add_generation_prompt=False, tokenize=False)
+    normalized_message = []
+    for msg in messages:
+        content = msg["content"]
+        if isinstance(content, list):
+            content = "".join(part["text"] for part in content if part.get("type") == "text")
+        normalized_message.append({"role": msg["role"], "content": content})
+    text = tokenizer.apply_chat_template(
+        normalized_message, add_generation_prompt=False, tokenize=False
+    )
     return len(tokenizer.encode(text, add_special_tokens=False))
 
 

--- a/flagscale/serve/run_fs_serve_vllm.py
+++ b/flagscale/serve/run_fs_serve_vllm.py
@@ -548,7 +548,7 @@ if __name__ == "__main__":
     serve.start(
         http_options={
             "host": "0.0.0.0",
-            "port": TASK_CONFIG.experiment.get("deploy", {}).get("port", 8000),
+            "port": TASK_CONFIG.experiment.get("runner", {}).get("deploy", {}).get("port", 8000),
         }
     )
     llm_actor = LLMActor.bind()

--- a/run.py
+++ b/run.py
@@ -1,6 +1,8 @@
+import warnings
+
 import hydra
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from flagscale.runner.auto_tuner import AutoTuner, ServeAutoTunner
 from flagscale.runner.runner_compress import SSHCompressRunner
@@ -13,8 +15,21 @@ from flagscale.runner.utils import is_master
 # we have placed the import statements inside the function body rather than at the beginning of the file.
 
 
+def check_config(config: DictConfig) -> None:
+    if config.experiment.get("deploy", {}):
+        OmegaConf.set_struct(config.experiment.runner, False)
+        config.experiment.runner.deploy = config.experiment.deploy
+        del config.experiment.deploy
+        warnings.warn(
+            "'config.experiment.deploy' has been moved to 'config.experiment.runner.deploy'. "
+            "Support for the old location will be removed in a future release."
+        )
+        OmegaConf.set_struct(config.experiment.runner, True)
+
+
 @hydra.main(version_base=None, config_name="config")
 def main(config: DictConfig) -> None:
+    check_config(config)
     task_type = config.experiment.task.get("type", "train")
     if task_type == "train":
         if config.action == "auto_tune":

--- a/run.py
+++ b/run.py
@@ -16,7 +16,7 @@ from flagscale.runner.utils import is_master
 
 
 def check_config(config: DictConfig) -> None:
-    if config.experiment.get("runner", {}).get("deploy", {}):
+    if config.experiment.get("deploy", {}):
         OmegaConf.set_struct(config.experiment.runner, False)
         config.experiment.runner.deploy = config.experiment.deploy
         del config.experiment.deploy

--- a/run.py
+++ b/run.py
@@ -16,7 +16,7 @@ from flagscale.runner.utils import is_master
 
 
 def check_config(config: DictConfig) -> None:
-    if config.experiment.get("deploy", {}):
+    if config.experiment.get("runner", {}).get("deploy", {}):
         OmegaConf.set_struct(config.experiment.runner, False)
         config.experiment.runner.deploy = config.experiment.deploy
         del config.experiment.deploy


### PR DESCRIPTION
## Description

Steps for automatic tuning PD Dissagragetion:

- step1. Tune the optimal configurations for single instance of P (Prefill) and D (Decode). The tuning objective for P is maximizing input throughput per card, while for D it is maximizing output throughput per card.

- step2. Based on the optimal configurations of P and D, tune the optimal ratio between P and D.

Note: 'config.experiment.deploy' has been moved to 'config.experiment.runner.deploy'. Support of old deploy location will be removed in future.