### PR TITLE
[Core] Update FlagScale setup

### DIFF
--- a/custom_build_backend/flagscale_build_backend.py
+++ b/custom_build_backend/flagscale_build_backend.py
@@ -1,0 +1,16 @@
+import os
+
+import setuptools.build_meta as orig_backend
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    build_args = config_settings or {}
+
+    if "backend" in build_args:
+        os.environ["FLAGSCALE_BACKEND"] = build_args["backend"]
+        print(f"[FLAGSCALE] Set FLAGSCALE_BACKEND={build_args['backend']}")
+    if "device" in build_args:
+        os.environ["FLAGSCALE_DEVICE"] = build_args["device"]
+        print(f"[FLAGSCALE] Set FLAGSCALE_DEVICE={build_args['device']}")
+
+    return orig_backend.build_wheel(wheel_directory, config_settings, metadata_directory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=77.0", "wheel", "gitpython"]
+build-backend = "custom_build_backend.flagscale_build_backend"
+
 [tool.black]
 line-length = 100
 skip_string_normalization = true

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,33 @@ def _build_llama_cpp(device):
 
 
 def _build_megatron_energon(device):
-    pass
+    try:
+        import editables
+        import hatch_vcs
+        import hatchling
+    except:
+        try:
+            print("[INFO] hatchling not found. Installing...")
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "hatchling", "--no-build-isolation"]
+            )
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "hatch-vcs", "--no-build-isolation"]
+            )
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "editables", "--no-build-isolation"]
+            )
+            import editables
+            import hatch_vcs
+            import hatchling
+        except:
+            print("[ERROR] Failed to install hatchling, hatch-vcs and editables.")
+            sys.exit(1)
+    energon_path = os.path.join(os.path.dirname(__file__), "third_party", "Megatron-Energon")
+    subprocess.check_call(
+        [sys.executable, '-m', 'pip', 'install', '-e', '.', '--no-build-isolation', '--verbose'],
+        cwd=energon_path,
+    )
 
 
 class FlagScaleBuild(_build):
@@ -384,7 +410,10 @@ class FlagScaleBuildExt(_build_ext):
                         f"[build_ext] Megatron-LM does not need to be built, just copy the source code."
                     )
                 elif backend == "Megatron-Energon":
-                    pass
+                    _build_megatron_energon(self.device)
+                    print(
+                        f"[build_ext] Megatron-Energon will be copied to megatron after installed."
+                    )
                 else:
                     raise ValueError(f"Unknown backend: {backend}")
         super().run()

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 import os
+import shutil
 import subprocess
 import sys
 
 from setuptools import find_packages, setup
+from setuptools.command.build import build as _build
+from setuptools.command.build_ext import build_ext as _build_ext
+from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.install import install
+from setuptools.command.install_lib import install_lib as _install_lib
 
 try:
     import git  # from GitPython
@@ -18,74 +23,348 @@ except:
         )
         sys.exit(1)
 
-from tools.patch.unpatch import unpatch
+SUPPORTED_DEVICES = ["cpu", "gpu", "ascend", "cambricon", "bi", "metax", "kunlunxin", "musa"]
+VLLM_UNPATCH_DEVICES = ["ascend", "cambricon", "bi", "metax", "kunlunxin"]
 
 
-def is_nvidia_chip():
-    try:
-        result = subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if result.returncode == 0:
-            return True
-    except Exception as e:
-        pass
-    return False
+def _check_backend(backend):
+    if backend not in ["llama.cpp", "Megatron-LM", "sglang", "vllm", "Megatron-Energon"]:
+        raise ValueError(f"Invalid backend {backend}.")
 
 
-class InstallRequirement(install):
+def check_backends(backends):
+    for backend in backends:
+        _check_backend(backend)
+
+
+def check_vllm_unpatch_device(device):
+    is_supported = False
+    for supported_device in VLLM_UNPATCH_DEVICES:
+        if supported_device in device.lower():
+            is_supported = True
+            return is_supported
+    return is_supported
+
+
+def check_device(device):
+    is_supported = False
+    for supported_device in SUPPORTED_DEVICES:
+        if supported_device in device.lower():
+            is_supported = True
+            return
+    if not is_supported:
+        raise ValueError(f"Unsupported device {device}. Supported devices are {SUPPORTED_DEVICES}.")
+
+
+# Call for the extensions
+def _build_vllm(device):
+    assert device != "cpu"
+    vllm_path = os.path.join(os.path.dirname(__file__), "third_party", "vllm")
+    if device != "gpu":
+        vllm_path = os.path.join(
+            os.path.dirname(__file__), "build", device, "FlagScale", "third_party", "vllm"
+        )
+    subprocess.check_call(
+        [sys.executable, '-m', 'pip', 'install', '.', '--no-build-isolation', '--verbose'],
+        cwd=vllm_path,
+    )
+
+
+def _build_sglang(device):
+    assert device != "cpu"
+    sglang_path = os.path.join(os.path.dirname(__file__), "third_party", "sglang")
+    if device != "gpu":
+        sglang_path = os.path.join(
+            os.path.dirname(__file__), "build", device, "FlagScale", "third_party", "sglang"
+        )
+    subprocess.check_call(
+        [
+            sys.executable,
+            '-m',
+            'pip',
+            'install',
+            '-e',
+            'python[all]',
+            '--no-build-isolation',
+            '--verbose',
+        ],
+        cwd=sglang_path,
+    )
+
+
+def _build_llama_cpp(device):
+    llama_cpp_path = os.path.join(os.path.dirname(__file__), "third_party", "llama.cpp")
+    print(f"[build_ext] Build llama.cpp for {device}")
+    if device == "gpu":
+        subprocess.check_call(["cmake", "-B", "build", "-DGGML_CUDA=ON"], cwd=llama_cpp_path)
+        subprocess.check_call(
+            ["cmake", "--build", "build", "--config", "Release", "-j64"], cwd=llama_cpp_path
+        )
+    elif device == "musa":
+        subprocess.check_call(["cmake", "-B", "build", "-DGGML_MUSA=ON"], cwd=llama_cpp_path)
+        subprocess.check_call(
+            ["cmake", "--build", "build", "--config", "Release", "-j8"], cwd=llama_cpp_path
+        )
+    elif device == "cpu":
+        subprocess.check_call(["cmake", "-B", "build"], cwd=llama_cpp_path)
+        subprocess.check_call(
+            ["cmake", "--build", "build", "--config", "Release", "-j8"], cwd=llama_cpp_path
+        )
+    else:
+        raise ValueError(f"Unsupported device {device} for llama.cpp backend.")
+
+
+def _build_megatron_energon(device):
+    pass
+
+
+class FlagScaleBuild(_build):
+    """
+    Build the FlagScale backends.
+    """
+
+    user_options = _build.user_options + [
+        ('backend=', None, 'Build backends'),
+        ('device=', None, 'Device type for build'),
+    ]
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.backend = None
+        self.device = None
+
+    def finalize_options(self):
+        super().finalize_options()
+        if self.backend is None:
+            self.backend = os.environ.get("FLAGSCALE_BACKEND")
+        if self.device is None:
+            self.device = os.environ.get("FLAGSCALE_DEVICE", "gpu")
+        if self.backend is not None:
+            # Set the environment variables for backends and device to use in the install command
+            # os.environ["FLAGSCALE_BACKEND"] = self.backend
+            # os.environ["FLAGSCALE_DEVICE"] = self.device
+            check_device(self.device)
+
+            from tools.patch.patch import normalize_backend
+
+            backends = self.backend.split(",")
+            self.backend = [normalize_backend(backend.strip()) for backend in backends]
+            print(f"[build] Received backend = {self.backend}")
+            print(f"[build] Received device = {self.device}")
+        else:
+            print(f"[build] No backend specified, just build FlagScale python codes.")
+
     def run(self):
-        if is_nvidia_chip():
-            # TODO: At present, it is assumed that the relevant dependencies have been installed,
-            # and automatic installation of the relevant dependencies is supported in the future.
-            # After verification, open the comment.
-            """
-            print("In NVIDIA chip, install train and inference dependencies automatically...")
-            # Install train requirements
-            print("Install train dependencies...")
-            env_param = '--env train'
-            subprocess.check_call(['bash', './install/install-requirements.sh', env_param])
+        if self.backend is not None:
+            build_py_cmd = self.get_finalized_command('build_py')
+            build_py_cmd.backend = self.backend
+            build_py_cmd.device = self.device
+            build_py_cmd.ensure_finalized()
 
-            # Install vllm requirements
-            print("Install inference dependencies...")
-            env_param = "--env inference"
-            subprocess.check_call(
-                ["bash", "./install/install-requirements.sh", env_param]
+            build_ext_cmd = self.get_finalized_command('build_ext')
+            build_ext_cmd.backend = self.backend
+            build_ext_cmd.device = self.device
+            build_ext_cmd.ensure_finalized()
+
+            self.run_command('build_py')
+            self.run_command('build_ext')
+        super().run()
+
+
+class FlagScaleBuildPy(_build_py):
+    """
+    Unpatch the FlagScale backends.
+    """
+
+    user_options = _build_py.user_options + [
+        ('backend=', None, 'Build backends'),
+        ('device=', None, 'Device type for build'),
+    ]
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.backend = None
+        self.device = None
+
+    def unpatch_backend(self):
+        from tools.patch.unpatch import unpatch
+
+        main_path = os.path.dirname(__file__)
+        for backend in self.backend:
+            if backend == "FlagScale":
+                continue
+            backend_commit = None
+            if backend == "Megatron-LM":
+                backend_commit = os.getenv(f"FLAGSCALE_MEGATRON_COMMIT", None)
+            elif backend == "Megatron-Energon":
+                backend_commit = os.getenv(f"FLAGSCALE_ENERGON_COMMIT", None)
+            elif backend == "sglang":
+                backend_commit = os.getenv(f"FLAGSCALE_SGLANG_COMMIT", None)
+            elif backend == "vllm":
+                backend_commit = os.getenv(f"FLAGSCALE_VLLM_COMMIT", None)
+            elif backend == "llama.cpp":
+                backend_commit = os.getenv(f"FLAGSCALE_LLAMA_CPP_COMMIT", None)
+            dst = os.path.join(main_path, "third_party", backend)
+            src = os.path.join(main_path, "flagscale", "backends", backend)
+            print(f"[build_py] Device {self.device} initializing the {backend} backend.")
+            force = os.getenv("FLAGSCALE_FORCE_INIT", False)
+            unpatch(
+                main_path,
+                src,
+                dst,
+                backend,
+                mode="copy",
+                force=force,
+                backend_commit=backend_commit,
+                fs_extension=True,
             )
-            """
-            pass
-        # Continue to install
-        install.run(self)
+            # ===== Copy for packaging =====
+            if backend == "Megatron-LM":
+                rel_src = os.path.join("third_party", backend, "megatron")
+                abs_src = os.path.join(main_path, rel_src)
+                abs_dst = os.path.join(self.build_lib, "flag_scale", rel_src)
+                print(f"[build_py] Copying {abs_src} -> {abs_dst}")
+                if os.path.exists(abs_dst):
+                    shutil.rmtree(abs_dst)
+                shutil.copytree(abs_src, abs_dst)
+
+    def run(self):
+        super().run()
+        if self.backend:
+            print(f"[build_py] Running with backend = {self.backend}")
+            assert self.device is not None
+            from tools.patch.unpatch import apply_hardware_patch
+
+            # At present, only vLLM supports domestic chips, and the remaining backends have not been supported yet.
+            # FlagScale just modified the vLLM and Megatron-LM
+            main_path = os.path.dirname(__file__)
+            if "vllm" in self.backend or "Megatron-LM" in self.backend:
+                if check_vllm_unpatch_device(self.device):
+                    print(f"[build_py] Device {self.device} unpatching the vllm backend.")
+                    # Unpatch the backed in specified device
+                    from git import Repo
+
+                    main_repo = Repo(main_path)
+                    commit = os.getenv("FLAGSCALE_UNPATCH_COMMIT", None)
+                    if commit is None:
+                        commit = main_repo.head.commit.hexsha
+                    # Checkout to the commit and apply the patch to build FlagScale
+                    key_path = os.getenv("FLAGSCALE_KEY_PATH", None)
+                    apply_hardware_patch(
+                        self.device, self.backend, commit, main_path, True, key_path=key_path
+                    )
+                    build_lib_flagscale = os.path.join(self.build_lib, "flag_scale")
+                    src_flagscale = os.path.join(main_path, "build", self.device, "FlagScale")
+
+                    for f in os.listdir(build_lib_flagscale):
+                        if f.endswith(".py"):
+                            file_path = os.path.join(build_lib_flagscale, f)
+                            print(f"[build_py] Removing file {file_path}")
+                            os.remove(file_path)
+
+                    for f in os.listdir(src_flagscale):
+                        if f.endswith(".py"):
+                            src_file = os.path.join(src_flagscale, f)
+                            dst_file = os.path.join(build_lib_flagscale, f)
+                            print(f"[build_py] Copying file {src_file} -> {dst_file}")
+                            shutil.copy2(src_file, dst_file)
+
+                    dirs_to_copy = ["flagscale", "examples", "tools", "tests"]
+                    for d in dirs_to_copy:
+                        src_dir = os.path.join(src_flagscale, d)
+                        dst_dir = os.path.join(build_lib_flagscale, d)
+                        if os.path.exists(dst_dir):
+                            print(f"[build_py] Removing directory {dst_dir}")
+                            shutil.rmtree(dst_dir)
+                        if os.path.exists(src_dir):
+                            print(f"[build_py] Copying directory {src_dir} -> {dst_dir}")
+                            shutil.copytree(src_dir, dst_dir)
+
+                    # ===== Copy for packaging =====
+                    if "Megatron-LM" in self.backend:
+                        rel_src = os.path.join(
+                            main_path,
+                            "build",
+                            self.device,
+                            "FlagScale",
+                            "third_party",
+                            "Megatron-LM",
+                            "megatron",
+                        )
+                        abs_src = os.path.join(main_path, rel_src)
+                        abs_dst = os.path.join(
+                            self.build_lib, "flag_scale", "third_party", "Megatron-LM", "megatron"
+                        )
+                        print(f"[build_py] Copying {abs_src} -> {abs_dst}")
+                        if os.path.exists(abs_dst):
+                            shutil.rmtree(abs_dst)
+                        shutil.copytree(abs_src, abs_dst)
+                else:
+                    self.unpatch_backend()
+            else:
+                self.unpatch_backend()
 
 
-# unpatch the Megatron-LM
-main_path = os.path.dirname(__file__)
+class FlagScaleBuildExt(_build_ext):
+    """
+    Build or pip install the FlagScale backends.
+    """
 
-backend = "Megatron-LM"
-src = os.path.join(main_path, "flagscale", "backends", backend)
-dst = os.path.join(main_path, "third_party", backend)
-unpatch(main_path, src, dst, backend, mode="copy")
+    user_options = _build_py.user_options + [
+        ('backend=', None, 'Build backends'),
+        ('device=', None, 'Device type for build'),
+    ]
 
-backend = "Megatron-Energon"
-src = os.path.join(main_path, "flagscale",  "backends", backend)
-dst = os.path.join(main_path, "third_party", backend)
-unpatch(main_path, src, dst, backend, mode="copy")
+    def initialize_options(self):
+        super().initialize_options()
+        self.backend = None
+        self.device = None
 
-backend = "vllm"
-src = os.path.join(main_path, "flagscale", "backends", backend)
-dst = os.path.join(main_path, "third_party", backend)
-unpatch(main_path, src, dst, backend, mode="copy")
+    def finalize_options(self):
+        super().finalize_options()
+        if self.backend:
+            print(f"[build_ext] Backend received: {self.backend}")
+
+    def run(self):
+        if self.backend:
+            print(f"[build_ext] Building extensions for backend = {self.backend}")
+            for backend in self.backend:
+                if backend == "FlagScale":
+                    continue
+                elif backend == "vllm":
+                    _build_vllm(self.device)
+                elif backend == "sglang":
+                    _build_sglang(self.device)
+                elif backend == "llama.cpp":
+                    _build_llama_cpp(self.device)
+                elif backend == "Megatron-LM":
+                    print(
+                        f"[build_ext] Megatron-LM does not need to be built, just copy the source code."
+                    )
+                elif backend == "Megatron-Energon":
+                    pass
+                else:
+                    raise ValueError(f"Unknown backend: {backend}")
+        super().run()
+
+
+class FlagScaleInstallLib(_install_lib):
+    def run(self):
+        build_py_cmd = self.get_finalized_command("build_py")
+        backend = getattr(build_py_cmd, "backend", None)
+        print(f"[install_lib] Got backends from build_py: {backend}")
+        super().run()
+
+        raise ValueError(self.install_dir)
 
 
 setup(
     name="flag_scale",
-    version="0.6.0",
+    version="0.8.0",
     description="FlagScale is a comprehensive toolkit designed to support the entire lifecycle of large models, developed with the backing of the Beijing Academy of Artificial Intelligence (BAAI). ",
     url="https://github.com/FlagOpen/FlagScale",
     packages=[
         "flag_scale",
-        "flag_scale.third_party.Megatron-LM.megatron",
-        "flag_scale.third_party.Megatron-LM.tests",
-        "flag_scale.third_party.Megatron-LM.tools",
-        "flag_scale.third_party.Megatron-LM.megatron.energon",
         "flag_scale.flagscale",
         "flag_scale.examples",
         "flag_scale.tools",
@@ -93,20 +372,12 @@ setup(
     ],
     package_dir={
         "flag_scale": "",
-        "flag_scale.third_party.Megatron-LM.megatron": "third_party/Megatron-LM/megatron",
-        "flag_scale.third_party.Megatron-LM.tests": "third_party/Megatron-LM/tests",
-        "flag_scale.third_party.Megatron-LM.tools": "third_party/Megatron-LM/tools",
-        "flag_scale.third_party.Megatron-LM.megatron.energon": "third_party/Megatron-Energon/src/megatron/energon",
         "flag_scale.flagscale": "flagscale",
         "flag_scale.examples": "examples",
         "flag_scale.tools": "tools",
         "flag_scale.tests": "tests",
     },
     package_data={
-        "flag_scale.third_party.Megatron-LM.megatron": ["**/*"],
-        "flag_scale.third_party.Megatron-LM.tests": ["**/*"],
-        "flag_scale.third_party.Megatron-LM.tools": ["**/*"],
-        "flag_scale.third_party.Megatron-LM.megatron.energon": ["**/*"],
         "flag_scale.flagscale": ["**/*"],
         "flag_scale.examples": ["**/*"],
         "flag_scale.tools": ["**/*"],
@@ -116,10 +387,14 @@ setup(
         "click",
         "gitpython",
         "cryptography",
-        "setuptools>=75.1.0",
-        "packaging>=24.1",
+        "setuptools>=77.0.0",
+        "packaging>=24.2",
         "importlib_metadata>=8.5.0",
     ],
     entry_points={"console_scripts": ["flagscale=flag_scale.flagscale.cli:flagscale"]},
-    cmdclass={"install": InstallRequirement},
+    cmdclass={
+        "build": FlagScaleBuild,
+        "build_py": FlagScaleBuildPy,
+        "build_ext": FlagScaleBuildExt,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -228,6 +228,20 @@ class FlagScaleBuildPy(_build_py):
                     shutil.rmtree(abs_dst)
                 shutil.copytree(abs_src, abs_dst)
 
+        # ===== Copy for packaging for Megatron-Energon =====
+        if "Megatron-Energon" in self.backend:
+            assert "Megatron-LM" in self.backend, "Megatron-Energon requires Megatron-LM"
+            abs_src = os.path.join(
+                main_path, "third_party", "Megatron-Energon", "src", "megatron", "energon"
+            )
+            abs_dst = os.path.join(
+                self.build_lib, "flag_scale", "third_party", "Megatron-LM", "megatron", "energon"
+            )
+            print(f"[build_py] Copying {abs_src} -> {abs_dst}")
+            if os.path.exists(abs_dst):
+                shutil.rmtree(abs_dst)
+            shutil.copytree(abs_src, abs_dst)
+
     def run(self):
         super().run()
         if self.backend:
@@ -294,6 +308,34 @@ class FlagScaleBuildPy(_build_py):
                         abs_src = os.path.join(main_path, rel_src)
                         abs_dst = os.path.join(
                             self.build_lib, "flag_scale", "third_party", "Megatron-LM", "megatron"
+                        )
+                        print(f"[build_py] Copying {abs_src} -> {abs_dst}")
+                        if os.path.exists(abs_dst):
+                            shutil.rmtree(abs_dst)
+                        shutil.copytree(abs_src, abs_dst)
+
+                    if "Megatron-Energon" in self.backend:
+                        assert (
+                            "Megatron-LM" in self.backend
+                        ), "Megatron-Energon requires Megatron-LM"
+                        abs_src = os.path.join(
+                            main_path,
+                            "build",
+                            self.device,
+                            "FlagScale",
+                            "third_party",
+                            "Megatron-Energon",
+                            "src",
+                            "megatron",
+                            "energon",
+                        )
+                        abs_dst = os.path.join(
+                            self.build_lib,
+                            "flag_scale",
+                            "third_party",
+                            "Megatron-LM",
+                            "megatron",
+                            "energon",
                         )
                         print(f"[build_py] Copying {abs_src} -> {abs_dst}")
                         if os.path.exists(abs_dst):


### PR DESCRIPTION
This PR updates the installation mechanism of FlagScale. Usage is as follows:
`cd FlagScale`
`PYTHONPATH=./:$PYTHONPATH pip install . --config-settings=backend=<backend> --config-settings=device=<device>  --verbose --no-build-isolation`
The `backend` parameter can accept multiple values, separated by commas, such as "vllm,sglang,llama.cpp"