### PR TITLE
[Tool] Add patch history yaml

### DIFF
--- a/hardware/patch_history.yaml
+++ b/hardware/patch_history.yaml
@@ -1,0 +1,59 @@
+BI_V150:
+  inference:
+    FlagScale+vllm:
+    - 39c0adcf0db48417ded4842c92067626bd55562f
+    vllm:
+    - 39c0adcf0db48417ded4842c92067626bd55562f
+    FlagScale:
+    - 39c0adcf0db48417ded4842c92067626bd55562f
+Cambricon_MLU:
+  inference:
+    FlagScale+vllm:
+    - 10faa30d1635fb8a102a48352d196870841100a0
+    - 1d6faaad9c56e3e5ccae0526a6a977fae46650d2
+    vllm:
+    - 10faa30d1635fb8a102a48352d196870841100a0
+    - 1d6faaad9c56e3e5ccae0526a6a977fae46650d2
+    FlagScale:
+    - 10faa30d1635fb8a102a48352d196870841100a0
+    - 1d6faaad9c56e3e5ccae0526a6a977fae46650d2
+Kunlunxin_R310p:
+  inference:
+    FlagScale+vllm:
+    - 571b9880d2b81ffe85e87e2e0bc3cf23f1d402d9
+    vllm:
+    - 571b9880d2b81ffe85e87e2e0bc3cf23f1d402d9
+    FlagScale:
+    - 571b9880d2b81ffe85e87e2e0bc3cf23f1d402d9
+MUSA_S5000:
+  train:
+    FlagScale+Megatron-LM:
+    - e4a55046ec83451444b03de17d0a743794e85a87
+    - ab023d3c849cbe22c586cba5970260dd501093f2
+    - ad8411712dfbbdf03ec791878d32d578e917593f
+    Megatron-LM:
+    - e4a55046ec83451444b03de17d0a743794e85a87
+    - ab023d3c849cbe22c586cba5970260dd501093f2
+    - ad8411712dfbbdf03ec791878d32d578e917593f
+    FlagScale:
+    - e4a55046ec83451444b03de17d0a743794e85a87
+    - ab023d3c849cbe22c586cba5970260dd501093f2
+    - ad8411712dfbbdf03ec791878d32d578e917593f
+Metax_C550:
+  inference:
+    FlagScale+vllm:
+    - 2c0b2d6123bab89e85b84e2a33ba7bd50f70de48
+    - 6798d71df02b1d7c7dc6d659573a2e33c2b1021e
+    vllm:
+    - 2c0b2d6123bab89e85b84e2a33ba7bd50f70de48
+    - 6798d71df02b1d7c7dc6d659573a2e33c2b1021e
+    FlagScale:
+    - 2c0b2d6123bab89e85b84e2a33ba7bd50f70de48
+    - 6798d71df02b1d7c7dc6d659573a2e33c2b1021e
+  train:
+    FlagScale+Megatron-LM:
+    - 242842398986e61cdd43b0b3e2b03e95f6553899
+    Megatron-LM:
+    - 242842398986e61cdd43b0b3e2b03e95f6553899
+    FlagScale:
+    - 242842398986e61cdd43b0b3e2b03e95f6553899

--- a/tools/patch/merge.py
+++ b/tools/patch/merge.py
@@ -1,0 +1,80 @@
+import argparse
+import yaml
+import os
+from git.repo import Repo
+
+from patch import normalize_backend
+
+def merge(backends, device_type, tasks, commit):
+    """
+    Merge patch history for the specified backend(s), device type, and task(s).
+    """
+    if not commit:
+        raise ValueError("Commit ID must be provided.")
+    if not device_type:
+        raise ValueError("Device type must be provided.")
+    patch_dir = os.path.dirname(os.path.abspath(__file__))
+    tools_dir = os.path.dirname(patch_dir)
+    FlagScale_dir = os.path.dirname(tools_dir)
+    main_repo = Repo(FlagScale_dir)
+    try:
+        main_repo.commit(commit)
+    except Exception as e:
+        raise ValueError(f"Invalid commit ID: {commit}. Error: {e}")
+    history_yaml = os.path.join(FlagScale_dir, "hardware", "patch_history.yaml")
+    if os.path.exists(history_yaml):
+        with open(history_yaml, "r") as f:
+            history = yaml.safe_load(f) or {}
+    else:
+        history = {}
+
+    if device_type not in history:
+        history[device_type] = {}
+
+    backends_key = "+".join(sorted(backends))
+
+    for task in tasks:
+        if task not in history[device_type]:
+            history[device_type][task] = {}
+        if backends_key not in history[device_type][task]:
+            history[device_type][task][backends_key] = []
+        if commit not in history[device_type][task][backends_key]:
+            history[device_type][task][backends_key].append(commit)
+
+        # Also write to each individual backend
+        for backend in backends:
+            if backend not in history[device_type][task]:
+                history[device_type][task][backend] = []
+            if commit not in history[device_type][task][backend]:
+                history[device_type][task][backend].append(commit)
+
+    with open(history_yaml, "w") as f:
+        yaml.dump(history, f, sort_keys=False)
+    print(f"Patch history updated in {history_yaml}.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Add patch history.")
+    parser.add_argument(
+        "--backend",
+        nargs="+",
+        type=normalize_backend,
+        default=["Megatron-LM"],
+        help="Backend to patch (default: Megatron-LM)",
+    )
+    parser.add_argument(
+        "--device-type", type=str, required=True, help="Device type (e.g., gpu, cambricon, ascend)."
+    )
+    parser.add_argument(
+        "--task",
+        nargs="+",
+        required=True,
+        choices=["train", "inference", "post_train"],
+        help="Task(s) to add.",
+    )
+    parser.add_argument(
+        "--commit", type=str, required=True, help="Commit ID to record."
+    )
+
+    args = parser.parse_args()
+
+    merge(args.backend, args.device_type, args.task, args.commit)

--- a/tools/patch/unpatch.py
+++ b/tools/patch/unpatch.py
@@ -117,7 +117,9 @@ def commit_to_checkout(main_path, device_type=None, tasks=None, backends=None, c
         with open(history_yaml, 'r') as f:
             history = yaml.safe_load(f)
             if device_type not in history:
-                raise ValueError(f"Device type {device_type} not found in {history_yaml}.")
+                logger.warning(f"Device type {device_type} not found in {history_yaml}.")
+                logger.warning("Try to use the current commit to unpatch.")
+                return main_repo.head.commit.hexsha
 
             # Find the newest flagscale commit in the history
             for task in tasks:
@@ -139,9 +141,11 @@ def commit_to_checkout(main_path, device_type=None, tasks=None, backends=None, c
                         f"The commit ID {newest_flagscale_commit} does not exist in the FlagScale. Please check the {history_yaml}"
                     )
                     newest_flagscale_commit = None
-        assert (
-            newest_flagscale_commit is not None
-        ), f"FlagScale Commit for device type {device_type}, task {task} is not found. Please check the {history_yaml}."
+        if not newest_flagscale_commit:
+            logger.warning(
+                f"No valid commit found for device type {device_type}, task {task} in {history_yaml}. Try to use the current commit to unpatch."
+            )
+            return main_repo.head.commit.hexsha
     return newest_flagscale_commit
 
 


### PR DESCRIPTION
This PR adds the patch history yaml for hardware and use `python tools/patch/merge.py --backend vllm FlagScale --task inference --device-type <device> --commit <merged_in_flagscale_commit>` to add information.