### PR TITLE
[Serve] Support cloud serving

### DIFF
--- a/examples/cloud/conf/serve.yaml
+++ b/examples/cloud/conf/serve.yaml
@@ -11,7 +11,7 @@ experiment:
     use_fs_serve: false
   runner:
     type: cloud
-    hostfile: ${oc.env:HOSTFILE, null}
+    hostfile: ${oc.env:HOSTFILE, /etc/hostfile}
     master_addr: ${oc.env:MASTER_ADDR, 127.0.0.1}
     master_port: 7396
   envs:

--- a/examples/cloud/conf/serve.yaml
+++ b/examples/cloud/conf/serve.yaml
@@ -11,14 +11,14 @@ experiment:
     use_fs_serve: false
   runner:
     type: cloud
-    hostfile: ${oc.env:HOSTFILE}
-    master_addr: ${oc.env:MASTER_ADDR}
+    hostfile: ${oc.env:HOSTFILE, null}
+    master_addr: ${oc.env:MASTER_ADDR, 127.0.0.1}
     master_port: 7396
   envs:
     CUDA_DEVICE_MAX_CONNECTIONS: 1
 
   cmds:
-    before_start: source activate flagscale-inference
+    before_start: source /root/miniconda3/bin/activate flagscale-inference
 
 action: run
 

--- a/examples/cloud/conf/serve.yaml
+++ b/examples/cloud/conf/serve.yaml
@@ -14,6 +14,7 @@ experiment:
     hostfile: ${oc.env:HOSTFILE, /etc/hostfile}
     master_addr: ${oc.env:MASTER_ADDR, 127.0.0.1}
     master_port: 7396
+    device_type: ${oc.env:DEVICE_TYPE, gpu}
   envs:
     CUDA_DEVICE_MAX_CONNECTIONS: 1
 

--- a/examples/cloud/conf/serve.yaml
+++ b/examples/cloud/conf/serve.yaml
@@ -15,6 +15,7 @@ experiment:
     master_addr: ${oc.env:MASTER_ADDR, 127.0.0.1}
     master_port: 7396
     device_type: ${oc.env:DEVICE_TYPE, gpu}
+    nproc_per_node: ${oc.env:AIRS_ACCELERATOR_NUM, 1}
   envs:
     CUDA_DEVICE_MAX_CONNECTIONS: 1
 

--- a/examples/cloud/conf/serve.yaml
+++ b/examples/cloud/conf/serve.yaml
@@ -1,0 +1,27 @@
+defaults:
+- _self_
+- serve: cloud_model
+
+experiment:
+  exp_name: cloud
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: serve
+  deploy:
+    use_fs_serve: false
+  runner:
+    type: cloud
+    hostfile: ${oc.env:HOSTFILE}
+    master_addr: ${oc.env:MASTER_ADDR}
+    master_port: 7396
+  envs:
+    CUDA_DEVICE_MAX_CONNECTIONS: 1
+
+  cmds:
+    before_start: source activate flagscale-inference
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/examples/cloud/conf/serve/cloud_model.yaml
+++ b/examples/cloud/conf/serve/cloud_model.yaml
@@ -1,9 +1,8 @@
 - serve_id: vllm_model
   engine: vllm
   engine_args:
-    model: ${oc.env:MODEL_PATH}
-    served_model_name: ${oc.env:MODEL_NAME}
-    port: ${oc.env:PORT, 8000}
+    model: null
+    port: 8000
     host: 0.0.0.0
     tensor_parallel_size: 1
     pipeline_parallel_size: 1

--- a/examples/cloud/conf/serve/cloud_model.yaml
+++ b/examples/cloud/conf/serve/cloud_model.yaml
@@ -3,11 +3,9 @@
   engine_args:
     model: ${oc.env:MODEL_PATH}
     served_model_name: ${oc.env:MODEL_NAME}
-    port: ${oc.env:PORT}
+    port: ${oc.env:PORT, 8000}
     host: 0.0.0.0
     tensor_parallel_size: 1
     pipeline_parallel_size: 1
     gpu_memory_utilization: 0.9
     max_model_len: 32768
-    max_num_seqs: 256
-    trust_remote_code: true

--- a/examples/cloud/conf/serve/cloud_model.yaml
+++ b/examples/cloud/conf/serve/cloud_model.yaml
@@ -1,0 +1,13 @@
+- serve_id: vllm_model
+  engine: vllm
+  engine_args:
+    model: ${oc.env:MODEL_PATH}
+    served_model_name: ${oc.env:MODEL_NAME}
+    port: ${oc.env:PORT}
+    host: 0.0.0.0
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.9
+    max_model_len: 32768
+    max_num_seqs: 256
+    trust_remote_code: true

--- a/examples/cloud/conf/serve/cloud_model.yaml
+++ b/examples/cloud/conf/serve/cloud_model.yaml
@@ -4,7 +4,7 @@
     model: null
     port: 8000
     host: 0.0.0.0
+    served_model_name: cloud
     tensor_parallel_size: 1
     pipeline_parallel_size: 1
-    gpu_memory_utilization: 0.9
     max_model_len: 32768

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -630,8 +630,8 @@ def _generate_cloud_run_script_serve(
                         if before_start_cmd:
                             node_cmd = f"{before_start_cmd} && " + node_cmd
                         f.write(f"{node_cmd}\n")
-                if not is_address_matched:
-                    raise ValueError(f"The current node can not match any given node.")
+            if not is_address_matched:
+                raise ValueError(f"The current node can not match any given node.")
 
         else:
             # Note: config key device_type is specified for single node serving in neither gpu or cpu.
@@ -664,22 +664,23 @@ def _generate_cloud_run_script_serve(
             if node_cmd:
                 f.write(f"{node_cmd}\n")
 
-        f.write(f"mkdir -p {logging_config.log_dir}\n")
-        f.write(f"mkdir -p {logging_config.pids_dir}\n")
-        f.write(f"\n")
-        f.write(f"cd {root_dir}\n")
-        f.write(f"\n")
-        f.write(f'cmd="{cmd}"\n')
-        f.write(f"\n")
-        # TODO: need a option to control whether to append or overwrite the output file
-        # Now, it always appends to the output file
-        f.write("echo '=========== launch task ==========='\n")
-        if background:
-            f.write(
-                f'nohup bash -c "$cmd; sync" >> {host_output_file} 2>&1 & echo $! > {host_pid_file}\n'
-            )
-        else:
-            f.write(f'bash -c "$cmd; sync" >> {host_output_file} 2>&1\n')
+        if is_master(config):
+            f.write(f"mkdir -p {logging_config.log_dir}\n")
+            f.write(f"mkdir -p {logging_config.pids_dir}\n")
+            f.write(f"\n")
+            f.write(f"cd {root_dir}\n")
+            f.write(f"\n")
+            f.write(f'cmd="{cmd}"\n')
+            f.write(f"\n")
+            # TODO: need a option to control whether to append or overwrite the output file
+            # Now, it always appends to the output file
+            f.write("echo '=========== launch task ==========='\n")
+            if background:
+                f.write(
+                    f'nohup bash -c "$cmd; sync" >> {host_output_file} 2>&1 & echo $! > {host_pid_file}\n'
+                )
+            else:
+                f.write(f'bash -c "$cmd; sync" >> {host_output_file} 2>&1\n')
         f.write("\n")
         f.flush()
         os.fsync(f.fileno())

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -631,7 +631,7 @@ def _generate_cloud_run_script_serve(
                     )
                 if match_address(ip):
                     is_address_matched = True
-                    if is_master(config):
+                    if is_master(config, collections.OrderedDict(nodes)):
                         # master node
                         f.write(f"# start cluster\n")
                         f.write(f"# master node\n")
@@ -701,7 +701,7 @@ def _generate_cloud_run_script_serve(
             if node_cmd:
                 f.write(f"{node_cmd}\n")
 
-        if is_master(config):
+        if not nodes or is_master(config, collections.OrderedDict(nodes)):
             f.write(f"mkdir -p {logging_config.log_dir}\n")
             f.write(f"mkdir -p {logging_config.pids_dir}\n")
             f.write(f"\n")

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -155,7 +155,7 @@ def _update_auto_engine_args(config, model="vllm_model"):
                 nproc_per_node = int(config.experiment.runner.get("nproc_per_node", 1))
                 tensor_parallel_size = 2 ** int(math.floor(math.log2(nproc_per_node)))
             if model_args.get("pipeline_parallel_size", None):
-                pipeline_parallel_size = int(model_args.get("tensor_parallel_size"))
+                pipeline_parallel_size = int(model_args.get("pipeline_parallel_size"))
             else:
                 pipeline_parallel_size = len(config.get("nodes", [])) or 1
             model_args["tensor_parallel_size"] = tensor_parallel_size

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -18,6 +18,7 @@ from flagscale.runner.utils import (
     benchmark,
     dummy_random_input,
     flatten_dict_to_args,
+    get_addr,
     get_free_port,
     get_ip_addr,
     get_nproc_per_node,
@@ -528,16 +529,18 @@ def _generate_cloud_run_script_serve(
 ):
     nodes = config.get("nodes", None)
     logging_config = config.logging
-
+    node_id = ""
+    if nodes:
+        node_id = get_addr()
     no_shared_fs = config.experiment.runner.get("no_shared_fs", False)
     if no_shared_fs:
         host_output_file = os.path.join(logging_config.log_dir, f"host.output")
     else:
         host_output_file = os.path.join(logging_config.log_dir, f"host_{node_rank}_{host}.output")
     host_run_script_file = os.path.join(
-        logging_config.scripts_dir, f"host_{node_rank}_{host}_run.sh"
+        logging_config.scripts_dir, node_id, f"host_{node_rank}_{host}_run.sh"
     )
-    host_pid_file = os.path.join(logging_config.pids_dir, f"host_{node_rank}_{host}.pid")
+    host_pid_file = os.path.join(logging_config.pids_dir, node_id, f"host_{node_rank}_{host}.pid")
 
     os.makedirs(logging_config.scripts_dir, exist_ok=True)
 

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -540,9 +540,11 @@ def _generate_cloud_run_script_serve(
     host_run_script_file = os.path.join(
         logging_config.scripts_dir, node_id, f"host_{node_rank}_{host}_run.sh"
     )
-    host_pid_file = os.path.join(logging_config.pids_dir, node_id, f"host_{node_rank}_{host}.pid")
+    host_pid_file = os.path.join(logging_config.pids_dir, f"host_{node_rank}_{host}.pid")
 
     os.makedirs(logging_config.scripts_dir, exist_ok=True)
+    if node_id:
+        os.makedirs(os.path.join(logging_config.scripts_dir, node_id), exist_ok=True)
 
     root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     cmds_config = config.experiment.get("cmds", None)

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -570,13 +570,13 @@ def _generate_cloud_run_script_serve(
         f.write(f"fi\n")
         f.write(f"\n")
         envs_str = " && ".join(f"export {key}={value}" for key, value in envs.items())
+        f.write(f"{envs_str}\n")
 
         if nodes:
             f.write(f"ray_path=$(realpath $(which ray))\n")
             master_ip = nodes[0][0]
-            target_port = nodes[0][1].get("port")
 
-            master_port = target_port if target_port else get_free_port()
+            master_port = config.experiment.runner.get("master_port", 7396)
 
             address = f"{master_ip}:{master_port}"
             is_address_matched = False

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -180,7 +180,7 @@ def _update_config_serve(config: DictConfig):
 
     OmegaConf.set_struct(config, False)
 
-    if config.experiment.runner.type == "cloud":
+    if config.experiment.runner.get("type", "ssh") == "cloud":
         # set auto tp and pp size
         _update_auto_engine_args(config)
     if deploy_config.get("prefill_decode_disaggregation", False):

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -898,6 +898,7 @@ class SSHServeRunner(RunnerBase):
         self.host = None
 
     def _prepare(self):
+        _update_config_serve(self.config)
         self.user_args = _get_args_vllm(self.config)
         self.user_envs = self.config.experiment.get("envs", {})
         entrypoint = self.config.experiment.task.get("entrypoint", None)
@@ -916,7 +917,6 @@ class SSHServeRunner(RunnerBase):
             raise ValueError(
                 f"Invalid config entrypoint: {entrypoint}, must be a python file path or null."
             )
-        self.resources = None
         hostfile_path = self.config.experiment.runner.get("hostfile", None)
         if hostfile_path:
             if os.path.isabs(hostfile_path):
@@ -925,6 +925,7 @@ class SSHServeRunner(RunnerBase):
                 hostfile_path = os.path.join(os.getcwd(), hostfile_path)
             if not os.path.exists(hostfile_path):
                 raise ValueError(f"The hostfile {hostfile_path} does not exist")
+        self.resources = None
         if hostfile_path:
             self.resources = parse_hostfile(hostfile_path)
             for key, value in self.resources.items():
@@ -937,8 +938,6 @@ class SSHServeRunner(RunnerBase):
                 OmegaConf.set_struct(self.config, False)
                 self.config["nodes"] = list(self.resources.items())
                 OmegaConf.set_struct(self.config, True)
-
-        _update_config_serve(self.config)
 
         logger.info("\n************** configuration **************")
         logger.info(f"\n{OmegaConf.to_yaml(self.config)}")

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -226,7 +226,7 @@ def match_address(address):
 def parse_cloud_hostfile(hostfile_path):
     if hostfile_path is None or not os.path.isfile(hostfile_path):
         logger.warning(
-            f"Hostfile {hostfile_path} not found. The training will proceed using only local resources."
+            f"Hostfile {hostfile_path} not found. The task will proceed using only local resources."
         )
         return None
 
@@ -1140,12 +1140,6 @@ class SSHServeRunner(RunnerBase):
 
 
 class CloudServeRunner(RunnerBase):
-    def __init__(self, config: DictConfig):
-        super().__init__(config)
-        self.task_type = getattr(self.config.experiment.task, "type", None)
-        assert self.task_type == "train", f"Unsupported task type: {self.task_type}"
-        self._prepare()
-
     def __init__(self, config: DictConfig):
         super().__init__(config)
         self.task_type = getattr(self.config.experiment.task, "type", None)

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -232,6 +232,7 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
         f.write(f"fi\n")
         f.write(f"\n")
         envs_str = " && ".join(f"export {key}={value}" for key, value in envs.items())
+        f.write(f"{envs_str}\n")
 
         if nodes:
             if deploy_config.get("prefill_decode_disaggregation", False):
@@ -397,6 +398,8 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
 
                         if before_start_cmd:
                             node_cmd = f"{before_start_cmd} && " + node_cmd
+                        if envs_str:
+                            node_cmd = f"{envs_str} && " + node_cmd
 
                         ssh_cmd = f'ssh -n -p {ssh_port} {ip} "{node_cmd}"'
 
@@ -459,6 +462,8 @@ def _generate_run_script_serve(config, host, node_rank, cmd, background=True, wi
                             )
                         if before_start_cmd:
                             node_cmd = f"{before_start_cmd} && " + node_cmd
+                        if envs_str:
+                            node_cmd = f"{envs_str} && " + node_cmd
                         ssh_cmd = f'ssh -n -p {ssh_port} {ip} "{node_cmd}"'
                         if docker_name:
                             ssh_cmd = f"ssh -n -p {ssh_port} {ip} \"docker exec {docker_name} /bin/bash -c '{node_cmd}'\""

--- a/flagscale/runner/utils.py
+++ b/flagscale/runner/utils.py
@@ -286,6 +286,26 @@ def get_ip_addr():
     return ip
 
 
+def get_addr():
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+            if not ip.startswith == "127.0.0.1":
+                return ip
+    except:
+        pass
+
+    try:
+        ip = socket.gethostbyname(socket.getfqdn())
+        if not ip.startswith == "127.0.0.1":
+            return ip
+    except:
+        pass
+
+    return socket.gethostname()
+
+
 def is_master(config):
     """Check if current node is master."""
     nnodes = config.experiment.runner.get("nnodes", 1)

--- a/flagscale/runner/utils.py
+++ b/flagscale/runner/utils.py
@@ -286,26 +286,6 @@ def get_ip_addr():
     return ip
 
 
-def get_addr():
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-            s.connect(("8.8.8.8", 80))
-            ip = s.getsockname()[0]
-            if not ip.startswith == "127.0.0.1":
-                return ip
-    except:
-        pass
-
-    try:
-        ip = socket.gethostbyname(socket.getfqdn())
-        if not ip.startswith == "127.0.0.1":
-            return ip
-    except:
-        pass
-
-    return socket.gethostname()
-
-
 def is_master(config, resources=None):
     """Check if current node is master."""
     nnodes = config.experiment.runner.get("nnodes", 1)

--- a/flagscale/runner/utils.py
+++ b/flagscale/runner/utils.py
@@ -96,6 +96,26 @@ def get_host_name_or_ip():
     return IP
 
 
+def get_addr():
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+            if not ip.startswith == "127.0.0.1":
+                return ip
+    except:
+        pass
+
+    try:
+        ip = socket.gethostbyname(socket.getfqdn())
+        if not ip.startswith == "127.0.0.1":
+            return ip
+    except:
+        pass
+
+    return socket.gethostname()
+
+
 def run_local_command(cmd, dryrun=False, query=False):
     logger.info(f"Run the local command: {cmd}")
     if dryrun:

--- a/flagscale/runner/utils.py
+++ b/flagscale/runner/utils.py
@@ -306,7 +306,7 @@ def get_addr():
     return socket.gethostname()
 
 
-def is_master(config):
+def is_master(config, resources=None):
     """Check if current node is master."""
     nnodes = config.experiment.runner.get("nnodes", 1)
 
@@ -317,7 +317,8 @@ def is_master(config):
         if os.environ.get("AIRS_HOSTFILE_PATH", None):
             hostfile = os.environ["AIRS_HOSTFILE_PATH"]
 
-    resources = parse_hostfile(hostfile)
+    if not resources:
+        resources = parse_hostfile(hostfile)
     if not resources and nnodes > 1:
         raise ValueError("In the multi-node mode, please set the hostfile")
 

--- a/run.py
+++ b/run.py
@@ -64,7 +64,7 @@ def main(config: DictConfig) -> None:
         else:
             if config.experiment.runner.get("type", "ssh") == "ssh":
                 runner = SSHServeRunner(config)
-            elif config.experiment.runner.get("type") == "cloud":
+            elif config.experiment.runner.get("type", "ssh") == "cloud":
                 runner = CloudServeRunner(config)
             else:
                 raise ValueError(f"Unknown runner type {config.runner.type}")

--- a/run.py
+++ b/run.py
@@ -5,7 +5,7 @@ from omegaconf import DictConfig
 from flagscale.runner.auto_tuner import AutoTuner, ServeAutoTunner
 from flagscale.runner.runner_compress import SSHCompressRunner
 from flagscale.runner.runner_inference import SSHInferenceRunner
-from flagscale.runner.runner_serve import SSHServeRunner
+from flagscale.runner.runner_serve import CloudServeRunner, SSHServeRunner
 from flagscale.runner.runner_train import CloudTrainRunner, SSHTrainRunner
 from flagscale.runner.utils import is_master
 
@@ -62,7 +62,12 @@ def main(config: DictConfig) -> None:
             tuner = ServeAutoTunner(config)
             tuner.tune()
         else:
-            runner = SSHServeRunner(config)
+            if config.experiment.runner.get("type", "ssh") == "ssh":
+                runner = SSHServeRunner(config)
+            elif config.experiment.runner.get("type") == "cloud":
+                runner = CloudServeRunner(config)
+            else:
+                raise ValueError(f"Unknown runner type {config.runner.type}")
             if config.action == "run":
                 runner.run()
             elif config.action == "test":


### PR DESCRIPTION
In each node, run same below command
```
docker run -it \
  --name cloud \
  --privileged \
  --gpus all \
  --net=host \
  --ipc=host \
  --device=/dev/infiniband \
  --shm-size 512g \
  --ulimit memlock=-1 \
  -v /mnt/xxx/workspace:/workspace \
  -v /mnt/xxx/models:/models \
  --env MASTER_ADDR=xxx \
  --env AIRS_ACCELERATOR_NUM=8 \
  flagscale_maas:v1 \
  /bin/bash -c "flagscale serve cloud --model-path /model/qwen --port 8000 --engine-args='{"tensor_parallel_size":4}'; tail -f /dev/null"
```

**Note:**
required args for user: --model-path
optional args for user: --port, --engine-args

**Serve API:**
serve API as OpenAI style : `http://{MASTER_ADDR}:{PORT}`