### PR TITLE
[Serve] Move config.experiment.deploy into config.experiment.runner.deploy

### DIFF
--- a/examples/cloud/conf/serve.yaml
+++ b/examples/cloud/conf/serve.yaml
@@ -7,8 +7,6 @@ experiment:
   exp_dir: outputs/${experiment.exp_name}
   task:
     type: serve
-  deploy:
-    use_fs_serve: false
   runner:
     type: cloud
     hostfile: ${oc.env:HOSTFILE, /etc/hostfile}
@@ -16,6 +14,8 @@ experiment:
     master_port: 7396
     device_type: ${oc.env:DEVICE_TYPE, gpu}
     nproc_per_node: ${oc.env:AIRS_ACCELERATOR_NUM, 1}
+    deploy:
+      use_fs_serve: false
   envs:
     CUDA_DEVICE_MAX_CONNECTIONS: 1
 

--- a/examples/deepseek_v3/conf/serve_auto_tuner.yaml
+++ b/examples/deepseek_v3/conf/serve_auto_tuner.yaml
@@ -7,13 +7,13 @@ experiment:
   exp_dir: ./outputs/${experiment.exp_name}
   task:
     type: serve
-  deploy:
-    use_fs_serve: false
   runner:
     nnodes: 2
     nproc_per_node: 8
     hostfile: examples/deepseek/conf/hostfile.txt
     docker: ds
+    deploy:
+      use_fs_serve: false
   auto_tuner:
     space:
       tensor_model_parallel_size: [4, 8]

--- a/examples/qwen2_5/conf/serve.yaml
+++ b/examples/qwen2_5/conf/serve.yaml
@@ -7,10 +7,10 @@ experiment:
   exp_dir: outputs/${experiment.exp_name}
   task:
     type: serve
-  deploy:
-    use_fs_serve: false
   runner:
     hostfile: null
+    deploy:
+      use_fs_serve: false
   envs:
     CUDA_VISIBLE_DEVICES: 0
     CUDA_DEVICE_MAX_CONNECTIONS: 1

--- a/examples/qwen2_5/conf/serve_auto_tuner.yaml
+++ b/examples/qwen2_5/conf/serve_auto_tuner.yaml
@@ -7,12 +7,12 @@ experiment:
   exp_dir: ./outputs
   task:
     type: serve
-  deploy:
-    port: 6701
-    use_fs_serve: false
   runner:
     nnodes: 1
     nproc_per_node: 4
+    deploy:
+      port: 6701
+      use_fs_serve: false
   auto_tuner:
     space:
       tensor_model_parallel_size: "auto"

--- a/examples/qwen2_5/conf/serve_disagg_xpyd.yaml
+++ b/examples/qwen2_5/conf/serve_disagg_xpyd.yaml
@@ -7,18 +7,18 @@ experiment:
   exp_dir: outputs/${experiment.exp_name}
   task:
     type: serve
-  deploy:
-    port: 10001
-    use_fs_serve: false
-    prefill_decode_disaggregation: true
-    prefill_num: 2
-    prefill_address: x.x.x.x # optional, default "auto"
-    decode_num: 2
-    decode_address: x.x.x.x # optional, default "auto"
-    prefill_decode_strategy: slo # optional, one of [slo|random|robin], default slo
   runner:
     hostfile: examples/qwen/conf/hostfile.txt
     docker: fr-v2
+    deploy:
+      port: 10001
+      use_fs_serve: false
+      prefill_decode_disaggregation: true
+      prefill_num: 2
+      prefill_address: x.x.x.x # optional, default "auto"
+      decode_num: 2
+      decode_address: x.x.x.x # optional, default "auto"
+      prefill_decode_strategy: slo # optional, one of [slo|random|robin], default slo
   envs:
     CUDA_DEVICE_MAX_CONNECTIONS: 1
     VLLM_USE_V1: 0

--- a/examples/qwen2_5/conf/serve_multiple_instance.yaml
+++ b/examples/qwen2_5/conf/serve_multiple_instance.yaml
@@ -8,15 +8,15 @@ experiment:
   task:
     type: serve
     entrypoint: null
-  deploy:
-    port: 6701
-    use_fs_serve: true
   runner:
     hostfile: null # /path/to/hostfile.txt
     docker: ds
     ssh_port: 22
     nnodes: 2
     nproc_per_node: 8
+    deploy:
+      port: 6701
+      use_fs_serve: true
   auto_tuner:
     space:
       tensor_model_parallel_size: [2,4]

--- a/examples/qwen3/conf/serve.yaml
+++ b/examples/qwen3/conf/serve.yaml
@@ -7,10 +7,10 @@ experiment:
   exp_dir: outputs/${experiment.exp_name}
   task:
     type: serve
-  deploy:
-    use_fs_serve: false
   runner:
     hostfile: null
+    deploy:
+      use_fs_serve: false
   envs:
     CUDA_VISIBLE_DEVICES: 0
     CUDA_DEVICE_MAX_CONNECTIONS: 1

--- a/examples/qwen3/conf/serve_atmb.yaml
+++ b/examples/qwen3/conf/serve_atmb.yaml
@@ -8,12 +8,12 @@ experiment:
   exp_dir: outputs/${experiment.exp_name}
   task:
     type: serve
-  deploy:
-    port: 6701
-    use_fs_serve: false
   runner:
     nnodes: 1
     nproc_per_node: 4
+    deploy:
+      port: 6701
+      use_fs_serve: false
   envs:
     CUDA_VISIBLE_DEVICES: 0,1,2,3
     CUDA_DEVICE_MAX_CONNECTIONS: 1

--- a/examples/robobrain/conf/serve.yaml
+++ b/examples/robobrain/conf/serve.yaml
@@ -8,13 +8,13 @@ experiment:
   task:
     type: serve
     entrypoint: null
-  deploy:
-    port: 6701
-    use_fs_serve: true
   runner:
     hostfile: null #examples/robobrain/conf/hostfile.txt
     docker: robobrain
     ssh_port: 22
+    deploy:
+      port: 6701
+      use_fs_serve: true
 
   cmds:
     before_start: export RAY_DEDUP_LOGS=0

--- a/flagscale/runner/auto_tuner/generate.py
+++ b/flagscale/runner/auto_tuner/generate.py
@@ -167,7 +167,7 @@ class ServeGenerator(Generator):
         current_pp = model_config.engine_args_specific[engine].get("pipeline_parallel_size", 1)
         model_config.resources["num_gpus"] = current_tp * current_pp
 
-        if not config.experiment.get("deploy", {}).get("use_fs_serve", True):
+        if not config.experiment.get("runner", {}).get("deploy", {}).get("use_fs_serve", True):
             del model_config["resources"]
 
     def gen(self, strategy):

--- a/flagscale/runner/auto_tuner/tuner.py
+++ b/flagscale/runner/auto_tuner/tuner.py
@@ -309,12 +309,14 @@ class ServeAutoTunner(AutoTuner):
         logger.addHandler(handler)
         self.logger = logger
         self.handler = handler
-        deploy_config = config.experiment.get("deploy", {})
+        deploy_config = config.experiment.get("runner", {}).get("deploy", {})
 
         if not deploy_config.get("use_fs_serve", True) and deploy_config.get("port", None):
             for item in config.serve:
                 if item.get("serve_id") == "vllm_model":
-                    item.engine_args["port"] = config.experiment.get("deploy", {}).get("port", None)
+                    item.engine_args["port"] = (
+                        config.experiment.get("runner", {}).get("deploy", {}).get("port", None)
+                    )
 
         # Deepcopy the original config to isolate from each task config
         # Modify the orig config when run best task

--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -188,7 +188,7 @@ def _update_config_serve(config: DictConfig):
     cli_engine_args_str = (
         config.experiment.get("runner", {}).get("cli_args", {}).get("engine_args", None)
     )
-    cli_engine_args = json.loads(cli_engine_args) if cli_engine_args_str else {}
+    cli_engine_args = json.loads(cli_engine_args_str) if cli_engine_args_str else {}
 
     if cli_model_path or cli_engine_args:
         for item in config.serve:
@@ -196,7 +196,7 @@ def _update_config_serve(config: DictConfig):
                 if cli_model_path:
                     item.engine_args["model"] = cli_model_path
                 if cli_engine_args:
-                    item.engine_args.update(json.loads(cli_engine_args))
+                    item.engine_args.update(cli_engine_args)
 
     if config.experiment.runner.get("type", "ssh") == "cloud":
         # set auto tp and pp size

--- a/flagscale/serve/run_disagg_xpyd_router.py
+++ b/flagscale/serve/run_disagg_xpyd_router.py
@@ -36,7 +36,9 @@ TASK_CONFIG = serve.task_config
 MODEL_PATH = TASK_CONFIG.serve[0].get("engine_args", {}).get("model", None)
 
 # Scheduling strategy: 'random', 'robin', 'slo'
-SCHEDULING_STRATEGY = TASK_CONFIG.experiment.get("deploy", {}).get("prefill_decode_strategy", "slo")
+SCHEDULING_STRATEGY = (
+    TASK_CONFIG.experiment.get("runner", {}).get("deploy", {}).get("prefill_decode_strategy", "slo")
+)
 
 
 @lru_cache(maxsize=32)
@@ -275,7 +277,7 @@ async def handle_request():
 
 
 def main():
-    deploy_config = TASK_CONFIG.experiment.get("deploy", {})
+    deploy_config = TASK_CONFIG.experiment.get("runner", {}).get("deploy", {})
     serve_port = deploy_config.get("port", None)
     # Used to register with the pd service discovery
     pd_proxy_port = deploy_config.get("pd_proxy_port", None)

--- a/flagscale/serve/run_fs_serve_vllm.py
+++ b/flagscale/serve/run_fs_serve_vllm.py
@@ -591,7 +591,7 @@ if __name__ == "__main__":
     serve.start(
         http_options={
             "host": "0.0.0.0",
-            "port": TASK_CONFIG.experiment.get("deploy", {}).get("port", 8000),
+            "port": TASK_CONFIG.experiment.get("runner", {}).get("deploy", {}).get("port", 8000),
         }
     )
     llm_actor = LLMActor.bind()


### PR DESCRIPTION
### Description
'config.experiment.deploy' has been moved to 'config.experiment.runner.deploy'. Support of old deploy location will be removed in future.


Todo:
- [ ] 'config.experiment.auto_tuner' is moved to 'config.experiment.runner.auto_tuner'.