### PR TITLE
Support the deployment of RoboBrain2 models in both 7B and 32B configuration

### DIFF
--- a/examples/robobrain2/conf/serve.yaml
+++ b/examples/robobrain2/conf/serve.yaml
@@ -1,0 +1,18 @@
+defaults:
+  - _self_
+  - serve: 32b
+experiment:
+  exp_name: robobrain2_32b
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: serve
+  deploy:
+    use_fs_serve: false
+  runner:
+    ssh_port: 22
+  envs:
+    CUDA_DEVICE_MAX_CONNECTIONS: 1
+action: run
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/examples/robobrain2/conf/serve/32b.yaml
+++ b/examples/robobrain2/conf/serve/32b.yaml
@@ -1,0 +1,15 @@
+- serve_id: vllm_model
+  engine: vllm
+  engine_args:
+    model: /share/project/lms/robobrain2_32b # should be customized
+    served_model_name: robobrain2_32b-nv-flagos
+    tensor_parallel_size: 8
+    max_model_len: 32768
+    pipeline_parallel_size: 1
+    max_num_seqs: 8 # Even at full 32,768 context usage, 8 concurrent operations won't trigger OOM
+    gpu_memory_utilization: 0.9
+    limit_mm_per_prompt: image=18 # should be customized, 18 images/request is enough for most scenarios
+    port: 9010
+    trust_remote_code: true
+    enforce_eager: false # set true if use FlagGems 
+    enable_chunked_prefill: true

--- a/examples/robobrain2/conf/serve/7b.yaml
+++ b/examples/robobrain2/conf/serve/7b.yaml
@@ -1,0 +1,15 @@
+- serve_id: vllm_model
+  engine: vllm
+  engine_args:
+    model: /share/project/lms/robobrain2_7b # should be customized
+    served_model_name: robobrain2_7b-nv-flagos
+    tensor_parallel_size: 1
+    max_model_len: 32768
+    pipeline_parallel_size: 1
+    max_num_seqs: 8 # Even at full 32,768 context usage, 8 concurrent operations won't trigger OOM
+    gpu_memory_utilization: 0.9
+    limit_mm_per_prompt: image=18 # should be customized, 18 images/request is enough for most scenarios
+    port: 9010
+    trust_remote_code: true
+    enforce_eager: false # set true if use FlagGems 
+    enable_chunked_prefill: true


### PR DESCRIPTION
This PR update adds support for the inference deployment of 7B and 32B embodied intelligence models for RoboBrain2.