### PR TITLE
[CICD][Metax] Add inference test cases for Metax

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -151,8 +151,10 @@ jobs:
         task:
           - deepseek
           - qwen3
+          - metax
           # - deepseek_flaggems   # TODO: need fix
           # - qwen3_flaggems      # TODO: need fix
+          # - metax_flaggems      # TODO: need fix
     name: "inference-${{ matrix.task }}"
     with:
       task: ${{ matrix.task }}

--- a/tests/functional_tests/test_cases/inference-pipeline/metax/conf/inference/metax.yaml
+++ b/tests/functional_tests/test_cases/inference-pipeline/metax/conf/inference/metax.yaml
@@ -1,0 +1,17 @@
+llm:
+  model: /home/gitlab-runner/data
+  tokenizer: /home/gitlab-runner/data
+  trust_remote_code: true
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  gpu_memory_utilization: 0.9
+  seed: 1234
+
+generate:
+  prompts: [
+    "The first President of the United States",
+    "The capital of France",
+  ]
+  sampling:
+    top_p: 0.1
+    temperature: 0.1

--- a/tests/functional_tests/test_cases/inference-pipeline/metax/conf/metax.yaml
+++ b/tests/functional_tests/test_cases/inference-pipeline/metax/conf/metax.yaml
@@ -1,0 +1,29 @@
+defaults:
+  - _self_
+  - inference: metax
+
+experiment:
+  exp_name: metax
+  exp_dir: tests/functional_tests/test_cases/inference-pipeline/metax/results_test/metax
+  task:
+    type: inference
+    backend: vllm
+    entrypoint: flagscale/inference/inference_aquila.py
+  runner:
+    hostfile: null
+  cmds:
+    before_start:
+      source /root/miniconda3/bin/activate flagscale-inference
+  envs:
+    VLLM_LATENCY_DEBUG: true
+    CNCL_CNPX_DOMAIN_ENABLE: 0
+    PYTORCH_MLU_ALLOC_CONF: "expandable_segments:True"
+    EXPERT_PARALLEL_EN: true
+    VLLM_GRAPH_DEBUG: false
+    VLLM_AVG_MOE_EN: 1
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/tests/functional_tests/test_cases/inference-pipeline/metax/results_gold/metax
+++ b/tests/functional_tests/test_cases/inference-pipeline/metax/results_gold/metax
@@ -1,0 +1,8 @@
+**************************************************
+output.prompt='The first President of the United States'
+output.outputs[0].text=', George Washington, was born on February 22, 173'
+output.outputs[0].token_ids=[11, 9857, 6515, 11, 572, 9223, 389, 7400, 220, 17, 17, 11, 220, 16, 22, 18]
+**************************************************
+output.prompt='The capital of France'
+output.outputs[0].text=' is Paris. The capital of Germany is Berlin. The capital of Italy is Rome'
+output.outputs[0].token_ids=[374, 12095, 13, 576, 6722, 315, 9856, 374, 19846, 13, 576, 6722, 315, 15344, 374, 21718]

--- a/tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/conf/inference/metax_flaggems.yaml
+++ b/tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/conf/inference/metax_flaggems.yaml
@@ -1,0 +1,17 @@
+llm:
+  model: /home/gitlab-runner/data
+  tokenizer: /home/gitlab-runner/data
+  trust_remote_code: true
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  gpu_memory_utilization: 0.9
+  seed: 1234
+
+generate:
+  prompts: [
+    "The first President of the United States",
+    "The capital of France",
+  ]
+  sampling:
+    top_p: 0.1
+    temperature: 0.1

--- a/tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/conf/metax_flaggems.yaml
+++ b/tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/conf/metax_flaggems.yaml
@@ -1,0 +1,30 @@
+defaults:
+  - _self_
+  - inference: metax_flaggems
+
+experiment:
+  exp_name: metax_flaggems
+  exp_dir: tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/results_test/metax_flaggems
+  task:
+    type: inference
+    backend: vllm
+    entrypoint: flagscale/inference/inference_aquila.py
+  runner:
+    hostfile: null
+  cmds:
+    before_start:
+      source /root/miniconda3/bin/activate flagscale-inference
+  envs:
+    VLLM_LATENCY_DEBUG: true
+    CNCL_CNPX_DOMAIN_ENABLE: 0
+    PYTORCH_MLU_ALLOC_CONF: "expandable_segments:True"
+    EXPERT_PARALLEL_EN: true
+    VLLM_GRAPH_DEBUG: false
+    VLLM_AVG_MOE_EN: 1
+    USE_FLAGGEMS: "true"
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/results_gold/metax_flaggems
+++ b/tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/results_gold/metax_flaggems
@@ -1,0 +1,8 @@
+**************************************************
+output.prompt='The first President of the United States'
+output.outputs[0].text=', George Washington, was born on February 22, 173'
+output.outputs[0].token_ids=[11, 9857, 6515, 11, 572, 9223, 389, 7400, 220, 17, 17, 11, 220, 16, 22, 18]
+**************************************************
+output.prompt='The capital of France'
+output.outputs[0].text=' is Paris. The capital of Germany is Berlin. The capital of Italy is Rome'
+output.outputs[0].token_ids=[374, 12095, 13, 576, 6722, 315, 9856, 374, 19846, 13, 576, 6722, 315, 15344, 374, 21718]

--- a/tests/scripts/functional_tests/test_all.sh
+++ b/tests/scripts/functional_tests/test_all.sh
@@ -23,8 +23,12 @@ commands=(
     # "tests/scripts/functional_tests/test_task.sh --type inference-pipeline --task Qwen3-4B --hardware bi_v150 --flaggems enable"
     "tests/scripts/functional_tests/test_task.sh --type inference-pipeline --task Qwen3-4B --hardware cambricon_mlu"
     # "tests/scripts/functional_tests/test_task.sh --type inference-pipeline --task Qwen3-4B --hardware cambricon_mlu --flaggems enable"
+    "tests/scripts/functional_tests/test_task.sh --type inference-pipeline --task Qwen3-4B --hardware metax"
+    # "tests/scripts/functional_tests/test_task.sh --type inference-pipeline --task Qwen3-4B --hardware metax --flaggems enable"
     # For serve
     # "tests/scripts/functional_tests/test_task.sh --type serve --task base"
+    # For rl
+    "tests/scripts/functional_tests/test_task.sh --type rl --task qwen2_5"
 )
 
 for cmd in "${commands[@]}"; do

--- a/tests/scripts/functional_tests/test_task.sh
+++ b/tests/scripts/functional_tests/test_task.sh
@@ -131,7 +131,7 @@ flaggems="disable"
 hardware="nvidia"
 
 # Define supported hardware options in a list (array)
-supported_hardware=("nvidia" "bi_v150" "cambricon_mlu")
+supported_hardware=("nvidia" "bi_v150" "cambricon_mlu" "metax")
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do


### PR DESCRIPTION
**Add configuration:**

- **metax configuration**
  - **tests/functional_tests/test_cases/inference-pipeline/metax/conf/inference/metax.yaml**
  - **tests/functional_tests/test_cases/inference-pipeline/metax/conf/metax.yaml**
- **metax_flaggems standard results**
  - **tests/functional_tests/test_cases/inference-pipeline/metax/results_gold/metax**
- **metax_flaggems configuration**
  - **tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/conf/inference/metax_flaggems.yaml**
  - **tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/conf/metax_flaggems.yaml**
- **metax_flaggems standard results**
  - **tests/functional_tests/test_cases/inference-pipeline/metax_flaggems/results_gold/metax_flaggems**

**Add running instructions:**

- **tests/scripts/functional_tests/test_all.sh:** Add running instructions
- **tests/scripts/functional_tests/test_task.sh:** Add hardware support for Mu Xi
