### PR TITLE
[Agent] Add environment info record/read

### DIFF
--- a/flagscale/agent/collaboration/collaborator.py
+++ b/flagscale/agent/collaboration/collaborator.py
@@ -371,6 +371,7 @@ class Collaborator:
             redis_client.hset("ENVIRONMENT_INFO", name, value)
             return True
         except (ConnectionError, TimeoutError, RedisError) as e:
+            print(f"Error Failed to write ENVIRONMENT_INFO[{name}] = {value}: {type(e).__name__} - {e}")
             return False
 
     def read_environment(self, name: str) -> Optional[Union[Dict[str, str], str]]:
@@ -411,6 +412,7 @@ class Collaborator:
                 return None
             return json.loads(raw_value)
         except (ConnectionError, TimeoutError, RedisError) as e:
+            print(f"Error Failed to read ENVIRONMENT_INFO[{name}]: {type(e).__name__} - {e}")
             return None
 
     # ----------------- Close Connection -----------------

--- a/flagscale/agent/collaboration/collaborator.py
+++ b/flagscale/agent/collaboration/collaborator.py
@@ -407,7 +407,9 @@ class Collaborator:
         try:
             redis_client = self._get_conn()
             raw_value = redis_client.hget("ENVIRONMENT_INFO", name)
-            return raw_value
+            if not raw_value:
+                return None
+            return json.loads(raw_value)
         except (ConnectionError, TimeoutError, RedisError) as e:
             return None
 

--- a/flagscale/agent/collaboration/collaborator.py
+++ b/flagscale/agent/collaboration/collaborator.py
@@ -261,8 +261,8 @@ class Collaborator:
             bool: True if update succeeded, False on failure
 
         Example:
-            >>> coll.update_agent_busy("robot_1", True)  # Set busy
-            >>> coll.update_agent_busy("robot_1", False) # Set available
+            >>> coll.update_agent_busy("agent_1", True)  # Set busy
+            >>> coll.update_agent_busy("agent_1", False) # Set available
         """
         try:
             redis_client = self._get_conn()
@@ -307,8 +307,8 @@ class Collaborator:
                 - False if timeout occurred
 
         Example:
-            >>> # Wait for robot1 and robot2 to become free
-            >>> success = coll.wait_agent_free(["robot1", "robot2"])
+            >>> # Wait for agent_1 and agent_2 to become free
+            >>> success = coll.wait_agent_free(["agent_1", "agent_2"])
             >>> if success:
             >>>     print("All agents are now available")
         """


### PR DESCRIPTION
- Added methods to store environment objects and agent state in Redis hash
- Implemented read_environment() to retrieve ENVIRONMENT_INFO
- Implemented record_environment() to update specific ENVIRONMENT_INFO fields
- Unified JSON serialization/deserialization for all Redis values