### PR TITLE
[FlagRelease] Support GLM4.5 and Step3 on Nvidia GPUs

### DIFF
--- a/examples/glm45/conf/serve.yaml
+++ b/examples/glm45/conf/serve.yaml
@@ -1,0 +1,21 @@
+defaults:
+- _self_
+- serve: 355b
+
+experiment:
+  exp_name: glm45_355b
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: serve
+  runner:
+    hostfile: null
+    deploy:
+      use_fs_serve: false
+  envs:
+    CUDA_DEVICE_MAX_CONNECTIONS: 1
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/examples/glm45/conf/serve/355b.yaml
+++ b/examples/glm45/conf/serve/355b.yaml
@@ -1,0 +1,24 @@
+- serve_id: vllm_model
+  engine: vllm
+  engine_args:
+    model: /share/GLM-4.5
+    served_model_name: GLM-4.5-nvidia-flagos
+    host: 0.0.0.0
+    port: 9010
+  engine_args_specific:
+    vllm:
+      tensor_parallel_size: 8
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.95
+      tool_call_parser: glm45
+      reasoning_parser: glm45
+      trust_remote_code: true
+      enforce_eager: true
+      enable_chunked_prefill: true
+      enable_auto_tool_choice: true
+  profile:
+    prefix_len: 0
+    input_len: 1024
+    output_len: 1024
+    num_prompts: 128
+    range_ratio: 1

--- a/examples/step3/conf/serve.yaml
+++ b/examples/step3/conf/serve.yaml
@@ -1,0 +1,21 @@
+defaults:
+- _self_
+- serve: 321b
+
+experiment:
+  exp_name: step3_321b
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: serve
+  runner:
+    hostfile: null
+    deploy:
+      use_fs_serve: false
+  envs:
+    CUDA_DEVICE_MAX_CONNECTIONS: 1
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/examples/step3/conf/serve/321b.yaml
+++ b/examples/step3/conf/serve/321b.yaml
@@ -1,0 +1,24 @@
+- serve_id: vllm_model
+  engine: vllm
+  engine_args:
+    model: /share/step3
+    served_model_name: step3-nvidia-flagos
+    host: 0.0.0.0
+    port: 9010
+  engine_args_specific:
+    vllm:
+      tensor_parallel_size: 8
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.95
+      tool_call_parser: step3
+      reasoning_parser: step3
+      trust_remote_code: true
+      limit_mm_per_prompt.image: 8
+      enable_chunked_prefill: true
+      enable_auto_tool_choice: true
+  profile:
+    prefix_len: 0
+    input_len: 1024
+    output_len: 1024
+    num_prompts: 128
+    range_ratio: 1


### PR DESCRIPTION
The model files for Step3 and GLM4.5 is much more than MiniCPM-V-4. For example: https://github.com/vllm-project/vllm/pull/21998. This PR is validated on vllm 0.10.1.dev627+ga353bd083.cu129, which is committed to vllm main branch at Thu Aug 14 00:41:51 2025 -0400. 

I recommend to upgrade third_party/vllm as vllm's main branch, latest commit, to avoid copying those step3's model files.