### PR TITLE
[AutoTuner] Fix the ep error

### DIFF
--- a/flagscale/runner/auto_tuner/search/searcher.py
+++ b/flagscale/runner/auto_tuner/search/searcher.py
@@ -293,7 +293,7 @@ class Searcher:
         self._sort("context_parallel_size", space["context_parallel_size"], priority)
 
         # Set expert parallel degree
-        if  not hasattr(config.train.model, "num_experts"):
+        if not hasattr(config.train.model, "num_experts"):
             space["expert_model_parallel_size"] = [1]
         else:
             space["expert_model_parallel_size"] = (
@@ -301,7 +301,8 @@ class Searcher:
                 if "expert_model_parallel_size" not in config.experiment.auto_tuner.space
                 or config.experiment.auto_tuner.space.expert_model_parallel_size == "auto"
                 else config.experiment.auto_tuner.space.expert_model_parallel_size
-        )
+            )
+
         self._sort("expert_model_parallel_size", space["expert_model_parallel_size"], priority)
 
         return space


### PR DESCRIPTION
**run example autotune aquila 7b** 
**if no  set space:** 
<img width="454" height="197" alt="no set space" src="https://github.com/user-attachments/assets/6266cac9-f464-4c81-93d6-6be9e1e8abb4" />
**error** 
<img width="1519" height="567" alt="error" src="https://github.com/user-attachments/assets/939c7115-1d9f-452d-83a3-a038d5b95762" />
**reason**
7b.yaml no set num_experts
<img width="761" height="89" alt="reason" src="https://github.com/user-attachments/assets/cbfb7776-8f59-413b-a6cc-97e82c271767" />
some models that are  not  moe , not num_experts attribute, may cause error. 

