### PR TITLE
[elastic] add Log Collection and Diagnosis

### DIFF
--- a/flagscale/runner/elastic/diagnostic.py
+++ b/flagscale/runner/elastic/diagnostic.py
@@ -1,0 +1,58 @@
+import os
+
+from datetime import datetime
+
+from flagscale.runner.utils import logger
+
+
+def generate_diagnostic_report(config, host, node_rank, log_file, return_content=False):
+    """
+    Generate a diagnostic report from a log file.
+
+    Args:
+        config (DictConfig): Configuration object.
+        host (str): Hostname or IP.
+        node_rank (int): Node rank.
+        log_file (str): Path to the log file.
+        return_content (bool): If True, return report as string instead of writing to file.
+
+    Returns:
+        str: Diagnostic report content if return_content=True, else None.
+    """
+    report_content = f"Diagnostic Report for {host} (node {node_rank})\n"
+    report_content += f"Generated at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+    report_content += f"Log file analyzed: {log_file}\n"
+    report_content += "Analysis:\n"
+
+    try:
+        if not os.path.exists(log_file) or os.path.getsize(log_file) == 0:
+            report_content += "- Log file is empty or does not exist, no analysis possible.\n"
+            return report_content if return_content else None
+        else:
+            with open(log_file, 'r') as f:
+                log_content = f.read()
+            if not log_content.strip():
+                report_content += "- Log file is empty, no analysis possible.\n"
+            elif "error" in log_content.lower():
+                report_content += "- Found error in logs, please check for issues.\n"
+            else:
+                report_content += "- No errors detected in logs.\n"
+    except Exception as e:
+        logger.error(f"Failed to read log file {log_file} for {host} (node {node_rank}): {e}")
+        report_content += f"- Error reading log file: {e}\n"
+
+    if return_content:
+        return report_content
+    else:
+        try:
+            diagnostic_file = log_file.replace("temp", "diagnostic").replace(".log", ".txt")
+            os.makedirs(os.path.dirname(diagnostic_file), exist_ok=True)
+            with open(diagnostic_file, 'w') as f:
+                f.write(report_content)
+            logger.info(
+                f"Generated diagnostic report for {host} (node {node_rank}) at {diagnostic_file}"
+            )
+            return diagnostic_file
+        except Exception as e:
+            logger.error(f"Failed to write diagnostic report for {host} (node {node_rank}): {e}")
+            return None

--- a/flagscale/runner/elastic/log_collector.py
+++ b/flagscale/runner/elastic/log_collector.py
@@ -1,0 +1,68 @@
+import os
+import shlex
+
+from datetime import datetime
+
+from flagscale.runner.utils import logger, run_local_command, run_scp_command
+
+_log_offsets = {}
+
+
+def collect_logs(config, host, node_rank, destination_dir, dryrun=False):
+    """
+    Collect logs incrementally from a specified host and node rank, saving to destination_dir.
+
+    Args:
+        config (DictConfig): Configuration object containing experiment and logging details.
+        host (str): Hostname or IP of the node.
+        node_rank (int): Rank of the node.
+        destination_dir (str): Directory to store collected logs.
+        dryrun (bool): If True, simulate the collection without executing commands.
+
+    Returns:
+        str: Path to the collected log file.
+    """
+    logging_config = config.train.system.logging
+    no_shared_fs = config.experiment.runner.get("no_shared_fs", False)
+    log_dir = logging_config.log_dir
+    src_log_file = os.path.join(
+        log_dir, f"host{'_' + str(node_rank) + '_' + host if not no_shared_fs else ''}.output"
+    )
+    dest_log_file = os.path.join(
+        destination_dir,
+        f"host_{node_rank}_{host}_temp_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log",
+    )
+
+    os.makedirs(destination_dir, exist_ok=True)
+
+    log_key = f"{host}_{node_rank}"
+    offset = _log_offsets.get(log_key, 0)
+
+    try:
+        if host != "localhost":
+            ssh_port = config.experiment.runner.get("ssh_port", 22)
+            command = f"tail -c +{offset + 1} {src_log_file} > {dest_log_file}"
+            run_scp_command(host, src_log_file, dest_log_file, ssh_port, dryrun, incremental=True)
+            logger.info(
+                f"Collected incremental log from {host} (node {node_rank}) to {dest_log_file}"
+            )
+        else:
+            command = f"tail -c +{offset + 1} {src_log_file} > {dest_log_file}"
+            run_local_command(command, dryrun)
+            logger.info(f"Collected incremental local log to {dest_log_file}")
+
+        if os.path.exists(dest_log_file) and os.path.getsize(dest_log_file) > 0:
+            new_offset = os.path.getsize(src_log_file)
+            _log_offsets[log_key] = new_offset
+            return dest_log_file
+        else:
+            logger.warning(f"Log file {src_log_file} not found or empty")
+            if os.path.exists(dest_log_file):
+                os.remove(dest_log_file)
+            return None
+
+    except Exception as e:
+        logger.error(f"Failed to collect logs from {host} (node {node_rank}): {e}")
+        if os.path.exists(dest_log_file):
+            os.remove(dest_log_file)
+        return None


### PR DESCRIPTION

Modify the `/flagscale/runner/runner_train.py` file to add the following logic:

- Add a `collect_and_diagnose_logs()` method to the `SSHTrainRunner` class:
  - Call the `collect_logs` method to collect log files and check if the log files exist or are non-empty.
  - If the logs are non-empty, write them to a combined log file, call `generate_diagnostic_report` for real-time diagnostics, and write the results to a diagnostic report.
- Modify the `run()` method in the `SSHTrainRunner` class to include the following logic:
   - Use the `_monitor_logs` method to call `collect_and_diagnose_logs()` at fixed intervals for real-time log collection and diagnostics.
   - Use the `_query_status` method to check the `torchrun` status to control the start and end of log collection and diagnostics.
- Add the `/flagscale/runner/elastic` folder with the following logic:
  - `log_collector.py`: Use a global offset dictionary and adopt an incremental collection approach to collect logs from specified nodes.
  - `diagnostic.py`: Read log files, match keywords to corresponding diagnostic information, and write "timestamp, original log content, diagnostic information" to a diagnostic report.