### PR TITLE
tp/pp to ep

### DIFF
--- a/flagscale/backends/Megatron-LM/megatron/core/optimizer/optimizer.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/optimizer/optimizer.py.patch
@@ -1,8 +1,16 @@
 diff --git a/megatron/core/optimizer/optimizer.py b/megatron/core/optimizer/optimizer.py
-index b5bc894c..93c8b45e 100644
+index b5bc894c..38d4fdf5 100644
 --- a/megatron/core/optimizer/optimizer.py
 +++ b/megatron/core/optimizer/optimizer.py
-@@ -92,7 +92,7 @@ def _multi_tensor_copy_this_to_that(
+@@ -49,6 +49,7 @@ from ..transformer.module import param_is_not_shared
+ from .clip_grads import clip_grad_by_total_norm_fp32, count_zeros_fp32, get_grad_norm_fp32
+ from .grad_scaler import MegatronGradScaler
+ from .optimizer_config import OptimizerConfig
++from megatron.training.global_vars import get_args
+ 
+ logger = getLogger(__name__)
+ 
+@@ -92,7 +93,7 @@ def _multi_tensor_copy_this_to_that(
              that_.copy_(this_)
  
  
@@ -11,7 +19,7 @@ index b5bc894c..93c8b45e 100644
  
  
  class MegatronOptimizer(ABC):
-@@ -465,12 +465,23 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
+@@ -465,12 +466,23 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
              )
  
          # Update across all model parallel instances.
@@ -41,7 +49,146 @@ index b5bc894c..93c8b45e 100644
          # Check for nan.
          found_inf_flag = self.found_inf.item() > 0
  
-@@ -1319,7 +1330,7 @@ class ChainedOptimizer(MegatronOptimizer):
+@@ -1144,29 +1156,118 @@ class ChainedOptimizer(MegatronOptimizer):
+                 model_sharded_state_dict, is_loading, **kwargs
+             )
+         else:
+-            sharded_state_dict = {}
+-            for optimizer_idx, optimizer in enumerate(self.chained_optimizers):
+-                optim_state_dict = optimizer.sharded_state_dict(
+-                    model_sharded_state_dict, is_loading, **kwargs
+-                )
+-                add_prefix_for_sharding(optim_state_dict, f'chained_{optimizer_idx}.')
+-                sharded_state_dict[optimizer_idx] = optim_state_dict
+-            return sharded_state_dict
++            if not is_loading:
++                sharded_state_dict = {} 
++                for optimizer_idx, optimizer in enumerate(self.chained_optimizers):
++                    optim_state_dict = optimizer.sharded_state_dict(
++                        model_sharded_state_dict, is_loading, **kwargs
++                    )    
++                    add_prefix_for_sharding(optim_state_dict, f'chained_{optimizer_idx}.')
++                    sharded_state_dict[optimizer_idx] = optim_state_dict
++                return sharded_state_dict
++                 
++            args = get_args()
++            if args.convert_expert_parallel:
++               #convert tp/pp ckpt to ep ckpt
++                print("sharded_state_dict:convert tp/pp ckpt to ep ckpt!")
++                sharded_state_dict = {} 
++                fake_sharded_state_dict = {
++                    'optimizer': {},
++                    'param_state': {},
++                    'param_state_sharding_type': {}
++                }    
++                global_pid = 0
++                mapping_idx = {} 
++                for optimizer_idx, optimizer in enumerate(self.chained_optimizers):
++                    optim_state_dict = optimizer.sharded_state_dict(
++                        model_sharded_state_dict, is_loading, **kwargs
++                    )
++                    tmp_dict = {}
++                    for local_pid, v in optim_state_dict['param_state'].items():
++                        fake_sharded_state_dict['param_state'][global_pid] = v
++                        tmp_dict[local_pid] = global_pid
++                        global_pid += 1
++                    mapping_idx[optimizer_idx] = tmp_dict
++                        
++                    fake_sharded_state_dict['optimizer'] = optim_state_dict['optimizer']
++                    fake_sharded_state_dict['param_state_sharding_type'] = optim_state_dict['param_state_sharding_type']
++                    
++                    sharded_state_dict[optimizer_idx] = {}
++                    sharded_state_dict[optimizer_idx]['optimizer'] = copy.deepcopy(optim_state_dict['optimizer'])
++                    sharded_state_dict[optimizer_idx]['param_state_sharding_type'] = copy.deepcopy(optim_state_dict['param_state_sharding_type'])
++                    sharded_state_dict[optimizer_idx]['len_param_state'] = len(optim_state_dict['param_state'])
++                    self.original_sharded_state_dict = sharded_state_dict
++                self.mapping_idx = mapping_idx
++                return fake_sharded_state_dict
++            else:   #megatron source apply ep
++                print("sharded_state_dict:megatron source apply ep!")
++                sharded_state_dict = {}
++                for optimizer_idx, optimizer in enumerate(self.chained_optimizers):
++                    optim_state_dict = optimizer.sharded_state_dict(
++                        model_sharded_state_dict, is_loading, **kwargs
++                    )
++                    add_prefix_for_sharding(optim_state_dict, f'chained_{optimizer_idx}.')
++                    sharded_state_dict[optimizer_idx] = optim_state_dict
++                return sharded_state_dict
++            #sharded_state_dict = {}
++            #for optimizer_idx, optimizer in enumerate(self.chained_optimizers):
++            #    optim_state_dict = optimizer.sharded_state_dict(
++            #        model_sharded_state_dict, is_loading, **kwargs
++            #    )
++            #    add_prefix_for_sharding(optim_state_dict, f'chained_{optimizer_idx}.')
++            #    sharded_state_dict[optimizer_idx] = optim_state_dict
++            #return sharded_state_dict
+ 
+     def load_state_dict(self, state_dict):
+         # If there is only one optimizer, we read the state dict as a single optimizer.
+-        if len(self.chained_optimizers) == 1:
+-            self.chained_optimizers[0].load_state_dict(state_dict)
+-            return
+-        if len(self.chained_optimizers) != len(state_dict):
+-            raise RuntimeError(
+-                f'Expected {len(self.chained_optimizers)} entries'
+-                f' in state dict, but got {len(state_dict)}.'
+-            )
+-        if isinstance(state_dict, dict):
+-            state_dict = (v for k, v in sorted(state_dict.items()))
+-        for optimizer, state in zip(self.chained_optimizers, state_dict):
+-            optimizer.load_state_dict(state)
++        args = get_args()
++        
++        if args.convert_expert_parallel:  #convert tp/pp ckpt to ep ckpt
++            print("load_state_dict:convert tp/pp ckpt to ep ckpt!")
++            new_state_dict = {}
++            for optimizer_idx, optimizer in enumerate(self.chained_optimizers):
++                new_state_dict[optimizer_idx] = {}
++                new_state_dict[optimizer_idx]['optimizer'] = self.original_sharded_state_dict[optimizer_idx]['optimizer']
++                new_state_dict[optimizer_idx]['param_state_sharding_type'] = self.original_sharded_state_dict[optimizer_idx]['param_state_sharding_type']
++                len_param_state = self.original_sharded_state_dict[optimizer_idx]['len_param_state']
++                new_state_dict[optimizer_idx]['param_state'] = {}
++                for i in range(len_param_state):
++                    new_state_dict[optimizer_idx]['param_state'][i] = state_dict['param_state'][self.mapping_idx[optimizer_idx][i]]
++            if len(self.chained_optimizers) != len(new_state_dict):
++                raise RuntimeError(
++                    f'Expected {len(self.chained_optimizers)} entries'
++                    f' in state dict, but got {len(new_state_dict)}.'
++              )
++            if isinstance(state_dict, dict):
++                new_state_dict = (v for k, v in sorted(new_state_dict.items()))
++            for optimizer, state in zip(self.chained_optimizers, new_state_dict):
++                optimizer.load_state_dict(state)
++        else:   #megatron source apply ep
++            print("load_state_dict:megatron source apply ep!")
++            if len(self.chained_optimizers) == 1:
++                self.chained_optimizers[0].load_state_dict(state_dict)
++                return
++            if len(self.chained_optimizers) != len(state_dict):
++                raise RuntimeError(
++                    f'Expected {len(self.chained_optimizers)} entries'
++                    f' in state dict, but got {len(state_dict)}.'
++                )
++            if isinstance(state_dict, dict):
++                state_dict = (v for k, v in sorted(state_dict.items()))
++            for optimizer, state in zip(self.chained_optimizers, state_dict):
++                optimizer.load_state_dict(state)
++        #if len(self.chained_optimizers) == 1:
++        #    self.chained_optimizers[0].load_state_dict(state_dict)
++        #    return
++        #if len(self.chained_optimizers) != len(state_dict):
++        #    raise RuntimeError(
++        #        f'Expected {len(self.chained_optimizers)} entries'
++        #        f' in state dict, but got {len(state_dict)}.'
++        #    )
++        #if isinstance(state_dict, dict):
++        #    state_dict = (v for k, v in sorted(state_dict.items()))
++        #for optimizer, state in zip(self.chained_optimizers, state_dict):
++        #    optimizer.load_state_dict(state)
+ 
+     @torch.no_grad()
+     def prepare_grads(self) -> bool:
+@@ -1319,7 +1420,7 @@ class ChainedOptimizer(MegatronOptimizer):
  
              # Lazy loading checkpoint, state dict is needed only when DP rank = 0.
              if optimizer.data_parallel_group.rank() == 0 and states is None:

--- a/flagscale/backends/Megatron-LM/megatron/training/arguments.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/arguments.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/training/arguments.py b/megatron/training/arguments.py
-index e36803fc..3a19a933 100644
+index e36803fc..4469cd66 100644
 --- a/megatron/training/arguments.py
 +++ b/megatron/training/arguments.py
 @@ -59,6 +59,7 @@ def add_megatron_arguments(parser: argparse.ArgumentParser):
@@ -390,7 +390,16 @@ index e36803fc..3a19a933 100644
      group.add_argument('--exit-on-missing-checkpoint', action='store_true',
                         help="If '--load' is set, but checkpoint is not found "
                         "(e.g., path typo), then exit instead of random "
-@@ -2293,7 +2436,7 @@ def _add_distributed_args(parser):
+@@ -2196,6 +2339,8 @@ def _add_checkpointing_args(parser):
+     group.add_argument('--load-model-opt-format', action='store_true',
+                        help='Load a checkpoint for TensorRT model optimizer (nvidia-modelopt).'
+                             'This function can also be used to load NeMo .nemo sharded checkpoints.')
++    group.add_argument('--convert-expert-parallel', action='store_true', default=None,
++                       help='Loading the ckpt, convert the keys of TP/PP to the keys of EP.')
+     return parser
+ 
+ 
+@@ -2293,7 +2438,7 @@ def _add_distributed_args(parser):
                         default=False, help='if set, overlap pipeline parallel communication in warmup and flush',
                         dest='overlap_p2p_comm_warmup_flush')
      group.add_argument('--distributed-backend', default='nccl',
@@ -399,7 +408,7 @@ index e36803fc..3a19a933 100644
                         help='Which backend to use for distributed training.')
      group.add_argument('--distributed-timeout-minutes', type=int, default=10,
                         help='Timeout minutes for torch.distributed.')
-@@ -2344,6 +2487,11 @@ def _add_distributed_args(parser):
+@@ -2344,6 +2489,11 @@ def _add_distributed_args(parser):
                         'complete it instead. Also turns on '
                         '--use-cpu-initialization flag. This is for '
                         'external DDP manager.' )
@@ -411,7 +420,7 @@ index e36803fc..3a19a933 100644
      group.add_argument('--account-for-embedding-in-pipeline-split', action='store_true',
                         default=False, help='If set, *input* embedding layer will be treated as a standard transformer'
                         'layer in the context of partition and placement for pipeline parallelism.')
-@@ -2378,6 +2526,10 @@ def _add_distributed_args(parser):
+@@ -2378,6 +2528,10 @@ def _add_distributed_args(parser):
                          'and performance requirements.')
      group.add_argument('--keep-fp8-transpose-cache-when-using-custom-fsdp', action='store_true',
                         help='If set, keep the fp8 transpose cache when using custom FSDP.')
@@ -422,7 +431,7 @@ index e36803fc..3a19a933 100644
      group.add_argument('--num-distributed-optimizer-instances', type=int, default=1,
                         help='Number of Distributed Optimizer copies across Data Parallel domain.')
      group.add_argument('--use-torch-fsdp2', action='store_true',
-@@ -2430,6 +2582,9 @@ def _add_validation_args(parser):
+@@ -2430,6 +2584,9 @@ def _add_validation_args(parser):
      group.add_argument('--eval-interval', type=int, default=1000,
                         help='Interval between running evaluation on '
                         'validation set.')
@@ -432,7 +441,7 @@ index e36803fc..3a19a933 100644
      group.add_argument("--test-mode", action="store_true", help='Run all real-time test alongside the experiment.')
      group.add_argument('--skip-train', action='store_true',
                         default=False, help='If set, bypass the training loop, '
-@@ -2444,6 +2599,8 @@ def _add_tokenizer_args(parser):
+@@ -2444,6 +2601,8 @@ def _add_tokenizer_args(parser):
                         help='Size of vocab before EOD or padding.')
      group.add_argument('--vocab-file', type=str, default=None,
                         help='Path to the vocab file.')
@@ -441,7 +450,7 @@ index e36803fc..3a19a933 100644
      group.add_argument('--merge-file', type=str, default=None,
                         help='Path to the BPE merge file.')
      group.add_argument('--vocab-extra-ids', type=int, default=0,
-@@ -2462,8 +2619,17 @@ def _add_tokenizer_args(parser):
+@@ -2462,8 +2621,17 @@ def _add_tokenizer_args(parser):
                                  'MultimodalTokenizer',
                                  'NullTokenizer',
                                  'NullMultimodalTokenizer',
@@ -460,7 +469,7 @@ index e36803fc..3a19a933 100644
      group.add_argument('--tokenizer-model', type=str, default=None,
                         help='Sentencepiece tokenizer model.')
      group.add_argument('--tiktoken-pattern', type=str, default=None,
-@@ -2497,6 +2663,11 @@ def _add_data_args(parser):
+@@ -2497,6 +2665,11 @@ def _add_data_args(parser):
      group.add_argument('--valid-data-path', nargs='*', default=None,
                         help='The weight and prefix list for an independent validation dataset. '
                         'Follows the same pattern rules as --data-path.')
@@ -472,7 +481,7 @@ index e36803fc..3a19a933 100644
      group.add_argument('--test-data-path', nargs='*', default=None,
                         help='The weight and prefix list for an independent test dataset. '
                         'Follows the same pattern rules as --data-path.')
-@@ -2545,11 +2716,18 @@ def _add_data_args(parser):
+@@ -2545,11 +2718,18 @@ def _add_data_args(parser):
                         'end-of-document token.')
      group.add_argument('--eod-mask-loss', action='store_true',
                         help='Mask loss for the end of document tokens.')
@@ -491,7 +500,7 @@ index e36803fc..3a19a933 100644
      group.add_argument('--object-storage-cache-path', type=str, default=None,
                         help='Path to cache index files when using s3 or msc dataloader')
      group.add_argument('--mid-level-dataset-surplus', type=float, default=0.005,
-@@ -2626,6 +2804,19 @@ def _add_biencoder_args(parser):
+@@ -2626,6 +2806,19 @@ def _add_biencoder_args(parser):
      return parser
  
  
@@ -511,7 +520,7 @@ index e36803fc..3a19a933 100644
  def _add_vision_args(parser):
      group = parser.add_argument_group(title="vision")
  
-@@ -2696,6 +2887,8 @@ def _add_vision_args(parser):
+@@ -2696,6 +2889,8 @@ def _add_vision_args(parser):
                         help='Whether to layer normalize the q and k attention embeddings.')
      group.add_argument('--qk-l2-norm', action='store_true',
                         help='Use llama 4 qk l2 norm')
@@ -520,7 +529,7 @@ index e36803fc..3a19a933 100644
  
      return parser
  
-@@ -3000,3 +3193,46 @@ def _add_sft_args(parser):
+@@ -3000,3 +3195,46 @@ def _add_sft_args(parser):
      group.add_argument('--sft-tokenizer-prompt-format', type=str, default="nemotron-h-aligned", 
                         help='SFT prompt format.')
      return parser


### PR DESCRIPTION
1.use load tp/pp ckpt to ep, must add arg --convert-expert-parallel and --no-load-rng,
2.If the --convert-expert-parallel option is enabled, Megatron will execute the modified code; otherwise, it will execute the native Megatron code.
3.For example, after running with the tp2 or pp2 parallel strategy, it is converted to the parallel strategy ep4.