### PR TITLE
[Runner] support served model name for autotune

### DIFF
--- a/flagscale/runner/runner_serve.py
+++ b/flagscale/runner/runner_serve.py
@@ -1173,7 +1173,7 @@ class SSHServeRunner(RunnerBase):
 
         trust_remote_code = engine_args.get("trust_remote_code", False)
 
-        model_id = engine_args.get("served_model_name", None)
+        served_model_name = engine_args.get("served_model_name", None)
         model_name = engine_args.get("model", None)
 
         if not model_name:
@@ -1206,7 +1206,7 @@ class SSHServeRunner(RunnerBase):
             benchmark(
                 api_url,
                 model=model_name,
-                model_id=model_id,
+                served_model_name=served_model_name,
                 tokenizer=tokenizer,
                 input_requests=dummy_input_requests,
                 selected_percentile_metrics="ttft,tpot,itl,e2el".split(","),

--- a/flagscale/runner/utils.py
+++ b/flagscale/runner/utils.py
@@ -608,7 +608,7 @@ async def get_request(input_requests):
 async def benchmark(
     api_url,
     model,
-    model_id,
+    served_model_name,
     tokenizer,
     input_requests,
     selected_percentile_metrics,
@@ -620,7 +620,7 @@ async def benchmark(
 
     request_func = async_request_openai_chat_completions
     req_model_id = model
-    req_model_name = model_id if model_id is not None else model
+    req_model_name = served_model_name if served_model_name is not None else model
 
     pbar = tqdm(total=len(input_requests))
 


### PR DESCRIPTION
The current automatic tuning benchmark function only supports the mode parameter and does not support served_model_name, which leads to an error if served_model_name is used.
