### PR TITLE
[tools]update flagscale patch file

### DIFF
--- a/flagscale/backends/Megatron-LM/examples/multimodal/mlp_converter.py.patch
+++ b/flagscale/backends/Megatron-LM/examples/multimodal/mlp_converter.py.patch
@@ -1,6 +1,6 @@
 diff --git a/examples/multimodal/mlp_converter.py b/examples/multimodal/mlp_converter.py
 new file mode 100644
-index 00000000..b105b93d
+index 000000000..b105b93d9
 --- /dev/null
 +++ b/examples/multimodal/mlp_converter.py
 @@ -0,0 +1,75 @@

--- a/flagscale/backends/Megatron-LM/megatron/__init__.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/__init__.py.patch
@@ -1,3 +1,3 @@
 diff --git a/megatron/__init__.py b/megatron/__init__.py
 new file mode 100644
-index 00000000..e69de29b
+index 000000000..e69de29bb

--- a/flagscale/backends/Megatron-LM/megatron/core/datasets/blended_dataset.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/datasets/blended_dataset.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/datasets/blended_dataset.py b/megatron/core/datasets/blended_dataset.py
-index e5c1915b..c77b041f 100644
+index e5c1915bc..c77b041fb 100644
 --- a/megatron/core/datasets/blended_dataset.py
 +++ b/megatron/core/datasets/blended_dataset.py
 @@ -13,7 +13,7 @@ import torch

--- a/flagscale/backends/Megatron-LM/megatron/core/datasets/blended_megatron_dataset_builder.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/datasets/blended_megatron_dataset_builder.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/datasets/blended_megatron_dataset_builder.py b/megatron/core/datasets/blended_megatron_dataset_builder.py
-index 5affd84b..f95cd376 100644
+index 5affd84b2..f95cd3766 100644
 --- a/megatron/core/datasets/blended_megatron_dataset_builder.py
 +++ b/megatron/core/datasets/blended_megatron_dataset_builder.py
 @@ -11,7 +11,7 @@ import torch

--- a/flagscale/backends/Megatron-LM/megatron/core/datasets/gpt_dataset.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/datasets/gpt_dataset.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/datasets/gpt_dataset.py b/megatron/core/datasets/gpt_dataset.py
-index b80caaf6..933b8582 100644
+index b80caaf6c..933b8582a 100644
 --- a/megatron/core/datasets/gpt_dataset.py
 +++ b/megatron/core/datasets/gpt_dataset.py
 @@ -14,7 +14,7 @@ from megatron.core.datasets.indexed_dataset import IndexedDataset

--- a/flagscale/backends/Megatron-LM/megatron/core/datasets/utils.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/datasets/utils.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/datasets/utils.py b/megatron/core/datasets/utils.py
-index e14656df..af125793 100644
+index e14656df7..af125793f 100644
 --- a/megatron/core/datasets/utils.py
 +++ b/megatron/core/datasets/utils.py
 @@ -1,11 +1,14 @@

--- a/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/exchange_utils.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/exchange_utils.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/dist_checkpointing/exchange_utils.py b/megatron/core/dist_checkpointing/exchange_utils.py
-index def79fb7..2f791449 100644
+index def79fb77..2f7914490 100644
 --- a/megatron/core/dist_checkpointing/exchange_utils.py
 +++ b/megatron/core/dist_checkpointing/exchange_utils.py
 @@ -63,7 +63,7 @@ class ShardDistribution(NamedTuple):

--- a/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/mapping.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/mapping.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/dist_checkpointing/mapping.py b/megatron/core/dist_checkpointing/mapping.py
-index d6d8e3d2..c44100f2 100644
+index d6d8e3d28..c44100f21 100644
 --- a/megatron/core/dist_checkpointing/mapping.py
 +++ b/megatron/core/dist_checkpointing/mapping.py
 @@ -205,7 +205,7 @@ class ShardedTensor(ShardedBase):

--- a/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/serialization.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/serialization.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/dist_checkpointing/serialization.py b/megatron/core/dist_checkpointing/serialization.py
-index 0469949c..e3feb8ce 100644
+index 0469949c6..e3feb8ce0 100644
 --- a/megatron/core/dist_checkpointing/serialization.py
 +++ b/megatron/core/dist_checkpointing/serialization.py
 @@ -8,6 +8,7 @@ Additionally, `load` expects the sharded state dict argument as a guidance for

--- a/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/strategies/filesystem_async.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/strategies/filesystem_async.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/dist_checkpointing/strategies/filesystem_async.py b/megatron/core/dist_checkpointing/strategies/filesystem_async.py
-index a8e75960..efdbfe8c 100644
+index a8e759608..efdbfe8c6 100644
 --- a/megatron/core/dist_checkpointing/strategies/filesystem_async.py
 +++ b/megatron/core/dist_checkpointing/strategies/filesystem_async.py
 @@ -8,13 +8,14 @@ import logging

--- a/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/strategies/torch.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/strategies/torch.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/dist_checkpointing/strategies/torch.py b/megatron/core/dist_checkpointing/strategies/torch.py
-index 56225ddd..f6530b19 100644
+index 56225ddd9..f6530b192 100644
 --- a/megatron/core/dist_checkpointing/strategies/torch.py
 +++ b/megatron/core/dist_checkpointing/strategies/torch.py
 @@ -878,6 +878,13 @@ class TorchDistLoadShardedStrategy(LoadShardedStrategy):

--- a/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/validation.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/dist_checkpointing/validation.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/dist_checkpointing/validation.py b/megatron/core/dist_checkpointing/validation.py
-index 7b423b7c..f8874bb7 100644
+index 7b423b7c8..f8874bb71 100644
 --- a/megatron/core/dist_checkpointing/validation.py
 +++ b/megatron/core/dist_checkpointing/validation.py
 @@ -503,7 +503,7 @@ def _validate_sharding_for_key_flattened(tensors_by_shard):

--- a/flagscale/backends/Megatron-LM/megatron/core/distributed/finalize_model_grads.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/distributed/finalize_model_grads.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/distributed/finalize_model_grads.py b/megatron/core/distributed/finalize_model_grads.py
-index b175eaae..19ed0836 100644
+index b175eaae1..19ed08364 100644
 --- a/megatron/core/distributed/finalize_model_grads.py
 +++ b/megatron/core/distributed/finalize_model_grads.py
 @@ -25,6 +25,18 @@ def _get_main_grad_attr(param: torch.nn.Parameter, use_custom_fsdp: bool = False

--- a/flagscale/backends/Megatron-LM/megatron/core/extensions/transformer_engine.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/extensions/transformer_engine.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/extensions/transformer_engine.py b/megatron/core/extensions/transformer_engine.py
-index 79de39b7..f90d97ff 100644
+index 79de39b7e..f90d97ff3 100644
 --- a/megatron/core/extensions/transformer_engine.py
 +++ b/megatron/core/extensions/transformer_engine.py
 @@ -23,6 +23,7 @@ from megatron.core.parallel_state import (

--- a/flagscale/backends/Megatron-LM/megatron/core/model_parallel_config.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/model_parallel_config.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/model_parallel_config.py b/megatron/core/model_parallel_config.py
-index fc0041a0..9e53424b 100644
+index fc0041a0a..9e53424bf 100644
 --- a/megatron/core/model_parallel_config.py
 +++ b/megatron/core/model_parallel_config.py
 @@ -346,6 +346,16 @@ class ModelParallelConfig:

--- a/flagscale/backends/Megatron-LM/megatron/core/models/common/embeddings/rotary_pos_embedding.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/models/common/embeddings/rotary_pos_embedding.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/models/common/embeddings/rotary_pos_embedding.py b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
-index b777de3a..9412be03 100644
+index b777de3ad..9412be030 100644
 --- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
 +++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
 @@ -223,7 +223,7 @@ class RotaryEmbedding(nn.Module):

--- a/flagscale/backends/Megatron-LM/megatron/core/models/common/language_module/language_module.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/models/common/language_module/language_module.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/models/common/language_module/language_module.py b/megatron/core/models/common/language_module/language_module.py
-index 6000e35b..5272dbe6 100644
+index 6000e35b5..5272dbe65 100644
 --- a/megatron/core/models/common/language_module/language_module.py
 +++ b/megatron/core/models/common/language_module/language_module.py
 @@ -171,9 +171,24 @@ class LanguageModule(MegatronModule):

--- a/flagscale/backends/Megatron-LM/megatron/core/models/gpt/gpt_layer_specs.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/models/gpt/gpt_layer_specs.py.patch
@@ -1,7 +1,7 @@
 diff --git a/megatron/core/models/gpt/gpt_layer_specs.py b/megatron/core/models/gpt/gpt_layer_specs.py
 old mode 100755
 new mode 100644
-index f186eabd..93a728fc
+index f186eabd0..93a728fcf
 --- a/megatron/core/models/gpt/gpt_layer_specs.py
 +++ b/megatron/core/models/gpt/gpt_layer_specs.py
 @@ -394,6 +394,7 @@ def get_gpt_decoder_block_spec(

--- a/flagscale/backends/Megatron-LM/megatron/core/models/multimodal/llava_model.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/models/multimodal/llava_model.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/models/multimodal/llava_model.py b/megatron/core/models/multimodal/llava_model.py
-index e4be5446..9e68791f 100644
+index e4be54462..9e68791f7 100644
 --- a/megatron/core/models/multimodal/llava_model.py
 +++ b/megatron/core/models/multimodal/llava_model.py
 @@ -332,9 +332,16 @@ class LLaVAModel(MegatronModule):

--- a/flagscale/backends/Megatron-LM/megatron/core/optimizer/__init__.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/optimizer/__init__.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/optimizer/__init__.py b/megatron/core/optimizer/__init__.py
-index 5ecc707c..dc4a3f12 100644
+index 5ecc707ce..dc4a3f12c 100644
 --- a/megatron/core/optimizer/__init__.py
 +++ b/megatron/core/optimizer/__init__.py
 @@ -53,6 +53,7 @@ def _get_param_groups(

--- a/flagscale/backends/Megatron-LM/megatron/core/optimizer/clip_grads.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/optimizer/clip_grads.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/optimizer/clip_grads.py b/megatron/core/optimizer/clip_grads.py
-index 0f33f919..ca7a34cf 100644
+index 0f33f919b..ca7a34cf6 100644
 --- a/megatron/core/optimizer/clip_grads.py
 +++ b/megatron/core/optimizer/clip_grads.py
 @@ -47,6 +47,7 @@ from ..tensor_parallel import param_is_not_tensor_parallel_duplicate

--- a/flagscale/backends/Megatron-LM/megatron/core/optimizer/optimizer_config.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/optimizer/optimizer_config.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/optimizer/optimizer_config.py b/megatron/core/optimizer/optimizer_config.py
-index d425202b..6a8bb144 100644
+index d425202b9..6a8bb1446 100644
 --- a/megatron/core/optimizer/optimizer_config.py
 +++ b/megatron/core/optimizer/optimizer_config.py
 @@ -173,6 +173,13 @@ class OptimizerConfig:

--- a/flagscale/backends/Megatron-LM/megatron/core/optimizer_param_scheduler.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/optimizer_param_scheduler.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/optimizer_param_scheduler.py b/megatron/core/optimizer_param_scheduler.py
-index da7e0787..e515a802 100644
+index da7e07876..e515a8026 100644
 --- a/megatron/core/optimizer_param_scheduler.py
 +++ b/megatron/core/optimizer_param_scheduler.py
 @@ -53,6 +53,7 @@ class OptimizerParamScheduler:

--- a/flagscale/backends/Megatron-LM/megatron/core/parallel_state.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/parallel_state.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/parallel_state.py b/megatron/core/parallel_state.py
-index 33424a39..1c8a5d73 100644
+index 33424a395..1c8a5d73c 100644
 --- a/megatron/core/parallel_state.py
 +++ b/megatron/core/parallel_state.py
 @@ -13,6 +13,15 @@ import torch

--- a/flagscale/backends/Megatron-LM/megatron/core/pipeline_parallel/p2p_communication.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/pipeline_parallel/p2p_communication.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/pipeline_parallel/p2p_communication.py b/megatron/core/pipeline_parallel/p2p_communication.py
-index 17f1a44c..5f44618c 100644
+index 17f1a44c6..5f44618c2 100644
 --- a/megatron/core/pipeline_parallel/p2p_communication.py
 +++ b/megatron/core/pipeline_parallel/p2p_communication.py
 @@ -242,6 +242,7 @@ def _communicate(

--- a/flagscale/backends/Megatron-LM/megatron/core/pipeline_parallel/schedules.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/pipeline_parallel/schedules.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/pipeline_parallel/schedules.py b/megatron/core/pipeline_parallel/schedules.py
-index 317789ad..dcc4f0c3 100644
+index 317789ad6..dcc4f0c39 100644
 --- a/megatron/core/pipeline_parallel/schedules.py
 +++ b/megatron/core/pipeline_parallel/schedules.py
 @@ -113,7 +113,11 @@ def get_forward_backward_func():

--- a/flagscale/backends/Megatron-LM/megatron/core/timers.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/timers.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/timers.py b/megatron/core/timers.py
-index a34b6634..46876a5e 100644
+index a34b66349..46876a5e7 100644
 --- a/megatron/core/timers.py
 +++ b/megatron/core/timers.py
 @@ -283,6 +283,8 @@ class Timers:

--- a/flagscale/backends/Megatron-LM/megatron/core/transformer/attention.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/transformer/attention.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/transformer/attention.py b/megatron/core/transformer/attention.py
-index 3d740f19..6ebaaced 100644
+index 3d740f19b..6ebaacedd 100644
 --- a/megatron/core/transformer/attention.py
 +++ b/megatron/core/transformer/attention.py
 @@ -825,22 +825,44 @@ class SelfAttention(Attention):

--- a/flagscale/backends/Megatron-LM/megatron/core/transformer/module.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/transformer/module.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/transformer/module.py b/megatron/core/transformer/module.py
-index 8a8bd8c5..048a3066 100644
+index 8a8bd8c57..048a30665 100644
 --- a/megatron/core/transformer/module.py
 +++ b/megatron/core/transformer/module.py
 @@ -232,12 +232,25 @@ class Float16Module(MegatronModule):

--- a/flagscale/backends/Megatron-LM/megatron/core/transformer/moe/experts.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/transformer/moe/experts.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/transformer/moe/experts.py b/megatron/core/transformer/moe/experts.py
-index c215c43e..200be4f9 100644
+index c215c43e2..200be4f9a 100644
 --- a/megatron/core/transformer/moe/experts.py
 +++ b/megatron/core/transformer/moe/experts.py
 @@ -226,6 +226,12 @@ class GroupedMLP(MegatronModule):

--- a/flagscale/backends/Megatron-LM/megatron/core/transformer/moe/moe_utils.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/transformer/moe/moe_utils.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/transformer/moe/moe_utils.py b/megatron/core/transformer/moe/moe_utils.py
-index b6732491..dfc06ca2 100644
+index b67324919..dfc06ca29 100644
 --- a/megatron/core/transformer/moe/moe_utils.py
 +++ b/megatron/core/transformer/moe/moe_utils.py
 @@ -700,6 +700,39 @@ def reduce_aux_losses_tracker_across_ranks(track_names: Optional[List[str]] = No

--- a/flagscale/backends/Megatron-LM/megatron/core/transformer/transformer_block.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/transformer/transformer_block.py.patch
@@ -1,7 +1,7 @@
 diff --git a/megatron/core/transformer/transformer_block.py b/megatron/core/transformer/transformer_block.py
 old mode 100755
 new mode 100644
-index af0b3234..64fd6d60
+index af0b3234c..64fd6d606
 --- a/megatron/core/transformer/transformer_block.py
 +++ b/megatron/core/transformer/transformer_block.py
 @@ -1,5 +1,5 @@

--- a/flagscale/backends/Megatron-LM/megatron/core/transformer/transformer_config.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/transformer/transformer_config.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/transformer/transformer_config.py
-index fe5f7a72..27b1b87b 100644
+index fe5f7a725..27b1b87b8 100644
 --- a/megatron/core/transformer/transformer_config.py
 +++ b/megatron/core/transformer/transformer_config.py
 @@ -283,6 +283,15 @@ class TransformerConfig(ModelParallelConfig):

--- a/flagscale/backends/Megatron-LM/megatron/core/transformer/transformer_layer.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/core/transformer/transformer_layer.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/core/transformer/transformer_layer.py b/megatron/core/transformer/transformer_layer.py
-index 51c90f5a..56212d24 100644
+index 51c90f5ac..56212d24b 100644
 --- a/megatron/core/transformer/transformer_layer.py
 +++ b/megatron/core/transformer/transformer_layer.py
 @@ -34,7 +34,7 @@ from megatron.core.utils import (

--- a/flagscale/backends/Megatron-LM/megatron/inference/text_generation/sampling.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/inference/text_generation/sampling.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/inference/text_generation/sampling.py b/megatron/inference/text_generation/sampling.py
-index 370773a3..b2fc7573 100644
+index 370773a36..b2fc7573c 100644
 --- a/megatron/inference/text_generation/sampling.py
 +++ b/megatron/inference/text_generation/sampling.py
 @@ -42,7 +42,7 @@ def modify_logits_for_top_p_filtering(logits, top_p):

--- a/flagscale/backends/Megatron-LM/megatron/inference/text_generation/tokenization.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/inference/text_generation/tokenization.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/inference/text_generation/tokenization.py b/megatron/inference/text_generation/tokenization.py
-index 541cc47b..a41c7f59 100644
+index 541cc47b3..a41c7f592 100644
 --- a/megatron/inference/text_generation/tokenization.py
 +++ b/megatron/inference/text_generation/tokenization.py
 @@ -41,6 +41,15 @@ def detokenize_generations(tokens_gpu_tensor,

--- a/flagscale/backends/Megatron-LM/megatron/training/arguments.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/arguments.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/training/arguments.py b/megatron/training/arguments.py
-index e36803fc..3d3e219e 100644
+index e36803fc5..3d3e219ed 100644
 --- a/megatron/training/arguments.py
 +++ b/megatron/training/arguments.py
 @@ -59,6 +59,7 @@ def add_megatron_arguments(parser: argparse.ArgumentParser):

--- a/flagscale/backends/Megatron-LM/megatron/training/checkpointing.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/checkpointing.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/training/checkpointing.py b/megatron/training/checkpointing.py
-index 652333ac..36f06c9b 100644
+index 652333acb..36f06c9be 100644
 --- a/megatron/training/checkpointing.py
 +++ b/megatron/training/checkpointing.py
 @@ -255,12 +255,14 @@ def read_metadata(tracker_filename):

--- a/flagscale/backends/Megatron-LM/megatron/training/global_vars.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/global_vars.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/training/global_vars.py b/megatron/training/global_vars.py
-index 7b946dc3..d589a76e 100644
+index 7b946dc34..d589a76e4 100644
 --- a/megatron/training/global_vars.py
 +++ b/megatron/training/global_vars.py
 @@ -5,6 +5,7 @@

--- a/flagscale/backends/Megatron-LM/megatron/training/initialize.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/initialize.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/training/initialize.py b/megatron/training/initialize.py
-index b4b5aa02..362f66b6 100644
+index b4b5aa027..362f66b63 100644
 --- a/megatron/training/initialize.py
 +++ b/megatron/training/initialize.py
 @@ -29,9 +29,12 @@ from megatron.training import inprocess_restart

--- a/flagscale/backends/Megatron-LM/megatron/training/tokenizer/gpt2_tokenization.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/tokenizer/gpt2_tokenization.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/training/tokenizer/gpt2_tokenization.py b/megatron/training/tokenizer/gpt2_tokenization.py
-index 55b95b8e..68e686ec 100644
+index 55b95b8ed..68e686ec1 100644
 --- a/megatron/training/tokenizer/gpt2_tokenization.py
 +++ b/megatron/training/tokenizer/gpt2_tokenization.py
 @@ -322,3 +322,55 @@ class GPT2Tokenizer(object):

--- a/flagscale/backends/Megatron-LM/megatron/training/tokenizer/rwkv_tokenization.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/tokenizer/rwkv_tokenization.py.patch
@@ -1,6 +1,6 @@
 diff --git a/megatron/training/tokenizer/rwkv_tokenization.py b/megatron/training/tokenizer/rwkv_tokenization.py
 new file mode 100644
-index 00000000..c814c554
+index 000000000..c814c5549
 --- /dev/null
 +++ b/megatron/training/tokenizer/rwkv_tokenization.py
 @@ -0,0 +1,150 @@

--- a/flagscale/backends/Megatron-LM/megatron/training/tokenizer/tokenization_utils.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/tokenizer/tokenization_utils.py.patch
@@ -1,6 +1,6 @@
 diff --git a/megatron/training/tokenizer/tokenization_utils.py b/megatron/training/tokenizer/tokenization_utils.py
 new file mode 100644
-index 00000000..8ec66b77
+index 000000000..8ec66b77a
 --- /dev/null
 +++ b/megatron/training/tokenizer/tokenization_utils.py
 @@ -0,0 +1,167 @@

--- a/flagscale/backends/Megatron-LM/megatron/training/tokenizer/tokenizer.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/tokenizer/tokenizer.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/training/tokenizer/tokenizer.py b/megatron/training/tokenizer/tokenizer.py
-index 5cf222cc..35ad2b85 100644
+index 5cf222ccc..35ad2b855 100644
 --- a/megatron/training/tokenizer/tokenizer.py
 +++ b/megatron/training/tokenizer/tokenizer.py
 @@ -11,9 +11,10 @@ from pathlib import Path

--- a/flagscale/backends/Megatron-LM/megatron/training/utils.py.patch
+++ b/flagscale/backends/Megatron-LM/megatron/training/utils.py.patch
@@ -1,5 +1,5 @@
 diff --git a/megatron/training/utils.py b/megatron/training/utils.py
-index 698c5a07..8d1ee302 100644
+index 698c5a07d..8d1ee3020 100644
 --- a/megatron/training/utils.py
 +++ b/megatron/training/utils.py
 @@ -52,6 +52,7 @@ try:

--- a/flagscale/backends/Megatron-LM/tasks/aquila/datasets.py.patch
+++ b/flagscale/backends/Megatron-LM/tasks/aquila/datasets.py.patch
@@ -1,6 +1,6 @@
 diff --git a/tasks/aquila/datasets.py b/tasks/aquila/datasets.py
 new file mode 100644
-index 00000000..d0e82d44
+index 000000000..d0e82d44d
 --- /dev/null
 +++ b/tasks/aquila/datasets.py
 @@ -0,0 +1,75 @@

--- a/flagscale/backends/Megatron-LM/tasks/aquila/evaluate.py.patch
+++ b/flagscale/backends/Megatron-LM/tasks/aquila/evaluate.py.patch
@@ -1,6 +1,6 @@
 diff --git a/tasks/aquila/evaluate.py b/tasks/aquila/evaluate.py
 new file mode 100644
-index 00000000..b63592ac
+index 000000000..b63592ac3
 --- /dev/null
 +++ b/tasks/aquila/evaluate.py
 @@ -0,0 +1,210 @@

--- a/flagscale/backends/Megatron-LM/tasks/main.py.patch
+++ b/flagscale/backends/Megatron-LM/tasks/main.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tasks/main.py b/tasks/main.py
-index da8c4b9b..9bba4424 100644
+index da8c4b9b9..9bba44242 100644
 --- a/tasks/main.py
 +++ b/tasks/main.py
 @@ -32,6 +32,9 @@ def get_tasks_args(parser):

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/data/__init__.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/data/__init__.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/data/__init__.py b/tests/unit_tests/data/__init__.py
-index e69de29b..d2d717b7 100644
+index e69de29bb..d2d717b73 100644
 --- a/tests/unit_tests/data/__init__.py
 +++ b/tests/unit_tests/data/__init__.py
 @@ -0,0 +1,25 @@

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/data/test_builder.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/data/test_builder.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/data/test_builder.py b/tests/unit_tests/data/test_builder.py
-index 93967726..65994255 100644
+index 939677268..659942550 100644
 --- a/tests/unit_tests/data/test_builder.py
 +++ b/tests/unit_tests/data/test_builder.py
 @@ -92,6 +92,9 @@ def test_builder():

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/__init__.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/__init__.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/dist_checkpointing/__init__.py b/tests/unit_tests/dist_checkpointing/__init__.py
-index ae163725..a4e01da7 100644
+index ae1637258..a4e01da73 100644
 --- a/tests/unit_tests/dist_checkpointing/__init__.py
 +++ b/tests/unit_tests/dist_checkpointing/__init__.py
 @@ -46,6 +46,10 @@ class TempNamedDir(TemporaryDirectory):

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/models/test_bert_model.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/models/test_bert_model.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/dist_checkpointing/models/test_bert_model.py b/tests/unit_tests/dist_checkpointing/models/test_bert_model.py
-index 27f01447..35d08237 100644
+index 27f014478..35d08237e 100644
 --- a/tests/unit_tests/dist_checkpointing/models/test_bert_model.py
 +++ b/tests/unit_tests/dist_checkpointing/models/test_bert_model.py
 @@ -74,6 +74,9 @@ class TestBertModel:

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/models/test_mlp_glu.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/models/test_mlp_glu.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/dist_checkpointing/models/test_mlp_glu.py b/tests/unit_tests/dist_checkpointing/models/test_mlp_glu.py
-index 1a085103..e45a23f9 100644
+index 1a0851039..e45a23f97 100644
 --- a/tests/unit_tests/dist_checkpointing/models/test_mlp_glu.py
 +++ b/tests/unit_tests/dist_checkpointing/models/test_mlp_glu.py
 @@ -41,6 +41,9 @@ def get_pp_offsets():

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py b/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
-index ca644352..e2392e59 100644
+index ca6443526..e2392e593 100644
 --- a/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
 +++ b/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
 @@ -109,6 +109,9 @@ if is_te_min_version("1.9.0.dev0"):

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/test_flattened_resharding.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/test_flattened_resharding.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/dist_checkpointing/test_flattened_resharding.py b/tests/unit_tests/dist_checkpointing/test_flattened_resharding.py
-index 1485eebe..a65e8cbe 100644
+index 1485eebe1..a65e8cbe4 100644
 --- a/tests/unit_tests/dist_checkpointing/test_flattened_resharding.py
 +++ b/tests/unit_tests/dist_checkpointing/test_flattened_resharding.py
 @@ -28,6 +28,9 @@ from tests.unit_tests.test_utilities import Utils

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/test_optimizer.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/test_optimizer.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/dist_checkpointing/test_optimizer.py b/tests/unit_tests/dist_checkpointing/test_optimizer.py
-index 7c1e5f15..596cf97d 100644
+index 7c1e5f15d..596cf97d6 100644
 --- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
 +++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
 @@ -196,6 +196,19 @@ def initialize_1d_flatten_tensor_model(

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/test_serialization.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/test_serialization.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/dist_checkpointing/test_serialization.py b/tests/unit_tests/dist_checkpointing/test_serialization.py
-index e0e2d948..e292b48e 100644
+index e0e2d9481..e292b48e7 100644
 --- a/tests/unit_tests/dist_checkpointing/test_serialization.py
 +++ b/tests/unit_tests/dist_checkpointing/test_serialization.py
 @@ -520,7 +520,14 @@ class TestSerialization:

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/utils.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/dist_checkpointing/utils.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/dist_checkpointing/utils.py b/tests/unit_tests/dist_checkpointing/utils.py
-index 18d50e71..eced1118 100644
+index 18d50e717..eced11189 100644
 --- a/tests/unit_tests/dist_checkpointing/utils.py
 +++ b/tests/unit_tests/dist_checkpointing/utils.py
 @@ -138,6 +138,7 @@ def init_checkpointing_mock_args(args, ckpt_dir, fully_parallel=False):

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py b/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
-index 71e45f9d..fb581fc2 100644
+index 71e45f9d9..fb581fc26 100644
 --- a/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
 +++ b/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
 @@ -101,12 +101,17 @@ def get_moe_model_and_buffers(

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/export/trtllm/test_distributed_fp8.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/export/trtllm/test_distributed_fp8.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/export/trtllm/test_distributed_fp8.py b/tests/unit_tests/export/trtllm/test_distributed_fp8.py
-index cf47a864..ba83ad96 100644
+index cf47a8641..ba83ad967 100644
 --- a/tests/unit_tests/export/trtllm/test_distributed_fp8.py
 +++ b/tests/unit_tests/export/trtllm/test_distributed_fp8.py
 @@ -104,7 +104,16 @@ def _forward_step_func(data_iterator, model):

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/export/trtllm/test_single_device_fp8.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/export/trtllm/test_single_device_fp8.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/export/trtllm/test_single_device_fp8.py b/tests/unit_tests/export/trtllm/test_single_device_fp8.py
-index 04bbfdb1..14e0b857 100644
+index 04bbfdb12..14e0b8576 100644
 --- a/tests/unit_tests/export/trtllm/test_single_device_fp8.py
 +++ b/tests/unit_tests/export/trtllm/test_single_device_fp8.py
 @@ -101,7 +101,16 @@ def _forward_step_func(data_iterator, model):

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/models/test_bert_model.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/models/test_bert_model.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/models/test_bert_model.py b/tests/unit_tests/models/test_bert_model.py
-index b30d1413..cff91738 100644
+index b30d1413c..cff917385 100644
 --- a/tests/unit_tests/models/test_bert_model.py
 +++ b/tests/unit_tests/models/test_bert_model.py
 @@ -6,6 +6,7 @@ from importlib.metadata import version

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/models/test_llava_model.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/models/test_llava_model.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/models/test_llava_model.py b/tests/unit_tests/models/test_llava_model.py
-index 086a7838..3637e79d 100644
+index 086a78387..3637e79df 100644
 --- a/tests/unit_tests/models/test_llava_model.py
 +++ b/tests/unit_tests/models/test_llava_model.py
 @@ -770,6 +770,245 @@ def count_parameters(model):

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/test_parallel_state.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/test_parallel_state.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/test_parallel_state.py b/tests/unit_tests/test_parallel_state.py
-index ddee6387..de1abb95 100644
+index ddee63877..de1abb95e 100644
 --- a/tests/unit_tests/test_parallel_state.py
 +++ b/tests/unit_tests/test_parallel_state.py
 @@ -229,7 +229,13 @@ def test_different_initialize_order_consistency(src_tp_pp, ep_size):

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/test_utils.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/test_utils.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/test_utils.py b/tests/unit_tests/test_utils.py
-index c507c053..98dcf003 100644
+index c507c0537..98dcf0030 100644
 --- a/tests/unit_tests/test_utils.py
 +++ b/tests/unit_tests/test_utils.py
 @@ -366,14 +366,14 @@ def test_straggler_detector():

--- a/flagscale/backends/Megatron-LM/tests/unit_tests/transformer/test_transformer_block.py.patch
+++ b/flagscale/backends/Megatron-LM/tests/unit_tests/transformer/test_transformer_block.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/unit_tests/transformer/test_transformer_block.py b/tests/unit_tests/transformer/test_transformer_block.py
-index 48b678c5..97150997 100644
+index 48b678c5f..971509977 100644
 --- a/tests/unit_tests/transformer/test_transformer_block.py
 +++ b/tests/unit_tests/transformer/test_transformer_block.py
 @@ -74,14 +74,14 @@ class TestParallelTransformerBlock:

--- a/flagscale/backends/Megatron-LM/tools/checkpoint/saver_legacy.py.patch
+++ b/flagscale/backends/Megatron-LM/tools/checkpoint/saver_legacy.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/checkpoint/saver_legacy.py b/tools/checkpoint/saver_legacy.py
-index 50af6a57..ab8cfebb 100644
+index 50af6a571..ab8cfebb2 100644
 --- a/tools/checkpoint/saver_legacy.py
 +++ b/tools/checkpoint/saver_legacy.py
 @@ -132,6 +132,8 @@ def save_checkpoint(queue, args):

--- a/flagscale/backends/Megatron-LM/tools/preprocess_data.py.patch
+++ b/flagscale/backends/Megatron-LM/tools/preprocess_data.py.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/preprocess_data.py b/tools/preprocess_data.py
-index 13e5b64a..c90feb5c 100644
+index 13e5b64a4..c90feb5c1 100644
 --- a/tools/preprocess_data.py
 +++ b/tools/preprocess_data.py
 @@ -12,6 +12,7 @@ import time

--- a/flagscale/backends/sglang/python/sglang/__init__.py.patch
+++ b/flagscale/backends/sglang/python/sglang/__init__.py.patch
@@ -1,5 +1,5 @@
 diff --git a/python/sglang/__init__.py b/python/sglang/__init__.py
-index 509b145a..8fb6dd2b 100644
+index 509b145a9..8fb6dd2b1 100644
 --- a/python/sglang/__init__.py
 +++ b/python/sglang/__init__.py
 @@ -1,8 +1,10 @@

--- a/flagscale/backends/sglang/python/sglang/srt/model_executor/model_runner.py.patch
+++ b/flagscale/backends/sglang/python/sglang/srt/model_executor/model_runner.py.patch
@@ -1,5 +1,5 @@
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 64bb885a..2c3e7169 100644
+index 64bb885a6..2c3e7169e 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
 @@ -142,6 +142,23 @@ UNBALANCED_MODEL_LOADING_TIMEOUT_S = 300


### PR DESCRIPTION
This pull request refreshes all flagscale .patch files. The sole modification in each file is the update of the blob object's short SHA-1 hash length in the index metadata line, which has been automatically increased by Git from 8 to 9 digits.