### PR TITLE
[Tools] Refine git apply logic in unpatch.py to ensure patch hash consistency

### DIFF
--- a/tools/patch/unpatch.py
+++ b/tools/patch/unpatch.py
@@ -276,13 +276,13 @@ def apply_hardware_patch(
 
             repo = Repo(submodule_path)
             try:
-                repo.git.apply(new_patch_file)
+                repo.git.apply("--whitespace", "warn", new_patch_file)
             except Exception as e:
                 logger.warning(
                     f"Failed to apply patch cleanly, and error is {e.stderr}. Retrying with --whitespace=fix."
                 )
 
-                repo.git.apply("--whitespace", "warn", new_patch_file)
+                repo.git.apply("--whitespace", "fix", new_patch_file)
             logger.info(f"Patch {new_patch_file} has been applied.")
 
         logger.info(f"Step 6: Moving patched temp path {temp_unpatch_path} to {final_path}")


### PR DESCRIPTION
unpatch.py currently always uses git apply --whitespace=fix, which alters patch hashes by "fixing" whitespace  This causes an index mismatch when running patch after unpatch. This PR fixes it by first attempting a strict git apply, and only falling back to git apply --whitespace=fix if the strict apply fails. This preserves the correct patch hash while maintaining compatibility.