### PR TITLE
[Train] Sync checkpoint conversion tools to the newest third_party/Megatron-LM

### DIFF
--- a/tools/checkpoint/aquila/args.py
+++ b/tools/checkpoint/aquila/args.py
@@ -47,6 +47,7 @@ def load_args_hf2mg(args):
     args.norm_has_bias = False
     args.tokenizer_type = "Qwen2TokenizerFS"
 
+
 def save_args_mg2hf(args):
     from .llama_model.configuration_llama import LlamaConfig
 


### PR DESCRIPTION

The checkpoint conversion tool must be updated accordingly following the Megatron update.
Error occurred when converting the trained torch-format ckpt to HF safetensor format:
1）The parameter args.expert_tensor_parallel_sizecannot be retrieved.
2）The model_provideris missing the model_builderparameter.
Fixed the two issues mentioned above.