### PR TITLE
[Elastic] Add straggler detection in training

### DIFF
--- a/tests/unit_tests/runner/straggler/__init__.py
+++ b/tests/unit_tests/runner/straggler/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests for straggler detection module

--- a/tests/unit_tests/runner/straggler/test_config.py
+++ b/tests/unit_tests/runner/straggler/test_config.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for straggler detection configuration module.
+"""
+
+import pytest
+
+from flagscale.runner.straggler.config import StragglerConfig
+
+
+class TestStragglerConfig:
+    """Test cases for StragglerConfig class."""
+
+    def test_default_values(self):
+        """Test that default values are set correctly."""
+        config = StragglerConfig()
+
+        assert config.enabled is True
+        assert config.profiling_interval == 10
+        assert config.report_interval_steps == 100
+        assert config.straggler_threshold == 1.5
+        assert config.warmup_steps == 10
+        assert config.sample_size == 100
+        assert config.gather_on_rank0 is True
+        assert config.enable_gpu_profile is True
+
+    def test_custom_values(self):
+        """Test that custom values can be set."""
+        config = StragglerConfig(
+            enabled=False,
+            profiling_interval=5,
+            report_interval_steps=50,
+            straggler_threshold=2.0,
+            warmup_steps=20,
+            sample_size=5,
+            gather_on_rank0=False,
+            enable_gpu_profile=False,
+        )
+
+        assert config.enabled is False
+        assert config.profiling_interval == 5
+        assert config.report_interval_steps == 50
+        assert config.straggler_threshold == 2.0
+        assert config.warmup_steps == 20
+        assert config.sample_size == 5
+        assert config.gather_on_rank0 is False
+        assert config.enable_gpu_profile is False
+
+    def test_monitor_sections_default(self):
+        """Test that monitor_sections has default values."""
+        config = StragglerConfig()
+
+        assert isinstance(config.monitor_sections, list)
+        assert len(config.monitor_sections) > 0
+        # Check some expected sections
+        assert "forward_backward" in config.monitor_sections
+        assert "optimizer" in config.monitor_sections
+
+    def test_monitor_sections_custom(self):
+        """Test that monitor_sections can be customized."""
+        custom_sections = ["custom_section1", "custom_section2"]
+        config = StragglerConfig(monitor_sections=custom_sections)
+
+        assert config.monitor_sections == custom_sections
+
+    def test_straggler_threshold_positive(self):
+        """Test straggler threshold with positive values."""
+        config = StragglerConfig(straggler_threshold=1.0)
+        assert config.straggler_threshold == 1.0
+
+        config = StragglerConfig(straggler_threshold=3.0)
+        assert config.straggler_threshold == 3.0
+
+    def test_config_immutability(self):
+        """Test that config values can be modified after creation."""
+        config = StragglerConfig()
+
+        # Modify values
+        config.enabled = False
+        config.straggler_threshold = 2.5
+
+        assert config.enabled is False
+        assert config.straggler_threshold == 2.5

--- a/tests/unit_tests/runner/straggler/test_detector.py
+++ b/tests/unit_tests/runner/straggler/test_detector.py
@@ -1,0 +1,457 @@
+"""
+Unit tests for straggler detector module.
+"""
+
+import json
+import os
+import tempfile
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flagscale.runner.straggler.config import StragglerConfig
+from flagscale.runner.straggler.detector import StragglerDetector
+
+
+class TestStragglerDetector:
+    """Test cases for StragglerDetector class."""
+
+    @pytest.fixture
+    def default_config(self):
+        """Create a default config for testing."""
+        return StragglerConfig(
+            enabled=True,
+            profiling_interval=10,
+            report_interval_steps=100,
+            straggler_threshold=1.5,
+            warmup_steps=10,
+            monitor_sections=["forward_backward", "optimizer"],
+        )
+
+    @pytest.fixture
+    def detector(self, default_config):
+        """Create a detector instance for testing."""
+        return StragglerDetector(
+            config=default_config, rank=0, world_size=8, node_name="test-node:gpu0"
+        )
+
+    def test_init(self, default_config):
+        """Test detector initialization."""
+        detector = StragglerDetector(
+            config=default_config, rank=0, world_size=8, node_name="test-node:gpu0"
+        )
+
+        assert detector.rank == 0
+        assert detector.world_size == 8
+        assert detector.node_name == "test-node:gpu0"
+        assert detector.enabled is True
+        assert detector.current_step == 0
+
+    def test_init_default_node_name(self, default_config):
+        """Test that node_name defaults to rank-{rank} if not provided."""
+        detector = StragglerDetector(config=default_config, rank=3, world_size=8)
+
+        assert detector.node_name == "rank-3"
+
+    def test_is_enabled(self, detector):
+        """Test is_enabled method."""
+        assert detector.is_enabled() is True
+
+        detector.set_enabled(False)
+        assert detector.is_enabled() is False
+
+    def test_set_enabled(self, detector):
+        """Test set_enabled method."""
+        detector.set_enabled(False)
+        assert detector.enabled is False
+
+        detector.set_enabled(True)
+        assert detector.enabled is True
+
+    def test_increment_step(self, detector):
+        """Test step counter increment."""
+        assert detector.current_step == 0
+
+        detector.increment_step()
+        assert detector.current_step == 1
+
+        detector.increment_step()
+        assert detector.current_step == 2
+
+    def test_record_section(self, detector):
+        """Test recording section timing data."""
+        detector.record_section("forward_backward", cpu_time=0.5, gpu_time=0.45)
+
+        assert "forward_backward" in detector.section_timings
+        assert len(detector.section_timings["forward_backward"]) == 1
+        assert detector.section_timings["forward_backward"][0] == (0, 0.5, 0.45)
+
+    def test_record_section_unmonitored(self, detector):
+        """Test that unmonitored sections are not recorded."""
+        detector.record_section("unmonitored_section", cpu_time=0.5)
+
+        assert "unmonitored_section" not in detector.section_timings
+
+    def test_record_section_disabled(self, default_config):
+        """Test that recording is skipped when disabled."""
+        default_config.enabled = False
+        detector = StragglerDetector(config=default_config, rank=0, world_size=1)
+
+        detector.record_section("forward_backward", cpu_time=0.5)
+
+        assert len(detector.section_timings) == 0
+
+    def test_should_profile_warmup(self, detector):
+        """Test should_profile respects warmup period."""
+        # During warmup (step < warmup_steps=10)
+        for step in range(10):
+            detector.current_step = step
+            assert detector.should_profile() is False
+
+        # After warmup
+        detector.current_step = 10
+        assert detector.should_profile() is True
+
+    def test_should_profile_interval(self, detector):
+        """Test should_profile respects profiling interval."""
+        # profiling_interval=10, warmup_steps=10
+        # After warmup, should profile at step 10, 20, 30, ...
+
+        detector.current_step = 10  # First step after warmup
+        assert detector.should_profile() is True
+
+        detector.current_step = 15
+        assert detector.should_profile() is False
+
+        detector.current_step = 20
+        assert detector.should_profile() is True
+
+    def test_should_report(self, detector):
+        """Test should_report respects report interval."""
+        # report_interval_steps=100
+
+        detector.current_step = 0
+        assert detector.should_report() is False
+
+        detector.current_step = 50
+        assert detector.should_report() is False
+
+        detector.current_step = 100
+        assert detector.should_report() is True
+
+        detector.current_step = 200
+        assert detector.should_report() is True
+
+    def test_get_recent_section_time(self, detector):
+        """Test getting recent section timing."""
+        # Record some timings
+        detector.record_section("forward_backward", cpu_time=0.1, step=1)
+        detector.record_section("forward_backward", cpu_time=0.2, step=2)
+        detector.record_section("forward_backward", cpu_time=0.3, step=3)
+
+        # Get average of last 2 samples
+        avg_time = detector.get_recent_section_time("forward_backward", num_samples=2)
+        assert avg_time == pytest.approx(0.25, rel=1e-3)
+
+        # Get most recent sample
+        recent_time = detector.get_recent_section_time("forward_backward", num_samples=1)
+        assert recent_time == pytest.approx(0.3, rel=1e-3)
+
+    def test_get_recent_section_time_no_data(self, detector):
+        """Test getting recent section time with no data."""
+        result = detector.get_recent_section_time("forward_backward")
+        assert result is None
+
+    def test_get_section_statistics(self, detector):
+        """Test getting section statistics."""
+        # Record some timings
+        detector.record_section("forward_backward", cpu_time=0.1)
+        detector.record_section("forward_backward", cpu_time=0.2)
+        detector.record_section("forward_backward", cpu_time=0.3)
+
+        stats = detector.get_section_statistics()
+
+        assert "forward_backward" in stats
+        assert stats["forward_backward"]["count"] == 3
+        assert stats["forward_backward"]["cpu_avg"] == pytest.approx(0.2, rel=1e-3)
+        assert stats["forward_backward"]["cpu_min"] == pytest.approx(0.1, rel=1e-3)
+        assert stats["forward_backward"]["cpu_max"] == pytest.approx(0.3, rel=1e-3)
+
+    def test_reset(self, detector):
+        """Test resetting detector state."""
+        detector.record_section("forward_backward", cpu_time=0.5)
+        detector.increment_step()
+        detector.increment_step()
+
+        assert len(detector.section_timings) > 0
+        assert detector.current_step == 2
+
+        detector.reset()
+
+        assert len(detector.section_timings) == 0
+        assert detector.current_step == 0
+
+
+class TestStragglerDetection:
+    """Test cases specifically for straggler detection logic."""
+
+    @pytest.fixture
+    def config(self):
+        """Create config for straggler detection tests."""
+        return StragglerConfig(
+            enabled=True,
+            straggler_threshold=1.5,
+            monitor_sections=["forward_backward", "optimizer"],
+        )
+
+    @pytest.fixture
+    def detector(self, config):
+        """Create detector for straggler detection tests."""
+        return StragglerDetector(config=config, rank=0, world_size=8, node_name="test-node:gpu0")
+
+    def test_identify_stragglers_no_straggler(self, detector):
+        """Test straggler identification when all ranks perform similarly."""
+        # All ranks have similar timing (within threshold)
+        section_times = {
+            "forward_backward": {
+                0: 0.100,
+                1: 0.102,
+                2: 0.098,
+                3: 0.101,
+                4: 0.099,
+                5: 0.103,
+                6: 0.097,
+                7: 0.100,
+            }
+        }
+
+        stragglers = detector._identify_stragglers_from_times(section_times)
+        assert len(stragglers) == 0
+
+    def test_identify_stragglers_single_straggler(self, detector):
+        """Test straggler identification with one slow rank."""
+        # Rank 2 is 2x slower than fastest (exceeds 1.5x threshold)
+        section_times = {
+            "forward_backward": {
+                0: 0.100,
+                1: 0.100,
+                2: 0.200,  # Straggler: 2x slower
+                3: 0.100,
+                4: 0.100,
+                5: 0.100,
+                6: 0.100,
+                7: 0.100,
+            }
+        }
+
+        stragglers = detector._identify_stragglers_from_times(section_times)
+        assert len(stragglers) == 1
+        assert 2 in stragglers
+
+    def test_identify_stragglers_multiple_stragglers(self, detector):
+        """Test straggler identification with multiple slow ranks."""
+        # Rank 2 and 5 are both stragglers
+        section_times = {
+            "forward_backward": {
+                0: 0.100,
+                1: 0.100,
+                2: 0.200,  # Straggler: 2x slower
+                3: 0.100,
+                4: 0.100,
+                5: 0.180,  # Straggler: 1.8x slower
+                6: 0.100,
+                7: 0.100,
+            }
+        }
+
+        stragglers = detector._identify_stragglers_from_times(section_times)
+        assert len(stragglers) == 2
+        assert 2 in stragglers
+        assert 5 in stragglers
+
+    def test_identify_stragglers_at_threshold(self, detector):
+        """Test straggler identification at threshold boundary."""
+        # Rank 2 is slightly above 1.5x threshold (1.51x)
+        section_times = {
+            "forward_backward": {
+                0: 0.100,
+                1: 0.100,
+                2: 0.151,  # Slightly above 1.5x threshold
+                3: 0.100,
+            }
+        }
+
+        stragglers = detector._identify_stragglers_from_times(section_times)
+        assert 2 in stragglers
+
+    def test_identify_stragglers_below_threshold(self, detector):
+        """Test straggler identification below threshold."""
+        # Rank 2 is 1.4x slower (below 1.5x threshold)
+        section_times = {
+            "forward_backward": {0: 0.100, 1: 0.100, 2: 0.140, 3: 0.100}  # Below 1.5x threshold
+        }
+
+        stragglers = detector._identify_stragglers_from_times(section_times)
+        assert 2 not in stragglers
+
+    def test_identify_stragglers_multiple_sections(self, detector):
+        """Test straggler identification with multiple sections."""
+        # Rank 3 is slow in forward_backward, rank 5 is slow in optimizer
+        section_times = {
+            "forward_backward": {0: 0.100, 1: 0.100, 2: 0.100, 3: 0.200},  # Slow here
+            "optimizer": {0: 0.010, 1: 0.010, 2: 0.010, 3: 0.010},
+        }
+
+        stragglers = detector._identify_stragglers_from_times(section_times)
+        assert 3 in stragglers
+
+    def test_identify_stragglers_empty_data(self, detector):
+        """Test straggler identification with empty data."""
+        stragglers = detector._identify_stragglers_from_times({})
+        assert len(stragglers) == 0
+
+    def test_identify_stragglers_custom_threshold(self, config):
+        """Test straggler identification with custom threshold."""
+        config.straggler_threshold = 2.0
+        detector = StragglerDetector(config=config, rank=0, world_size=4)
+
+        # Rank 2 is 1.8x slower (below 2.0 threshold, not a straggler)
+        section_times = {"forward_backward": {0: 0.100, 1: 0.100, 2: 0.180, 3: 0.100}}
+
+        stragglers = detector._identify_stragglers_from_times(section_times)
+        assert 2 not in stragglers
+
+        # Rank 3 is 2.5x slower (above 2.0 threshold, is a straggler)
+        section_times["forward_backward"][3] = 0.250
+        stragglers = detector._identify_stragglers_from_times(section_times)
+        assert 3 in stragglers
+
+
+class TestStragglerDetectorReportGeneration:
+    """Test cases for report generation without distributed environment."""
+
+    @pytest.fixture
+    def config(self):
+        """Create config for report tests."""
+        return StragglerConfig(
+            enabled=True,
+            straggler_threshold=1.5,
+            monitor_sections=["forward_backward", "optimizer"],
+        )
+
+    @pytest.fixture
+    def detector(self, config):
+        """Create detector for report tests."""
+        return StragglerDetector(
+            config=config,
+            rank=0,
+            world_size=1,  # Single rank for non-distributed testing
+            node_name="test-node:gpu0",
+        )
+
+    def test_generate_report_local(self, detector):
+        """Test report generation with local data only."""
+        # Record some data
+        for i in range(5):
+            detector.record_section("forward_backward", cpu_time=0.1 + i * 0.01)
+            detector.record_section("optimizer", cpu_time=0.01)
+            detector.increment_step()
+
+        detector.current_step = 10
+        report = detector.generate_report(step=10)
+
+        assert report.step == 10
+        assert report.node_names is not None
+        assert 0 in report.node_names
+
+    def test_save_report(self, detector):
+        """Test saving report to file."""
+        # Record some data
+        detector.record_section("forward_backward", cpu_time=0.1)
+        detector.increment_step()
+
+        report = detector.generate_report(step=1)
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            detector.save_report(report, temp_path)
+
+            # Verify file was created and contains valid JSON
+            assert os.path.exists(temp_path)
+
+            with open(temp_path, 'r') as f:
+                data = json.load(f)
+
+            assert "step" in data
+            assert "section_scores" in data
+            assert "node_names" in data
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+
+class TestStragglerDetectorWithMockedDistributed:
+    """Test cases for distributed functionality with mocked torch.distributed."""
+
+    @pytest.fixture
+    def config(self):
+        """Create config for distributed tests."""
+        return StragglerConfig(
+            enabled=True,
+            straggler_threshold=1.5,
+            monitor_sections=["forward_backward", "optimizer"],
+        )
+
+    @patch('flagscale.runner.straggler.detector.dist')
+    @patch('flagscale.runner.straggler.detector.TORCH_DISTRIBUTED_AVAILABLE', True)
+    def test_gather_section_times_across_ranks(self, mock_dist, config):
+        """Test gathering section times from all ranks."""
+        # Setup mock
+        mock_dist.is_initialized.return_value = True
+
+        # Create detector
+        detector = StragglerDetector(config=config, rank=0, world_size=4, node_name="node0:gpu0")
+
+        # Record local timing
+        detector.record_section("forward_backward", cpu_time=0.1)
+
+        # Mock all_gather to simulate gathering from 4 ranks
+        def mock_all_gather(gathered_list, local_tensor):
+            # Simulate different times from different ranks
+            times = [0.10, 0.11, 0.15, 0.12]
+            for i, t in enumerate(times):
+                gathered_list[i].fill_(t)
+
+        mock_dist.all_gather.side_effect = mock_all_gather
+
+        # Call gather method
+        result = detector._gather_section_times_across_ranks()
+
+        assert "forward_backward" in result
+        assert len(result["forward_backward"]) == 4
+
+    @patch('flagscale.runner.straggler.detector.dist')
+    @patch('flagscale.runner.straggler.detector.TORCH_DISTRIBUTED_AVAILABLE', True)
+    def test_gather_node_names_across_ranks(self, mock_dist, config):
+        """Test gathering node names from all ranks."""
+        # Setup mock
+        mock_dist.is_initialized.return_value = True
+
+        detector = StragglerDetector(config=config, rank=0, world_size=4, node_name="node0:gpu0")
+
+        # Mock all_gather_object
+        def mock_all_gather_object(output_list, local_obj):
+            names = ["node0:gpu0", "node0:gpu1", "node1:gpu0", "node1:gpu1"]
+            for i, name in enumerate(names):
+                output_list[i] = name
+
+        mock_dist.all_gather_object.side_effect = mock_all_gather_object
+
+        result = detector._gather_node_names_across_ranks()
+
+        assert len(result) == 4
+        assert result[0] == "node0:gpu0"
+        assert result[2] == "node1:gpu0"

--- a/tests/unit_tests/runner/straggler/test_healthcheck.py
+++ b/tests/unit_tests/runner/straggler/test_healthcheck.py
@@ -1,0 +1,355 @@
+"""
+Unit tests for straggler healthcheck module.
+"""
+
+import os
+import tempfile
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flagscale.runner.straggler.healthcheck import (
+    ElasticTrainingHealthChecker,
+    NetworkHealthChecker,
+)
+
+
+class TestNetworkHealthChecker:
+    """Test cases for NetworkHealthChecker class."""
+
+    @pytest.fixture
+    def checker(self):
+        """Create a NetworkHealthChecker for testing."""
+        return NetworkHealthChecker(rank=0, world_size=4)
+
+    def test_init(self):
+        """Test NetworkHealthChecker initialization."""
+        checker = NetworkHealthChecker(rank=2, world_size=8)
+
+        assert checker.rank == 2
+        assert checker.world_size == 8
+        assert checker.node_health == {}
+        assert checker.latency_matrix == {}
+
+    @patch('socket.socket')
+    def test_check_node_connectivity_success(self, mock_socket_class, checker):
+        """Test successful node connectivity check."""
+        mock_socket = MagicMock()
+        mock_socket.connect_ex.return_value = 0  # Success
+        mock_socket_class.return_value = mock_socket
+
+        results = checker.check_node_connectivity(["192.168.1.1", "192.168.1.2"])
+
+        assert results["192.168.1.1"] is True
+        assert results["192.168.1.2"] is True
+
+    @patch('socket.socket')
+    def test_check_node_connectivity_failure(self, mock_socket_class, checker):
+        """Test failed node connectivity check."""
+        mock_socket = MagicMock()
+        mock_socket.connect_ex.return_value = 1  # Failure
+        mock_socket_class.return_value = mock_socket
+
+        results = checker.check_node_connectivity(["192.168.1.1"])
+
+        assert results["192.168.1.1"] is False
+
+    @patch('socket.socket')
+    def test_check_node_connectivity_exception(self, mock_socket_class, checker):
+        """Test node connectivity check with exception."""
+        mock_socket = MagicMock()
+        mock_socket.connect_ex.side_effect = Exception("Connection error")
+        mock_socket_class.return_value = mock_socket
+
+        results = checker.check_node_connectivity(["192.168.1.1"])
+
+        assert results["192.168.1.1"] is False
+
+    @patch('subprocess.run')
+    def test_measure_latency_success(self, mock_run, checker):
+        """Test successful latency measurement."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="rtt min/avg/max/mdev = 0.5/1.0/1.5/0.2 ms"
+        )
+
+        results = checker.measure_latency(["192.168.1.1"])
+
+        assert "192.168.1.1" in results
+        # Should have parsed the latency value
+        mock_run.assert_called_once()
+
+    @patch('subprocess.run')
+    def test_measure_latency_failure(self, mock_run, checker):
+        """Test failed latency measurement."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+
+        results = checker.measure_latency(["192.168.1.1"])
+
+        assert results["192.168.1.1"] == float('inf')
+
+    @patch('subprocess.run')
+    def test_measure_latency_exception(self, mock_run, checker):
+        """Test latency measurement with exception."""
+        mock_run.side_effect = Exception("Ping failed")
+
+        results = checker.measure_latency(["192.168.1.1"])
+
+        assert results["192.168.1.1"] == float('inf')
+
+    def test_identify_unhealthy_nodes(self, checker):
+        """Test identifying unhealthy nodes from health results."""
+        health_results = {
+            "192.168.1.1": {"connectivity": True, "latency_ms": 50.0, "bandwidth_mbps": 100.0},
+            "192.168.1.2": {
+                "connectivity": False,  # Unhealthy - not connected
+                "latency_ms": 0.0,
+                "bandwidth_mbps": 0.0,
+            },
+            "192.168.1.3": {
+                "connectivity": True,
+                "latency_ms": 200.0,  # Unhealthy - high latency
+                "bandwidth_mbps": 50.0,
+            },
+            "192.168.1.4": {
+                "connectivity": True,
+                "latency_ms": 30.0,
+                "bandwidth_mbps": 5.0,  # Unhealthy - low bandwidth
+            },
+        }
+
+        unhealthy = checker.identify_unhealthy_nodes(
+            health_results, max_latency_ms=100.0, min_bandwidth_mbps=10.0
+        )
+
+        assert "192.168.1.2" in unhealthy  # Not connected
+        assert "192.168.1.3" in unhealthy  # High latency
+        assert "192.168.1.4" in unhealthy  # Low bandwidth
+        assert "192.168.1.1" not in unhealthy  # Healthy
+
+    def test_identify_unhealthy_nodes_all_healthy(self, checker):
+        """Test when all nodes are healthy."""
+        health_results = {
+            "192.168.1.1": {"connectivity": True, "latency_ms": 10.0, "bandwidth_mbps": 100.0},
+            "192.168.1.2": {"connectivity": True, "latency_ms": 20.0, "bandwidth_mbps": 80.0},
+        }
+
+        unhealthy = checker.identify_unhealthy_nodes(health_results)
+
+        assert len(unhealthy) == 0
+
+    def test_get_network_summary(self, checker):
+        """Test network summary generation with mocked health check."""
+        # Mock comprehensive_health_check
+        with patch.object(checker, 'comprehensive_health_check') as mock_check:
+            mock_check.return_value = {
+                "192.168.1.1": {
+                    "connectivity": True,
+                    "latency_ms": 10.0,
+                    "bandwidth_mbps": 100.0,
+                    "healthy": True,
+                },
+                "192.168.1.2": {
+                    "connectivity": True,
+                    "latency_ms": 15.0,
+                    "bandwidth_mbps": 90.0,
+                    "healthy": True,
+                },
+            }
+
+            summary = checker.get_network_summary(["192.168.1.1", "192.168.1.2"])
+
+            assert summary["total_nodes"] == 2
+            assert summary["healthy_nodes"] == 2
+            assert summary["health_percentage"] == 100.0
+            assert summary["network_healthy"] is True
+
+    def test_save_health_report(self, checker):
+        """Test saving health report to file."""
+        health_results = {
+            "192.168.1.1": {
+                "connectivity": True,
+                "latency_ms": 10.0,
+                "bandwidth_mbps": 100.0,
+                "healthy": True,
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            checker.save_health_report(health_results, temp_path)
+
+            assert os.path.exists(temp_path)
+
+            with open(temp_path, 'r') as f:
+                content = f.read()
+
+            assert "192.168.1.1" in content
+            assert "Network Health Check Report" in content
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+    def test_save_health_report_error_handling(self, checker):
+        """Test save health report handles write errors."""
+        health_results = {"192.168.1.1": {"connectivity": True}}
+
+        # Should not raise, just print warning
+        checker.save_health_report(health_results, "/nonexistent/path/report.txt")
+
+
+class TestElasticTrainingHealthChecker:
+    """Test cases for ElasticTrainingHealthChecker class."""
+
+    @pytest.fixture
+    def elastic_checker(self):
+        """Create an ElasticTrainingHealthChecker for testing."""
+        return ElasticTrainingHealthChecker(rank=0, world_size=4)
+
+    def test_init(self):
+        """Test ElasticTrainingHealthChecker initialization."""
+        checker = ElasticTrainingHealthChecker(rank=1, world_size=8)
+
+        assert checker.rank == 1
+        assert checker.world_size == 8
+        assert checker.health_history == []
+
+    def test_inherits_from_network_checker(self, elastic_checker):
+        """Test that ElasticTrainingHealthChecker inherits from NetworkHealthChecker."""
+        assert isinstance(elastic_checker, NetworkHealthChecker)
+
+    def test_detect_unstable_nodes(self, elastic_checker):
+        """Test detecting unstable nodes from health history."""
+        health_history = [
+            {
+                "check_id": 0,
+                "timestamp": 1000.0,
+                "health_results": {
+                    "192.168.1.1": {"connectivity": True},
+                    "192.168.1.2": {"connectivity": False},  # Failed
+                },
+            },
+            {
+                "check_id": 1,
+                "timestamp": 1030.0,
+                "health_results": {
+                    "192.168.1.1": {"connectivity": True},
+                    "192.168.1.2": {"connectivity": False},  # Failed again
+                },
+            },
+            {
+                "check_id": 2,
+                "timestamp": 1060.0,
+                "health_results": {
+                    "192.168.1.1": {"connectivity": True},
+                    "192.168.1.2": {"connectivity": True},  # Recovered
+                },
+            },
+        ]
+
+        # 192.168.1.2 failed 2 out of 3 times = 66.7% failure rate
+        unstable = elastic_checker.detect_unstable_nodes(
+            health_history, instability_threshold=0.5  # 50% threshold
+        )
+
+        assert "192.168.1.2" in unstable
+        assert "192.168.1.1" not in unstable
+
+    def test_detect_unstable_nodes_all_stable(self, elastic_checker):
+        """Test when all nodes are stable."""
+        health_history = [
+            {
+                "check_id": i,
+                "timestamp": 1000.0 + i * 30,
+                "health_results": {
+                    "192.168.1.1": {"connectivity": True},
+                    "192.168.1.2": {"connectivity": True},
+                },
+            }
+            for i in range(5)
+        ]
+
+        unstable = elastic_checker.detect_unstable_nodes(health_history)
+
+        assert len(unstable) == 0
+
+    def test_detect_unstable_nodes_empty_history(self, elastic_checker):
+        """Test with empty health history."""
+        unstable = elastic_checker.detect_unstable_nodes([])
+
+        assert len(unstable) == 0
+
+    def test_health_history_accumulation(self, elastic_checker):
+        """Test that health history is accumulated."""
+        assert len(elastic_checker.health_history) == 0
+
+        # Mock comprehensive_health_check
+        with patch.object(elastic_checker, 'comprehensive_health_check') as mock_check:
+            mock_check.return_value = {"192.168.1.1": {"connectivity": True}}
+
+            # This would normally take time due to sleep, so we mock the timing
+            with patch('time.sleep'):
+                elastic_checker.monitor_elastic_health(
+                    ["192.168.1.1"], check_interval=0.1, num_checks=3
+                )
+
+        assert len(elastic_checker.health_history) == 3
+
+
+class TestHealthCheckerEdgeCases:
+    """Test edge cases for health checker classes."""
+
+    def test_empty_node_list(self):
+        """Test with empty node list."""
+        checker = NetworkHealthChecker()
+
+        results = checker.check_node_connectivity([])
+        assert results == {}
+
+        latencies = checker.measure_latency([])
+        assert latencies == {}
+
+    def test_single_node(self):
+        """Test with single node."""
+        checker = NetworkHealthChecker(rank=0, world_size=1)
+
+        with patch('socket.socket') as mock_socket_class:
+            mock_socket = MagicMock()
+            mock_socket.connect_ex.return_value = 0
+            mock_socket_class.return_value = mock_socket
+
+            results = checker.check_node_connectivity(["localhost"])
+            assert len(results) == 1
+
+    def test_check_bandwidth_exception(self):
+        """Test bandwidth check handles exceptions."""
+        checker = NetworkHealthChecker()
+
+        with patch('socket.socket') as mock_socket_class:
+            mock_socket = MagicMock()
+            mock_socket.connect.side_effect = Exception("Connection failed")
+            mock_socket_class.return_value = mock_socket
+
+            bandwidths = checker.check_bandwidth(["192.168.1.1"])
+            assert bandwidths["192.168.1.1"] == 0.0
+
+    def test_network_summary_empty_nodes(self):
+        """Test network summary with no reachable nodes."""
+        checker = NetworkHealthChecker()
+
+        with patch.object(checker, 'comprehensive_health_check') as mock_check:
+            mock_check.return_value = {
+                "192.168.1.1": {
+                    "connectivity": False,
+                    "latency_ms": float('inf'),
+                    "bandwidth_mbps": 0.0,
+                    "healthy": False,
+                }
+            }
+
+            summary = checker.get_network_summary(["192.168.1.1"])
+
+            assert summary["healthy_nodes"] == 0
+            assert summary["network_healthy"] is False

--- a/tests/unit_tests/runner/straggler/test_report.py
+++ b/tests/unit_tests/runner/straggler/test_report.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for straggler report module.
+"""
+
+import json
+
+import pytest
+
+from flagscale.runner.straggler.report import StragglerReport
+
+
+class TestStragglerReport:
+    """Test cases for StragglerReport class."""
+
+    @pytest.fixture
+    def sample_section_scores(self):
+        """Create sample section scores data."""
+        return {
+            "forward_backward": {0: 0.100, 1: 0.105, 2: 0.098, 3: 0.102},
+            "optimizer": {0: 0.010, 1: 0.011, 2: 0.009, 3: 0.010},
+        }
+
+    @pytest.fixture
+    def sample_gpu_scores(self):
+        """Create sample GPU scores data."""
+        return {0: 10.0, 1: 9.5, 2: 10.2, 3: 9.8}
+
+    @pytest.fixture
+    def sample_node_names(self):
+        """Create sample node names data."""
+        return {0: "node0:gpu0", 1: "node0:gpu1", 2: "node1:gpu0", 3: "node1:gpu1"}
+
+    def test_init_basic(self):
+        """Test basic report initialization."""
+        report = StragglerReport(step=100)
+
+        assert report.step == 100
+        assert report.section_scores == {}
+        assert report.gpu_scores == {}
+        assert report.straggler_ranks == []
+        assert report.node_names == {}
+
+    def test_init_with_data(self, sample_section_scores, sample_gpu_scores, sample_node_names):
+        """Test report initialization with data."""
+        report = StragglerReport(
+            step=100,
+            section_scores=sample_section_scores,
+            gpu_scores=sample_gpu_scores,
+            straggler_ranks=[2],
+            node_names=sample_node_names,
+        )
+
+        assert report.step == 100
+        assert report.section_scores == sample_section_scores
+        assert report.gpu_scores == sample_gpu_scores
+        assert report.straggler_ranks == [2]
+        assert report.node_names == sample_node_names
+
+    def test_to_dict(self, sample_section_scores, sample_gpu_scores, sample_node_names):
+        """Test conversion to dictionary."""
+        report = StragglerReport(
+            step=100,
+            section_scores=sample_section_scores,
+            gpu_scores=sample_gpu_scores,
+            straggler_ranks=[2],
+            node_names=sample_node_names,
+        )
+
+        result = report.to_dict()
+
+        assert isinstance(result, dict)
+        assert result["step"] == 100
+        assert result["section_scores"] == sample_section_scores
+        assert result["gpu_scores"] == sample_gpu_scores
+        assert result["straggler_ranks"] == [2]
+        assert result["node_names"] == sample_node_names
+        assert "timestamp" in result
+
+    def test_to_dict_json_serializable(
+        self, sample_section_scores, sample_gpu_scores, sample_node_names
+    ):
+        """Test that to_dict result is JSON serializable."""
+        report = StragglerReport(
+            step=100,
+            section_scores=sample_section_scores,
+            gpu_scores=sample_gpu_scores,
+            straggler_ranks=[2, 3],
+            node_names=sample_node_names,
+        )
+
+        result = report.to_dict()
+
+        # Should not raise
+        json_str = json.dumps(result)
+        assert isinstance(json_str, str)
+
+        # Should be able to parse back
+        parsed = json.loads(json_str)
+        assert parsed["step"] == 100
+
+    def test_to_text_no_stragglers(
+        self, sample_section_scores, sample_gpu_scores, sample_node_names
+    ):
+        """Test text output when no stragglers detected."""
+        report = StragglerReport(
+            step=100,
+            section_scores=sample_section_scores,
+            gpu_scores=sample_gpu_scores,
+            straggler_ranks=[],
+            node_names=sample_node_names,
+        )
+
+        text = report.to_text()
+
+        assert "Step 100" in text
+        assert "No stragglers detected" in text
+        assert "forward_backward" in text
+        assert "optimizer" in text
+
+    def test_to_text_with_stragglers(
+        self, sample_section_scores, sample_gpu_scores, sample_node_names
+    ):
+        """Test text output when stragglers are detected."""
+        report = StragglerReport(
+            step=100,
+            section_scores=sample_section_scores,
+            gpu_scores=sample_gpu_scores,
+            straggler_ranks=[2, 3],
+            node_names=sample_node_names,
+        )
+
+        text = report.to_text()
+
+        assert "Step 100" in text
+        assert "STRAGGLERS DETECTED" in text or "Straggler" in text
+        # Should mention straggler ranks
+        assert "2" in text
+        assert "3" in text
+
+    def test_to_text_section_timings(self, sample_node_names):
+        """Test that section timings are properly formatted."""
+        section_scores = {"forward_backward": {0: 0.100, 1: 0.150, 2: 0.120, 3: 0.110}}
+
+        report = StragglerReport(
+            step=100, section_scores=section_scores, node_names=sample_node_names
+        )
+
+        text = report.to_text()
+
+        # Should contain section name
+        assert "forward_backward" in text
+        # Should contain timing statistics
+        assert "Min" in text or "min" in text
+        assert "Max" in text or "max" in text
+
+    def test_to_text_gpu_scores(self, sample_gpu_scores, sample_node_names):
+        """Test that GPU scores are properly formatted."""
+        report = StragglerReport(
+            step=100, section_scores={}, gpu_scores=sample_gpu_scores, node_names=sample_node_names
+        )
+
+        text = report.to_text()
+
+        # Should contain GPU scores section
+        assert "GPU" in text or "gpu" in text
+        # Should contain node names
+        assert "node0:gpu0" in text
+
+    def test_to_text_empty_report(self):
+        """Test text output for empty report."""
+        report = StragglerReport(step=100)
+
+        text = report.to_text()
+
+        assert "Step 100" in text
+        # Should still be valid text
+        assert isinstance(text, str)
+        assert len(text) > 0
+
+
+class TestStragglerReportStatistics:
+    """Test cases for report statistics calculations."""
+
+    def test_section_timing_statistics(self):
+        """Test that section timing statistics are calculated correctly."""
+        section_scores = {
+            "forward_backward": {0: 0.100, 1: 0.200, 2: 0.150, 3: 0.150}  # Min  # Max
+        }
+
+        report = StragglerReport(step=100, section_scores=section_scores)
+
+        text = report.to_text()
+
+        # Check that min/max/avg are displayed
+        # Values should be converted to milliseconds in output
+        assert "100" in text or "0.1" in text  # Min
+        assert "200" in text or "0.2" in text  # Max
+
+    def test_slowdown_calculation(self):
+        """Test slowdown ratio calculation in report."""
+        # Slowdown = max_time / min_time = 0.200 / 0.100 = 2.0x
+        section_scores = {"forward_backward": {0: 0.100, 1: 0.200}}
+
+        report = StragglerReport(step=100, section_scores=section_scores)
+
+        text = report.to_text()
+
+        # Should contain slowdown ratio
+        assert "2.0" in text or "Slowdown" in text
+
+
+class TestStragglerReportEdgeCases:
+    """Test edge cases for StragglerReport."""
+
+    def test_single_rank(self):
+        """Test report with single rank."""
+        report = StragglerReport(
+            step=100,
+            section_scores={"forward_backward": {0: 0.100}},
+            gpu_scores={0: 10.0},
+            node_names={0: "single-node:gpu0"},
+        )
+
+        text = report.to_text()
+        result = report.to_dict()
+
+        assert isinstance(text, str)
+        assert result["step"] == 100
+
+    def test_large_number_of_ranks(self):
+        """Test report with many ranks."""
+        num_ranks = 64
+        section_scores = {"forward_backward": {i: 0.1 + i * 0.001 for i in range(num_ranks)}}
+        gpu_scores = {i: 10.0 - i * 0.1 for i in range(num_ranks)}
+        node_names = {i: f"node{i // 8}:gpu{i % 8}" for i in range(num_ranks)}
+
+        report = StragglerReport(
+            step=100, section_scores=section_scores, gpu_scores=gpu_scores, node_names=node_names
+        )
+
+        text = report.to_text()
+        result = report.to_dict()
+
+        assert isinstance(text, str)
+        assert len(result["section_scores"]["forward_backward"]) == num_ranks
+
+    def test_zero_timing_values(self):
+        """Test report with zero timing values."""
+        report = StragglerReport(step=100, section_scores={"forward_backward": {0: 0.0, 1: 0.0}})
+
+        # Should not raise
+        text = report.to_text()
+        result = report.to_dict()
+
+        assert isinstance(text, str)
+        assert isinstance(result, dict)
+
+    def test_very_large_timing_values(self):
+        """Test report with very large timing values."""
+        report = StragglerReport(
+            step=100, section_scores={"forward_backward": {0: 1000.0, 1: 2000.0}}
+        )
+
+        text = report.to_text()
+        result = report.to_dict()
+
+        assert isinstance(text, str)
+        assert isinstance(result, dict)
+
+    def test_timestamp_is_set(self):
+        """Test that timestamp is set in report."""
+        report = StragglerReport(step=100)
+        report.timestamp = 1234567890.0
+
+        result = report.to_dict()
+
+        assert result["timestamp"] == 1234567890.0

--- a/tests/unit_tests/runner/straggler/test_section.py
+++ b/tests/unit_tests/runner/straggler/test_section.py
@@ -1,0 +1,348 @@
+"""
+Unit tests for straggler section profiling module.
+"""
+
+import time
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flagscale.runner.straggler.section import (
+    OptionalSectionContext,
+    SectionContext,
+    SectionProfiler,
+    create_section_decorator,
+)
+
+
+class TestSectionContext:
+    """Test cases for SectionContext class."""
+
+    @pytest.fixture
+    def mock_detector(self):
+        """Create a mock detector for testing."""
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        return detector
+
+    def test_basic_timing(self, mock_detector):
+        """Test that SectionContext records timing correctly."""
+        with SectionContext(mock_detector, "test_section"):
+            time.sleep(0.01)  # Small sleep to ensure measurable time
+
+        # Verify record_section was called
+        mock_detector.record_section.assert_called_once()
+
+        # Check call arguments
+        call_args = mock_detector.record_section.call_args
+        assert call_args.kwargs["name"] == "test_section"
+        assert call_args.kwargs["cpu_time"] > 0
+        assert call_args.kwargs["cpu_time"] >= 0.01  # At least sleep duration
+
+    def test_timing_accuracy(self, mock_detector):
+        """Test timing accuracy of SectionContext."""
+        sleep_duration = 0.05
+
+        with SectionContext(mock_detector, "timing_test"):
+            time.sleep(sleep_duration)
+
+        call_args = mock_detector.record_section.call_args
+        recorded_time = call_args.kwargs["cpu_time"]
+
+        # Should be close to sleep duration (within tolerance)
+        assert recorded_time >= sleep_duration
+        assert recorded_time < sleep_duration + 0.05  # Allow some overhead
+
+    def test_section_name(self, mock_detector):
+        """Test that section name is passed correctly."""
+        with SectionContext(mock_detector, "my_custom_section"):
+            pass
+
+        call_args = mock_detector.record_section.call_args
+        assert call_args.kwargs["name"] == "my_custom_section"
+
+    def test_no_cuda_profiling_by_default(self, mock_detector):
+        """Test that CUDA profiling is off by default."""
+        with SectionContext(mock_detector, "test_section"):
+            pass
+
+        call_args = mock_detector.record_section.call_args
+        # gpu_time should be None when CUDA profiling is disabled
+        assert call_args.kwargs["gpu_time"] is None
+
+    def test_exception_handling(self, mock_detector):
+        """Test that exceptions are not suppressed."""
+        with pytest.raises(ValueError):
+            with SectionContext(mock_detector, "error_section"):
+                raise ValueError("Test error")
+
+        # record_section should still be called
+        mock_detector.record_section.assert_called_once()
+
+    def test_exception_does_not_affect_timing(self, mock_detector):
+        """Test that exceptions don't prevent timing from being recorded."""
+        try:
+            with SectionContext(mock_detector, "error_section"):
+                time.sleep(0.01)
+                raise ValueError("Test error")
+        except ValueError:
+            pass
+
+        # Should have recorded timing before exception propagated
+        call_args = mock_detector.record_section.call_args
+        assert call_args.kwargs["cpu_time"] >= 0.01
+
+    def test_nested_contexts(self, mock_detector):
+        """Test nested SectionContext usage."""
+        with SectionContext(mock_detector, "outer"):
+            time.sleep(0.01)
+            with SectionContext(mock_detector, "inner"):
+                time.sleep(0.01)
+
+        # Both contexts should have recorded
+        assert mock_detector.record_section.call_count == 2
+
+        # Check call order (inner finishes first)
+        calls = mock_detector.record_section.call_args_list
+        assert calls[0].kwargs["name"] == "inner"
+        assert calls[1].kwargs["name"] == "outer"
+
+    def test_context_returns_self(self, mock_detector):
+        """Test that context manager returns self."""
+        with SectionContext(mock_detector, "test") as ctx:
+            assert isinstance(ctx, SectionContext)
+            assert ctx.name == "test"
+
+
+class TestOptionalSectionContext:
+    """Test cases for OptionalSectionContext class."""
+
+    @pytest.fixture
+    def mock_detector(self):
+        """Create a mock detector for testing."""
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        return detector
+
+    def test_enabled_profiles(self, mock_detector):
+        """Test that enabled OptionalSectionContext profiles."""
+        with OptionalSectionContext(mock_detector, "test", enabled=True):
+            time.sleep(0.01)
+
+        mock_detector.record_section.assert_called_once()
+
+    def test_disabled_does_not_profile(self, mock_detector):
+        """Test that disabled OptionalSectionContext does not profile."""
+        with OptionalSectionContext(mock_detector, "test", enabled=False):
+            time.sleep(0.01)
+
+        mock_detector.record_section.assert_not_called()
+
+    def test_default_is_enabled(self, mock_detector):
+        """Test that OptionalSectionContext is enabled by default."""
+        with OptionalSectionContext(mock_detector, "test"):
+            pass
+
+        mock_detector.record_section.assert_called_once()
+
+    def test_exception_handling_enabled(self, mock_detector):
+        """Test exception handling when enabled."""
+        with pytest.raises(ValueError):
+            with OptionalSectionContext(mock_detector, "test", enabled=True):
+                raise ValueError("Test error")
+
+        mock_detector.record_section.assert_called_once()
+
+    def test_exception_handling_disabled(self, mock_detector):
+        """Test exception handling when disabled."""
+        with pytest.raises(ValueError):
+            with OptionalSectionContext(mock_detector, "test", enabled=False):
+                raise ValueError("Test error")
+
+        mock_detector.record_section.assert_not_called()
+
+
+class TestSectionProfiler:
+    """Test cases for SectionProfiler class."""
+
+    @pytest.fixture
+    def mock_detector(self):
+        """Create a mock detector for testing."""
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        return detector
+
+    @pytest.fixture
+    def profiler(self, mock_detector):
+        """Create a SectionProfiler for testing."""
+        return SectionProfiler(mock_detector)
+
+    def test_start_and_end_section(self, profiler, mock_detector):
+        """Test starting and ending a section."""
+        ctx = profiler.start_section("test_section")
+        time.sleep(0.01)
+        profiler.end_section("test_section")
+
+        mock_detector.record_section.assert_called_once()
+        call_args = mock_detector.record_section.call_args
+        assert call_args.kwargs["name"] == "test_section"
+
+    def test_multiple_sections(self, profiler, mock_detector):
+        """Test multiple sections."""
+        profiler.start_section("section1")
+        profiler.start_section("section2")
+
+        profiler.end_section("section2")
+        profiler.end_section("section1")
+
+        assert mock_detector.record_section.call_count == 2
+
+    def test_start_duplicate_section_raises(self, profiler):
+        """Test that starting a duplicate section raises error."""
+        profiler.start_section("test")
+
+        with pytest.raises(ValueError, match="already active"):
+            profiler.start_section("test")
+
+    def test_end_nonexistent_section_raises(self, profiler):
+        """Test that ending a non-existent section raises error."""
+        with pytest.raises(ValueError, match="not active"):
+            profiler.end_section("nonexistent")
+
+    def test_active_sections_tracking(self, profiler):
+        """Test that active sections are tracked correctly."""
+        assert len(profiler.active_sections) == 0
+
+        profiler.start_section("section1")
+        assert "section1" in profiler.active_sections
+        assert len(profiler.active_sections) == 1
+
+        profiler.start_section("section2")
+        assert "section2" in profiler.active_sections
+        assert len(profiler.active_sections) == 2
+
+        profiler.end_section("section1")
+        assert "section1" not in profiler.active_sections
+        assert len(profiler.active_sections) == 1
+
+        profiler.end_section("section2")
+        assert len(profiler.active_sections) == 0
+
+
+class TestCreateSectionDecorator:
+    """Test cases for create_section_decorator function."""
+
+    @pytest.fixture
+    def mock_detector(self):
+        """Create a mock detector for testing."""
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        return detector
+
+    def test_decorator_wraps_function(self, mock_detector):
+        """Test that decorator wraps function correctly."""
+
+        @create_section_decorator(mock_detector, "decorated_section")
+        def my_function():
+            return "result"
+
+        result = my_function()
+
+        assert result == "result"
+        mock_detector.record_section.assert_called_once()
+
+    def test_decorator_preserves_arguments(self, mock_detector):
+        """Test that decorator preserves function arguments."""
+
+        @create_section_decorator(mock_detector, "decorated_section")
+        def my_function(a, b, c=None):
+            return a + b + (c or 0)
+
+        result = my_function(1, 2, c=3)
+
+        assert result == 6
+        mock_detector.record_section.assert_called_once()
+
+    def test_decorator_records_timing(self, mock_detector):
+        """Test that decorator records timing correctly."""
+
+        @create_section_decorator(mock_detector, "timed_section")
+        def slow_function():
+            time.sleep(0.02)
+            return "done"
+
+        result = slow_function()
+
+        assert result == "done"
+        call_args = mock_detector.record_section.call_args
+        assert call_args.kwargs["name"] == "timed_section"
+        assert call_args.kwargs["cpu_time"] >= 0.02
+
+    def test_decorator_handles_exceptions(self, mock_detector):
+        """Test that decorator handles exceptions correctly."""
+
+        @create_section_decorator(mock_detector, "error_section")
+        def error_function():
+            raise ValueError("Test error")
+
+        with pytest.raises(ValueError):
+            error_function()
+
+        # Should still record timing
+        mock_detector.record_section.assert_called_once()
+
+    def test_multiple_decorated_functions(self, mock_detector):
+        """Test multiple decorated functions."""
+
+        @create_section_decorator(mock_detector, "section_a")
+        def function_a():
+            return "a"
+
+        @create_section_decorator(mock_detector, "section_b")
+        def function_b():
+            return "b"
+
+        function_a()
+        function_b()
+
+        assert mock_detector.record_section.call_count == 2
+
+
+class TestSectionContextWithCuda:
+    """Test cases for CUDA profiling (mocked)."""
+
+    @pytest.fixture
+    def mock_detector(self):
+        """Create a mock detector for testing."""
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        return detector
+
+    @patch('flagscale.runner.straggler.section.TORCH_AVAILABLE', True)
+    @patch('flagscale.runner.straggler.section.torch')
+    def test_cuda_profiling_enabled(self, mock_torch, mock_detector):
+        """Test CUDA profiling when enabled."""
+        # Setup mock
+        mock_torch.cuda.is_available.return_value = True
+        mock_event = MagicMock()
+        mock_event.elapsed_time.return_value = 10.0  # 10ms
+        mock_torch.cuda.Event.return_value = mock_event
+
+        with SectionContext(mock_detector, "cuda_section", profile_cuda=True):
+            time.sleep(0.01)
+
+        mock_detector.record_section.assert_called_once()
+        # Should have synchronized CUDA
+        assert mock_torch.cuda.synchronize.called
+
+    @patch('flagscale.runner.straggler.section.TORCH_AVAILABLE', False)
+    def test_cuda_profiling_without_torch(self, mock_detector):
+        """Test CUDA profiling gracefully handles missing torch."""
+        with SectionContext(mock_detector, "section", profile_cuda=True):
+            pass
+
+        mock_detector.record_section.assert_called_once()
+        call_args = mock_detector.record_section.call_args
+        # gpu_time should be None when torch not available
+        assert call_args.kwargs["gpu_time"] is None


### PR DESCRIPTION
### PR Category
<!-- One of [ Train | Inference | Compress | Serve | RL | Core | Hardware | CICD | Tools | Others ] -->
Train

### PR Types
<!-- One of [ User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change| Deprecations | Test Case | Docs | Others ] -->
New Features 

### PR Description
<!-- Describe what you’ve done -->
Add the StragglerDetector related modules to detect and report performance "stragglers" (lagging processes/nodes) in real-time during PyTorch distributed training. The module collects timing data from training sections (such as forward, backward) and communication operations via hooks, computes performance scores, identifies lagging nodes that are slower than the threshold relative to the fastest process, and generates JSON-serializable reports.

Usage:
``` 
 python run.py \
    --config-path ./examples/gpt2/conf \
    --config-name train_single \
    action=run \
    +train.system.enable_straggler_detection=true \
    +train.system.straggler_profiling_interval=5 \
    +train.system.straggler_report_interval=10 \
    +train.system.straggler_log_dir=./outputs_gpt2/logs/straggler
```
straggler detection in output.log
```
[default0]:
[default0]:=== Straggler Report at Step 10 ===
[default0]:
[default0]:✓ No stragglers detected.
[default0]:
[default0]:Section Timings (ms):
[default0]:
[default0]:  optimizer:
[default0]:    Min: 9.17ms, Max: 10.12ms, Avg: 9.55ms, Slowdown: 1.10x
[default0]:    Rank 0: 9.98ms
[default0]:    Rank 1: 10.12ms
[default0]:    Rank 2: 9.46ms
[default0]:    Rank 3: 9.40ms
[default0]:    Rank 4: 9.17ms
[default0]:    Rank 5: 9.58ms
[default0]:    Rank 6: 9.24ms
[default0]:    Rank 7: 9.46ms
[default0]:
[default0]:  forward_backward:
[default0]:    Min: 281.94ms, Max: 343.19ms, Avg: 314.23ms, Slowdown: 1.22x
[default0]:    Rank 0: 343.19ms
[default0]:    Rank 1: 341.51ms
[default0]:    Rank 2: 333.13ms
[default0]:    Rank 3: 333.12ms
[default0]:    Rank 4: 291.74ms
[default0]:    Rank 5: 302.92ms
[default0]:    Rank 6: 286.27ms
[default0]:    Rank 7: 281.94ms
[default0]:
[default0]:GPU Performance Scores (higher=faster):
[default0]:  Rank 0 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 2.9138
[default0]:  Rank 1 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 2.9282
[default0]:  Rank 2 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 3.0018
[default0]:  Rank 3 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 3.0019
[default0]:  Rank 4 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 3.4277
[default0]:  Rank 5 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 3.3012
[default0]:  Rank 6 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 3.4932
[default0]:  Rank 7 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 3.5468
```
straggler detection report in output.json per 10 iters
```
{
  "step": 10,
  "section_scores": {
    "optimizer": {
      "0": 0.004562368034385145,
      "1": 0.004560340172611177,
      "2": 0.004532582545652986,
      "3": 0.004545721807517111,
      "4": 0.004345903592184186,
      "5": 0.004506054217927158,
      "6": 0.004503906634636223,
      "7": 0.004488412779755891
    },
    "forward_backward": {
      "0": 0.39116522478871046,
      "1": 0.39149687779136,
      "2": 0.3835162356030196,
      "3": 0.383761673187837,
      "4": 0.32889997139573096,
      "5": 0.32967520081438123,
      "6": 0.32046777561772616,
      "7": 0.32712613919284195
    }
  },
  "comm_stats": {},
  "gpu_scores": {
    "0": 2.556464472372651,
    "1": 2.554298786855023,
    "2": 2.607451542247372,
    "3": 2.6057839275433254,
    "4": 3.0404380874719035,
    "5": 3.0332885140579173,
    "6": 3.120438546660186,
    "7": 3.0569247766852916
  },
  "straggler_ranks": [],
  "node_names": {
    "0": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128",
    "1": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128",
    "2": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128",
    "3": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128",
    "4": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128",
    "5": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128",
    "6": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128",
    "7": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128"
  },
  "timestamp": 1764885816.7089095
}
```