### PR TITLE
[Misc] remove third_party/lerobot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,3 @@
 [submodule "third_party/verl"]
 	path = third_party/verl
 	url = https://github.com/volcengine/verl.git
-[submodule "third_party/lerobot"]
-	path = third_party/lerobot
-	url = https://github.com/huggingface/lerobot.git


### PR DESCRIPTION
### PR Category
Others

### PR Types
Bug Fixes

### PR Description
remove third_party/lerobot, now `git submodule` can work properly