### PR TITLE
Support FlagScale-FlagCX co-tuning

### DIFF
--- a/flagscale/runner/auto_tuner/generate.py
+++ b/flagscale/runner/auto_tuner/generate.py
@@ -45,10 +45,13 @@ class Generator:
     def _set_flagcx_tuning_params(self, config):
         if config.experiment.auto_tuner.flagcx_tune:
             config.train.system.flagcx_tune = True
-            # set a large number so that training won't stop before flagcx tuning ends 
+            config.train.system.flagcx_tune_groups = config.experiment.auto_tuner.flagcx_tune_groups
+            # set a large number so that training won't stop before flagcx tuning ends
             config.experiment.envs["FLAGCX_USE_TUNER"] = 1
             config.experiment.envs["TUNING_WITH_FLAGSCALE"] = 1
-            config.experiment.envs["FLAGCX_TUNE_FILE"] = os.path.abspath(os.path.join(config.experiment.exp_dir, "flagcx_tune", "tune_objects.json"))
+            config.experiment.envs["FLAGCX_TUNE_FILE"] = os.path.abspath(
+                os.path.join(config.experiment.exp_dir, "flagcx_tune", "tune_objects.json")
+            )
 
     def gen(self, strategy):
         config = copy.deepcopy(self.config)


### PR DESCRIPTION
### PR Category
<!-- One of [ Train | Inference | Compress | Serve | RL | Core | Hardware | CICD | Tools | Others ] -->
Train
### PR Types
<!-- One of [ User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change| Deprecations | Test Case | Docs | Others ] -->
New Features
### PR Description
<!-- Describe what you’ve done -->
This PR introduces the capability to dynamically tune FlagCX communication config in FlagScale based on end-to-end training performance. FlagCX tuning is triggered by FlagScale after finding the best parallelization strategy, and the goal is to find the best communication config for the parallelization strategy used by FlagScale during training. 