### PR TITLE
[MUSA] Correct flagscale commit id in hardware/MUSA_S5000/vllm.

### DIFF
--- a/hardware/MUSA_S5000/vllm/diff.yaml
+++ b/hardware/MUSA_S5000/vllm/diff.yaml
@@ -2,7 +2,7 @@ backends_commit:
   vllm: a5dd03c1ebc5e4f56f3c9d3dc0436e9c582c978f
 backends_version:
   vllm: v0.9.2
-commit: 7b64f0f8dbe438a12645784b3a14f395434d1203
+commit: 249e41c4c22d2171ab9897d42ca67b185ac084d3
 contact: lingfeng.qiu@mthreads.com
 device_type: MUSA_S5000
 models:


### PR DESCRIPTION
### PR Category
<!-- One of [ Train | Inference | Compress | Serve | RL | Core | Hardware | CICD | Tools | Others ] -->

### PR Types
<!-- One of [ User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change| Deprecations | Test Case | Docs | Others ] -->

### PR Description
<!-- Describe what you’ve done -->
