### PR TITLE
[CICD] restore inference ci test & save functional test error log

### DIFF
--- a/tests/functional_tests/test_cases/inference/robobrain2/conf/inference/7b-tp2.yaml
+++ b/tests/functional_tests/test_cases/inference/robobrain2/conf/inference/7b-tp2.yaml
@@ -1,10 +1,10 @@
 llm:
-  model: /home/gitlab-runner/data/BAAI/RoboBrain2.0-7B
-  tokenizer: /home/gitlab-runner/data/BAAI/RoboBrain2.0-7B
+  model: /workspace/RoboBrain2.0-7B
+  tokenizer: /workspace/RoboBrain2.0-7B
   trust_remote_code: true
   tensor_parallel_size: 2
   pipeline_parallel_size: 1
-  gpu_memory_utilization: 0.9
+  gpu_memory_utilization: 0.7
   seed: 1234
   enforce_eager: true
 
@@ -14,8 +14,8 @@ generate:
     - "What is shown in this image?"
     - "What food is in the picture?"
   mm_data:
-    - "/home/gitlab-runner/data/images/img1.jpg"
-    - "/home/gitlab-runner/data/images/img2.jpg"
+    - "/root/img1.jpg"
+    - "/root/img2.jpg"
   sampling:
     top_p: 0.1
     top_k: 1


### PR DESCRIPTION
### PR Category
CICD

### PR Types
Test Case

### PR Description
- Restore inference/serve ci test and Comment out the problematic test cases
- Save functional test error permanently for efficient troubleshooting
- Unitest uses a random temporary directory every time, resulting in sccache misses. Now change the random directory to a fixed directory to fix this issue.
