### PR TITLE
Fix the order of imports in megatron/legacy/model/__init__.py

### DIFF
--- a/flagscale/train/megatron/legacy/model/__init__.py
+++ b/flagscale/train/megatron/legacy/model/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# isort: skip_file
 from .fused_layer_norm import MixedFusedLayerNorm as LayerNorm
 from .rms_norm import RMSNorm
 


### PR DESCRIPTION
### PR Category
Train

### PR Types
Bug Fixes

### PR Description

Fix the order of imports in megatron/legacy/model/__init__.py. Wrong order will cause a circular import.