### PR TITLE
Fix: Correct limit_mm_per_prompt parameter format for vLLM

### DIFF
--- a/examples/llava_onevision/conf/serve/7b.yaml
+++ b/examples/llava_onevision/conf/serve/7b.yaml
@@ -6,7 +6,7 @@
     pipeline_parallel_size: 1
     gpu_memory_utilization: 0.9
     max_model_len: 32768
-    limit_mm_per_prompt: image=8
+    limit_mm_per_prompt: '{"image": 8}'
     max_num_seqs: 16
     enforce_eager: true
     trust_remote_code: true

--- a/examples/minicpm_o_2.6/conf/serve/7b.yaml
+++ b/examples/minicpm_o_2.6/conf/serve/7b.yaml
@@ -5,7 +5,7 @@
     pipeline_parallel_size: 1
     gpu_memory_utilization: 0.9
     max_num_seqs: 256
-    limit_mm_per_prompt: image=18
+    limit_mm_per_prompt: '{"image": 18}'
     port: 9010
     trust_remote_code: true
     enable_chunked_prefill: true

--- a/examples/robobrain/conf/serve/7b.yaml
+++ b/examples/robobrain/conf/serve/7b.yaml
@@ -6,7 +6,7 @@
     pipeline_parallel_size: 1
     gpu_memory_utilization: 0.9
     max_model_len: 32768
-    limit_mm_per_prompt: image=8
+    limit_mm_per_prompt: '{"image": 8}'
     max_num_seqs: 16
     trust_remote_code: true
     enable_chunked_prefill: false

--- a/examples/robobrain2/conf/serve/32b.yaml
+++ b/examples/robobrain2/conf/serve/32b.yaml
@@ -7,7 +7,7 @@
     pipeline_parallel_size: 1
     max_num_seqs: 8 # Even at full 32,768 context usage, 8 concurrent operations won't trigger OOM
     gpu_memory_utilization: 0.9
-    limit_mm_per_prompt: image=18 # should be customized, 18 images/request is enough for most scenarios
+    limit_mm_per_prompt: '{"image": 18}' # should be customized, 18 images/request is enough for most scenarios
     port: 9010
     trust_remote_code: true
     enforce_eager: false # set true if use FlagGems

--- a/examples/robobrain2/conf/serve/3b.yaml
+++ b/examples/robobrain2/conf/serve/3b.yaml
@@ -7,7 +7,7 @@
     pipeline_parallel_size: 1
     max_num_seqs: 8 # Even at full 32,768 context usage, 8 concurrent operations won't trigger OOM
     gpu_memory_utilization: 0.9
-    limit_mm_per_prompt: image=18 # should be customized, 18 images/request is enough for most scenarios
+    limit_mm_per_prompt: '{"image": 18}' # should be customized, 18 images/request is enough for most scenarios
     port: 9010
     trust_remote_code: true
     enforce_eager: false # set true if use FlagGems

--- a/examples/robobrain2/conf/serve/7b.yaml
+++ b/examples/robobrain2/conf/serve/7b.yaml
@@ -7,7 +7,7 @@
     pipeline_parallel_size: 1
     max_num_seqs: 8 # Even at full 32,768 context usage, 8 concurrent operations won't trigger OOM
     gpu_memory_utilization: 0.9
-    limit_mm_per_prompt: image=18 # should be customized, 18 images/request is enough for most scenarios
+    limit_mm_per_prompt: '{"image": 18}' # should be customized, 18 images/request is enough for most scenarios
     port: 9010
     trust_remote_code: true
     enforce_eager: false # set true if use FlagGems


### PR DESCRIPTION
### PR Category
Serve

### PR Types
Bug Fixes

### PR Description
The --limit-mm-per-prompt argument in vLLM uses json.loads for parsing, which requires a valid JSON string format. The original configuration files used an invalid format (image=X), causing a JSON parse error during service startup.

This PR fixes the issue by updating the format to valid JSON string syntax in 6 serve configuration files:

Before: limit_mm_per_prompt: image=X
After: limit_mm_per_prompt: '{image: X}'
✅ Verified with vLLM v0.13.0 — the service now starts successfully without parsing errors.

