### PR TITLE
Fix outdated installation instructions for Emu3.5

### DIFF
--- a/examples/emu3.5/conf/README.md
+++ b/examples/emu3.5/conf/README.md
@@ -5,14 +5,16 @@ vLLM implementation of https://github.com/baaivision/Emu3.5
 ## Environment Setup
 
 ### Install FlagScale
-- Build from source code base on vLLM tag/0.11.0
+- Install FlagScale and vLLM-FL backend (based on vLLM)
 ```bash
 git clone https://github.com/flagos-ai/FlagScale.git
-cd FlgScale
-python tools/patch/unpatch.py --backend vllm
-cd FlagScale/third_party/vllm
-pip install -r requirements/cuda.txt --no-cache-dir
-MAX_JOBS=32 pip install --no-build-isolation -v .
+cd FlagScale
+pip install . --verbose
+
+# Install vLLM-FL backend
+git clone https://github.com/flagos-ai/vllm-FL
+cd vllm-FL
+pip install -e .
 ```
 
 ### Prepare Emu3.5

--- a/examples/pi0/README.md
+++ b/examples/pi0/README.md
@@ -7,7 +7,7 @@ This guide covers how to train, run inference, and serve PI0 models using FlagSc
 ### Clone Repository
 
 ```sh
-git clone https://github.com/FlagOpen/FlagScale.git
+git clone https://github.com/flagos-ai/FlagScale.git
 cd FlagScale/
 ```
 

--- a/examples/pi0_5/README.md
+++ b/examples/pi0_5/README.md
@@ -7,7 +7,7 @@ This guide covers how to train, run inference, and serve PI0.5 models using Flag
 ### Clone Repository
 
 ```sh
-git clone https://github.com/FlagOpen/FlagScale.git
+git clone https://github.com/flagos-ai/FlagScale.git
 cd FlagScale/
 ```
 

--- a/examples/qwen2_5_vl/README.md
+++ b/examples/qwen2_5_vl/README.md
@@ -5,7 +5,7 @@
 ### Clone Repository
 
 ```sh
-git clone https://github.com/FlagOpen/FlagScale.git
+git clone https://github.com/flagos-ai/FlagScale.git
 cd FlagScale/
 ```
 

--- a/examples/qwen3_vl/README.md
+++ b/examples/qwen3_vl/README.md
@@ -7,7 +7,7 @@
 Download the source code。
 
 ```bash
-git clone https://github.com/FlagOpen/FlagScale.git
+git clone https://github.com/flagos-ai/FlagScale.git
 cd FlagScale
 ```
 
@@ -24,7 +24,7 @@ pip install --no-build-isolation .
 pip install transformers==4.57.1
 ```
 
-You can also refer to the readme in `https://github.com/FlagOpen/FlagScale.git`
+You can also refer to the readme in `https://github.com/flagos-ai/FlagScale.git`
 
 ### 2. Prepare checkpoint
 

--- a/examples/robobrain2/README.md
+++ b/examples/robobrain2/README.md
@@ -6,7 +6,7 @@
 ### Clone Repository
 
 ```sh
-git clone https://github.com/FlagOpen/FlagScale.git
+git clone https://github.com/flagos-ai/FlagScale.git
 cd FlagScale/
 ```
 

--- a/examples/robobrain2_5/README.md
+++ b/examples/robobrain2_5/README.md
@@ -6,7 +6,7 @@
 ### Clone Repository
 
 ```sh
-git clone https://github.com/FlagOpen/FlagScale.git
+git clone https://github.com/flagos-ai/FlagScale.git
 cd FlagScale/
 ```
 
@@ -87,7 +87,7 @@ tail -f outputs/robobrain2.5_4b/serve_logs/host_0_localhost.output
 
 ```sh
 cd FlagScale/
-vim examples/robobrain2_5/conf/serve/3b.yaml
+vim examples/robobrain2_5/conf/serve/32b.yaml
 ```
 
 Change 1 fields:

--- a/examples/robobrain_x0/README.md
+++ b/examples/robobrain_x0/README.md
@@ -3,7 +3,7 @@
 ### Clone Repository
 
 ```sh
-git clone https://github.com/FlagOpen/FlagScale.git
+git clone https://github.com/flagos-ai/FlagScale.git
 cd FlagScale/
 ```
 

--- a/examples/robobrain_x0_5/README.md
+++ b/examples/robobrain_x0_5/README.md
@@ -3,7 +3,7 @@
 ### Clone Repository
 
 ```sh
-git clone https://github.com/FlagOpen/FlagScale.git
+git clone https://github.com/flagos-ai/FlagScale.git
 cd FlagScale/
 ```
 


### PR DESCRIPTION
### PR Category
Serve

### PR Types
Bug Fixes | Docs | Deprecations

### PR Description
This PR updates the installation method to use the vLLM-FL backend instead of the now-removed patch mechanism, aligning with the v1.0.0-alpha.0 refactor that migrated hardware-specific support into dedicated plugin repositories. Specifically:

