### PR TITLE
Set logger stacklevel

### DIFF
--- a/flagscale/logger.py
+++ b/flagscale/logger.py
@@ -22,19 +22,19 @@ class Logger:
         self.logger.addHandler(stream_handler)
 
     def info(self, message):
-        self.logger.info(message)
+        self.logger.info(message, stacklevel=2)
 
     def warning(self, message):
-        self.logger.warning(message)
+        self.logger.warning(message, stacklevel=2)
 
     def error(self, message):
-        self.logger.error(message)
+        self.logger.error(message, stacklevel=2)
 
     def critical(self, message):
-        self.logger.critical(message)
+        self.logger.critical(message, stacklevel=2)
 
     def debug(self, message):
-        self.logger.debug(message)
+        self.logger.debug(message, stacklevel=2)
 
 
 GLOBAL_LOGGER = None


### PR DESCRIPTION
### PR Category
<!-- One of [ Train | Inference | Compress | Serve | RL | Core | Hardware | CICD | Tools | Others ] -->
Others
### PR Types
<!-- One of [ User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change| Deprecations | Test Case | Docs | Others ] -->
Improvements
### PR Description
<!-- Describe what you’ve done -->
Fix the logger stacklevel to point to the real location of the function
e.g.
before: 
[2026-02-09 19:51:00,204 FlagScale logger.py:25 INFO]
after:
[2026-02-10 11:58:06,728 FlagScale inference_qwen_gr00t.py:50 INFO]