### PR TITLE
Fix incorrect log path in robobrain2_5 README

### DIFF
--- a/examples/robobrain2_5/README.md
+++ b/examples/robobrain2_5/README.md
@@ -78,7 +78,7 @@ python run.py --config-path ./examples/robobrain2_5/conf --config-name inference
 
 ```sh
 cd FlagScale/
-tail -f outputs/robobrain2.5_4b/serve_logs/host_0_localhost.output
+tail -f outputs/robobrain2.5_8b/inference_logs/host_0_localhost.output
 ```
 
 ## Serving


### PR DESCRIPTION
### PR Category
Inference

### PR Types
Bug Fixes

### PR Description
This PR resolves issue #1098.
Changes include:
Updated model identifier from robobrain2.5_4b to robobrain2.5_8b to ensure consistency with the actual 8B model being utilized.
Renamed log directory from serve_logs to inference_logs to accurately reflect the inference process context.
