### PR TITLE
fix: remove dead reference to non-existent module `.file_utils`

### DIFF
--- a/flagscale/train/megatron/training/tokenizer/gpt2_tokenization.py
+++ b/flagscale/train/megatron/training/tokenizer/gpt2_tokenization.py
@@ -113,29 +113,10 @@ class GPT2Tokenizer(object):
                 special_tokens_file = None
             else:
                 logger.info("loading special tokens file {}".format(special_tokens_file))
-        # redirect to the cache, if necessary
-        try:
-            from .file_utils import cached_path
-            resolved_vocab_file = cached_path(vocab_file, cache_dir=cache_dir)
-            resolved_merges_file = cached_path(merges_file, cache_dir=cache_dir)
-        except EnvironmentError:
-            logger.error(
-                "Model name '{}' was not found in model name list ({}). "
-                "We assumed '{}' was a path or url but couldn't find files {} and {} "
-                "at this path or url.".format(
-                    pretrained_model_name_or_path,
-                    ', '.join(PRETRAINED_VOCAB_ARCHIVE_MAP.keys()),
-                    pretrained_model_name_or_path,
-                    vocab_file, merges_file))
-            return None
-        if resolved_vocab_file == vocab_file and resolved_merges_file == merges_file:
-            logger.info("loading vocabulary file {}".format(vocab_file))
-            logger.info("loading merges file {}".format(merges_file))
-        else:
-            logger.info("loading vocabulary file {} from cache at {}".format(
-                vocab_file, resolved_vocab_file))
-            logger.info("loading merges file {} from cache at {}".format(
-                merges_file, resolved_merges_file))
+        resolved_vocab_file = vocab_file
+        resolved_merges_file = merges_file
+        logger.info("loading vocabulary file {}".format(vocab_file))
+        logger.info("loading merges file {}".format(merges_file))
         if pretrained_model_name_or_path in PRETRAINED_VOCAB_POSITIONAL_EMBEDDINGS_SIZE_MAP:
             # if we're using a pretrained model, ensure the tokenizer wont index sequences longer
             # than the number of positional embeddings


### PR DESCRIPTION
## Summary
Removed the dead reference to the non-existent `.file_utils` module in `gpt2_tokenization.py` as requested.

## Problem
Closes #1077

## Solution
The `from_pretrained` method in `GPT2Tokenizer` previously attempted to import `cached_path` from `.file_utils` (a remnant of old huggingface/transformers code). Because `.file_utils` does not exist in the `flagscale.train.megatron.training.tokenizer` module, it could cause `ImportError` / `EnvironmentError`. I removed the `try-except` block entirely to keep the tokenizer loading strictly local vocabulary files cleanly.

## Testing
- Verified `pytest` does not break by missing imports.

---
*This PR was created with AI assistance.*