### PR TITLE
add straggler detection integration for the training

### DIFF
--- a/flagscale/runner/backend/backend_megatron.py
+++ b/flagscale/runner/backend/backend_megatron.py
@@ -78,6 +78,9 @@ class MegatronBackend(BackendBase):
             f.write(f"mkdir -p {system_config.logging.details_dir}\n")
             f.write(f"mkdir -p {system_config.logging.tensorboard_dir}\n")
             f.write(f"mkdir -p {system_config.logging.wandb_save_dir}\n")
+            f.write(f"mkdir -p {system_config.logging.straggler_dir}\n")
+            if system_config.get("straggler_log_dir", None):
+                f.write(f"mkdir -p {system_config.straggler_log_dir}\n")
             f.write("\n")
             f.write(f"cd {pkg_dir}\n")
             f.write("\n")

--- a/flagscale/runner/runner_train.py
+++ b/flagscale/runner/runner_train.py
@@ -47,7 +47,7 @@ def _get_args_megatron(config: DictConfig):
     new_config_dict.update(config_dict["model"])
     new_config_dict.update(config_dict["data"])
 
-    ignore_keys = ["log_dir", "details_dir", "scripts_dir", "pids_dir"]
+    ignore_keys = ["log_dir", "details_dir", "scripts_dir", "pids_dir", "straggler_dir"]
     # Flatten the dictionary to a list of arguments
     args = flatten_dict_to_args(new_config_dict, ignore_keys)
 
@@ -116,6 +116,17 @@ def _update_config_train(config: DictConfig):
         resolve_path(system.logging.wandb_save_dir, "logging.wandb_save_dir")
         if system.logging.get("wandb_save_dir", None)
         else os.path.join(exp_dir, "wandb")
+    )
+
+    system.logging.straggler_dir = (
+        resolve_path(system.logging.straggler_dir, "logging.straggler_dir")
+        if system.logging.get("straggler_dir", None)
+        else os.path.join(log_dir, "straggler")
+    )
+    system.straggler_log_dir = (
+        resolve_path(system.straggler_log_dir, "system.straggler_log_dir")
+        if system.get("straggler_log_dir", None)
+        else system.logging.straggler_dir
     )
 
     # Tokenizer file paths — resolve before passing to the training subprocess,
@@ -248,6 +259,9 @@ def _generate_run_script_train(
         f.write(f"mkdir -p {system_config.logging.details_dir}\n")
         f.write(f"mkdir -p {system_config.logging.tensorboard_dir}\n")
         f.write(f"mkdir -p {system_config.logging.wandb_save_dir}\n")
+        f.write(f"mkdir -p {system_config.logging.straggler_dir}\n")
+        if system_config.get("straggler_log_dir", None):
+            f.write(f"mkdir -p {system_config.straggler_log_dir}\n")
         f.write("\n")
         f.write(f"cd {pkg_dir}\n")
         f.write("\n")

--- a/flagscale/runner/straggler/README_STRAGGLER.md
+++ b/flagscale/runner/straggler/README_STRAGGLER.md
@@ -1,0 +1,105 @@
+# Straggler on Metax C550
+
+## Scope
+
+This note documents the current `straggler` integration for the Metax C550 training path on `main-legacy`.
+
+Important:
+
+- The active branch in use is `main-legacy`.
+- The current runnable path is still the legacy training stack.
+- The new launcher path `flagscale/runner/launcher/launcher_ssh.py` is not used here.
+
+## Current Code Path
+
+- FlagScale detector logic:
+  - `flagscale/runner/straggler/`
+- Train-side integration:
+  - `flagscale/train/train.py`
+
+This is a FlagScale-side detector layered on top of the existing Megatron training loop. It does not replace Megatron's native `log_straggler`.
+
+## Metax-Specific Notes
+
+- The implementation avoids new CUDA-only assumptions.
+- GPU event profiling is not required by default.
+- The practical validation path on Metax should use the mini Aquila config that already passed smoke training.
+
+## Known Pitfalls
+
+- Do not validate this first on the original full 7B config. The practical path we already stabilized on Metax is the mini Aquila config.
+- Do not reuse old checkpoints while testing. Use a fresh `exp_dir` and force a missing `checkpoint.load`.
+- If the straggler keys are not present in YAML, pass them with `++`.
+
+## Smoke Test
+
+Run from the generated Metax build tree:
+
+```bash
+cd /workspace/muxi-flagscale-legacy/build/Metax_C550/muxi-flagscale-legacy
+
+TS=$(date +%Y%m%d_%H%M%S)
+
+python run.py \
+  --config-path ./examples/aquila/conf \
+  --config-name train \
+  action=test \
+  experiment.exp_dir=/workspace/exp/aquila_straggler_smoke_${TS} \
+  train.system.checkpoint.load=/workspace/exp/__no_ckpt__/does_not_exist \
+  train.system.checkpoint.save=/workspace/exp/aquila_straggler_smoke_${TS}/checkpoints \
+  train.system.use_flash_attn=false \
+  train.model.attention_backend=unfused \
+  train.model.num_layers=8 \
+  train.model.hidden_size=1024 \
+  train.model.num_attention_heads=16 \
+  train.model.seq_length=512 \
+  train.model.max_position_embeddings=512 \
+  train.model.multiple_of=128 \
+  train.model.micro_batch_size=1 \
+  train.model.global_batch_size=8 \
+  train.model.train_samples=16 \
+  ++train.system.enable_straggler_detection=true \
+  ++train.system.straggler_report_interval=2 \
+  ++train.system.straggler_threshold=1.5 \
+  ++train.system.straggler_warmup_steps=0
+```
+
+## Expected Result
+
+- Training starts from random initialization.
+- `iteration 1/2` and `iteration 2/2` both complete.
+- A straggler report is printed near the end of the short run.
+- Report files are written under:
+
+```bash
+/workspace/exp/aquila_straggler_smoke_${TS}/logs/straggler
+```
+
+## Full Run Example
+
+```bash
+TS=$(date +%Y%m%d_%H%M%S)
+
+python run.py \
+  --config-path ./examples/aquila/conf \
+  --config-name train \
+  action=run \
+  experiment.exp_dir=/workspace/exp/aquila_straggler_run_${TS} \
+  train.system.checkpoint.load=/workspace/exp/__no_ckpt__/does_not_exist \
+  train.system.checkpoint.save=/workspace/exp/aquila_straggler_run_${TS}/checkpoints \
+  train.system.use_flash_attn=false \
+  train.model.attention_backend=unfused \
+  train.model.num_layers=8 \
+  train.model.hidden_size=1024 \
+  train.model.num_attention_heads=16 \
+  train.model.seq_length=512 \
+  train.model.max_position_embeddings=512 \
+  train.model.multiple_of=128 \
+  train.model.micro_batch_size=1 \
+  train.model.global_batch_size=8 \
+  train.model.train_samples=1600 \
+  ++train.system.enable_straggler_detection=true \
+  ++train.system.straggler_report_interval=20 \
+  ++train.system.straggler_threshold=1.5 \
+  ++train.system.straggler_warmup_steps=10
+```

--- a/flagscale/runner/straggler/__init__.py
+++ b/flagscale/runner/straggler/__init__.py
@@ -1,0 +1,29 @@
+"""FlagScale straggler detection utilities."""
+
+from .comm import CommProfiler, CommStatsCollector, GlooCommHook, NCCLCommHook
+from .config import StragglerConfig
+from .detector import StragglerDetector
+from .healthcheck import ElasticTrainingHealthChecker, NetworkHealthChecker
+from .report import StragglerReport
+from .section import (
+    OptionalSectionContext,
+    SectionContext,
+    SectionProfiler,
+    create_section_decorator,
+)
+
+__all__ = [
+    "CommProfiler",
+    "CommStatsCollector",
+    "ElasticTrainingHealthChecker",
+    "GlooCommHook",
+    "NCCLCommHook",
+    "NetworkHealthChecker",
+    "OptionalSectionContext",
+    "SectionContext",
+    "SectionProfiler",
+    "StragglerConfig",
+    "StragglerDetector",
+    "StragglerReport",
+    "create_section_decorator",
+]

--- a/flagscale/runner/straggler/comm.py
+++ b/flagscale/runner/straggler/comm.py
@@ -1,8 +1,8 @@
 """Communication monitoring helpers for straggler analysis."""
 
-from collections import defaultdict
 import time
-from typing import Any, Dict, Optional
+from collections import defaultdict
+from typing import Any
 
 
 class CommStatsCollector:
@@ -10,7 +10,7 @@ class CommStatsCollector:
 
     def __init__(self, enabled: bool = True):
         self.enabled = enabled
-        self.operation_stats: Dict[str, Dict[str, Any]] = defaultdict(
+        self.operation_stats: dict[str, dict[str, Any]] = defaultdict(
             lambda: {
                 "count": 0,
                 "total_time": 0.0,
@@ -34,8 +34,8 @@ class CommStatsCollector:
         op_name: str,
         start_time: float,
         end_time: float,
-        data_size: Optional[int] = None,
-        target_ranks: Optional[list] = None,
+        data_size: int | None = None,
+        target_ranks: list | None = None,
     ):
         if not self.enabled:
             return
@@ -55,10 +55,10 @@ class CommStatsCollector:
         if target_ranks is not None:
             stats["target_ranks"] = target_ranks
 
-    def get_operation_stats(self, op_type: str, op_name: str) -> Dict[str, Any]:
+    def get_operation_stats(self, op_type: str, op_name: str) -> dict[str, Any]:
         return self.operation_stats[f"{op_type}_{op_name}"].copy()
 
-    def get_all_stats(self) -> Dict[str, Dict[str, Any]]:
+    def get_all_stats(self) -> dict[str, dict[str, Any]]:
         return dict(self.operation_stats)
 
     def get_straggler_operations(self, threshold: float = 2.0) -> list:
@@ -182,7 +182,7 @@ class CommProfiler:
         op_name: str,
         start_time: float,
         end_time: float,
-        data_size: Optional[int] = None,
+        data_size: int | None = None,
     ):
         self.collector.record_operation(
             op_type,

--- a/flagscale/runner/straggler/comm.py
+++ b/flagscale/runner/straggler/comm.py
@@ -1,0 +1,193 @@
+"""Communication monitoring helpers for straggler analysis."""
+
+from collections import defaultdict
+import time
+from typing import Any, Dict, Optional
+
+
+class CommStatsCollector:
+    """Collect basic communication timings."""
+
+    def __init__(self, enabled: bool = True):
+        self.enabled = enabled
+        self.operation_stats: Dict[str, Dict[str, Any]] = defaultdict(
+            lambda: {
+                "count": 0,
+                "total_time": 0.0,
+                "min_time": float("inf"),
+                "max_time": 0.0,
+                "rank_times": defaultdict(list),
+            }
+        )
+        self.backend = "unknown"
+        self.world_size = 1
+        self.rank = 0
+
+    def set_backend_info(self, backend: str, world_size: int, rank: int):
+        self.backend = backend
+        self.world_size = world_size
+        self.rank = rank
+
+    def record_operation(
+        self,
+        op_type: str,
+        op_name: str,
+        start_time: float,
+        end_time: float,
+        data_size: Optional[int] = None,
+        target_ranks: Optional[list] = None,
+    ):
+        if not self.enabled:
+            return
+
+        duration = end_time - start_time
+        key = f"{op_type}_{op_name}"
+        stats = self.operation_stats[key]
+        stats["count"] += 1
+        stats["total_time"] += duration
+        stats["min_time"] = min(stats["min_time"], duration)
+        stats["max_time"] = max(stats["max_time"], duration)
+        stats["rank_times"][self.rank].append(duration)
+
+        if data_size is not None:
+            stats["total_data_size"] = stats.get("total_data_size", 0) + data_size
+
+        if target_ranks is not None:
+            stats["target_ranks"] = target_ranks
+
+    def get_operation_stats(self, op_type: str, op_name: str) -> Dict[str, Any]:
+        return self.operation_stats[f"{op_type}_{op_name}"].copy()
+
+    def get_all_stats(self) -> Dict[str, Dict[str, Any]]:
+        return dict(self.operation_stats)
+
+    def get_straggler_operations(self, threshold: float = 2.0) -> list:
+        stragglers = []
+        for op_key, stats in self.operation_stats.items():
+            if stats["count"] == 0:
+                continue
+            avg_time = stats["total_time"] / stats["count"]
+            max_time = stats["max_time"]
+            if avg_time > 0 and max_time / avg_time >= threshold:
+                stragglers.append(
+                    {
+                        "operation": op_key,
+                        "avg_time": avg_time,
+                        "max_time": max_time,
+                        "slowdown_ratio": max_time / avg_time,
+                        "count": stats["count"],
+                    }
+                )
+        return stragglers
+
+
+class NCCLCommHook:
+    """Wrap NCCL collectives with timing."""
+
+    def __init__(self, collector: CommStatsCollector):
+        self.collector = collector
+
+    def wrap_all_reduce(self, op_func):
+        def wrapped(*args, **kwargs):
+            start_time = time.perf_counter()
+            result = op_func(*args, **kwargs)
+            end_time = time.perf_counter()
+            self.collector.record_operation(
+                "all_reduce",
+                "default",
+                start_time,
+                end_time,
+            )
+            return result
+
+        return wrapped
+
+    def wrap_broadcast(self, op_func):
+        def wrapped(*args, **kwargs):
+            start_time = time.perf_counter()
+            result = op_func(*args, **kwargs)
+            end_time = time.perf_counter()
+            self.collector.record_operation(
+                "broadcast",
+                "default",
+                start_time,
+                end_time,
+            )
+            return result
+
+        return wrapped
+
+
+class GlooCommHook:
+    """Wrap Gloo collectives with timing."""
+
+    def __init__(self, collector: CommStatsCollector):
+        self.collector = collector
+
+    def wrap_all_reduce(self, op_func):
+        def wrapped(*args, **kwargs):
+            start_time = time.perf_counter()
+            result = op_func(*args, **kwargs)
+            end_time = time.perf_counter()
+            self.collector.record_operation(
+                "all_reduce",
+                "default",
+                start_time,
+                end_time,
+            )
+            return result
+
+        return wrapped
+
+
+class CommProfiler:
+    """Backend-aware communication profiler."""
+
+    def __init__(self, backend: str = "auto", enabled: bool = True):
+        self.collector = CommStatsCollector(enabled=enabled)
+        self.hooks = {}
+
+        if backend == "auto":
+            backend = self._detect_backend()
+
+        if backend == "nccl":
+            self.hooks["nccl"] = NCCLCommHook(self.collector)
+        elif backend == "gloo":
+            self.hooks["gloo"] = GlooCommHook(self.collector)
+
+        self.collector.set_backend_info(backend, 1, 0)
+
+    def _detect_backend(self) -> str:
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                return "nccl"
+        except ImportError:
+            pass
+        return "gloo"
+
+    def wrap_operation(self, op_type: str, op_func):
+        backend = self.collector.backend
+        if backend in self.hooks:
+            if op_type == "all_reduce":
+                return self.hooks[backend].wrap_all_reduce(op_func)
+            if op_type == "broadcast" and hasattr(self.hooks[backend], "wrap_broadcast"):
+                return self.hooks[backend].wrap_broadcast(op_func)
+        return op_func
+
+    def record_custom_operation(
+        self,
+        op_type: str,
+        op_name: str,
+        start_time: float,
+        end_time: float,
+        data_size: Optional[int] = None,
+    ):
+        self.collector.record_operation(
+            op_type,
+            op_name,
+            start_time,
+            end_time,
+            data_size=data_size,
+        )

--- a/flagscale/runner/straggler/config.py
+++ b/flagscale/runner/straggler/config.py
@@ -1,7 +1,7 @@
 """Configuration types for FlagScale straggler detection."""
 
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional
+from typing import Literal
 
 
 @dataclass
@@ -13,8 +13,8 @@ class StragglerConfig:
     gather_on_rank0: bool = True
     profiling_interval: int = 10
     report_interval_steps: int = 100
-    node_name: Optional[str] = None
-    monitor_sections: List[str] = field(
+    node_name: str | None = None
+    monitor_sections: list[str] = field(
         default_factory=lambda: [
             "dataloader",
             "forward",

--- a/flagscale/runner/straggler/config.py
+++ b/flagscale/runner/straggler/config.py
@@ -1,0 +1,32 @@
+"""Configuration types for FlagScale straggler detection."""
+
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+
+@dataclass
+class StragglerConfig:
+    """Runtime configuration for straggler detection."""
+
+    enabled: bool = True
+    scores_to_compute: Literal["relative", "individual", "all"] = "all"
+    gather_on_rank0: bool = True
+    profiling_interval: int = 10
+    report_interval_steps: int = 100
+    node_name: Optional[str] = None
+    monitor_sections: List[str] = field(
+        default_factory=lambda: [
+            "dataloader",
+            "forward",
+            "backward",
+            "optimizer",
+            "forward_backward",
+        ]
+    )
+    enable_comm_logging: bool = True
+    enable_gpu_profile: bool = True
+    straggler_threshold: float = 1.5
+    max_stragglers_to_report: int = 5
+    comm_backend: Literal["nccl", "gloo", "mpi", "all"] = "all"
+    sample_size: int = 100
+    warmup_steps: int = 10

--- a/flagscale/runner/straggler/detector.py
+++ b/flagscale/runner/straggler/detector.py
@@ -1,9 +1,8 @@
 """Main detector implementation for FlagScale straggler analysis."""
 
-from collections import defaultdict
 import json
 import time
-from typing import Dict, List, Optional, Tuple
+from collections import defaultdict
 
 try:
     import torch
@@ -27,13 +26,13 @@ class StragglerDetector:
         config: StragglerConfig,
         rank: int = 0,
         world_size: int = 1,
-        node_name: Optional[str] = None,
+        node_name: str | None = None,
     ):
         self.config = config
         self.rank = rank
         self.world_size = world_size
         self.node_name = node_name or f"rank-{rank}"
-        self.section_timings: Dict[str, List[Tuple[int, float, Optional[float]]]] = defaultdict(list)
+        self.section_timings: dict[str, list[tuple[int, float, float | None]]] = defaultdict(list)
         self.current_step = 0
         self.enabled = config.enabled
         self.straggler_threshold = config.straggler_threshold
@@ -42,8 +41,8 @@ class StragglerDetector:
         self,
         name: str,
         cpu_time: float,
-        gpu_time: Optional[float] = None,
-        step: Optional[int] = None,
+        gpu_time: float | None = None,
+        step: int | None = None,
     ):
         if not self.enabled:
             return
@@ -56,7 +55,7 @@ class StragglerDetector:
     def increment_step(self):
         self.current_step += 1
 
-    def should_profile(self, step: Optional[int] = None) -> bool:
+    def should_profile(self, step: int | None = None) -> bool:
         if not self.enabled:
             return False
         if step is None:
@@ -65,7 +64,7 @@ class StragglerDetector:
             return False
         return (step - self.config.warmup_steps) % self.config.profiling_interval == 0
 
-    def should_report(self, step: Optional[int] = None) -> bool:
+    def should_report(self, step: int | None = None) -> bool:
         if not self.enabled:
             return False
         if step is None:
@@ -75,8 +74,8 @@ class StragglerDetector:
     def compute_section_scores(
         self,
         section_name: str,
-        sample_size: Optional[int] = None,
-    ) -> Dict[int, float]:
+        sample_size: int | None = None,
+    ) -> dict[int, float]:
         if sample_size is None:
             sample_size = self.config.sample_size
         avg_time = self.get_recent_section_time(section_name, num_samples=sample_size)
@@ -86,8 +85,8 @@ class StragglerDetector:
 
     def compute_all_section_scores(
         self,
-        sample_size: Optional[int] = None,
-    ) -> Dict[str, Dict[int, float]]:
+        sample_size: int | None = None,
+    ) -> dict[str, dict[int, float]]:
         all_scores = {}
         for section_name in self.config.monitor_sections:
             scores = self.compute_section_scores(section_name, sample_size)
@@ -95,7 +94,7 @@ class StragglerDetector:
                 all_scores[section_name] = scores
         return all_scores
 
-    def compute_gpu_scores(self, sample_size: Optional[int] = None) -> Dict[int, float]:
+    def compute_gpu_scores(self, sample_size: int | None = None) -> dict[int, float]:
         if not self.config.enable_gpu_profile:
             return {}
 
@@ -114,9 +113,9 @@ class StragglerDetector:
 
     def identify_stragglers(
         self,
-        section_scores: Optional[Dict[str, Dict[int, float]]] = None,
-        threshold: Optional[float] = None,
-    ) -> List[int]:
+        section_scores: dict[str, dict[int, float]] | None = None,
+        threshold: float | None = None,
+    ) -> list[int]:
         if threshold is None:
             threshold = self.straggler_threshold
         if section_scores is None:
@@ -133,11 +132,13 @@ class StragglerDetector:
         except Exception:
             backend = ""
 
-        if ("cuda" in backend or "nccl" in backend or "flagcx" in backend) and torch.cuda.is_available():
+        if (
+            "cuda" in backend or "nccl" in backend or "flagcx" in backend
+        ) and torch.cuda.is_available():
             return torch.device("cuda", torch.cuda.current_device())
         return torch.device("cpu")
 
-    def _gather_section_times_across_ranks(self) -> Dict[str, Dict[int, float]]:
+    def _gather_section_times_across_ranks(self) -> dict[str, dict[int, float]]:
         if not TORCH_DISTRIBUTED_AVAILABLE or not dist.is_initialized():
             result = {}
             for section_name in self.config.monitor_sections:
@@ -167,7 +168,7 @@ class StragglerDetector:
 
         return result
 
-    def _gather_node_names_across_ranks(self) -> Dict[int, str]:
+    def _gather_node_names_across_ranks(self) -> dict[int, str]:
         if not TORCH_DISTRIBUTED_AVAILABLE or not dist.is_initialized():
             return {self.rank: self.node_name}
 
@@ -177,8 +178,8 @@ class StragglerDetector:
 
     def generate_report(
         self,
-        step: Optional[int] = None,
-        gather_on_rank0: Optional[bool] = None,
+        step: int | None = None,
+        gather_on_rank0: bool | None = None,
     ) -> StragglerReport:
         if step is None:
             step = self.current_step
@@ -213,9 +214,9 @@ class StragglerDetector:
 
     def _identify_stragglers_from_times(
         self,
-        section_times: Dict[str, Dict[int, float]],
-        threshold: Optional[float] = None,
-    ) -> List[int]:
+        section_times: dict[str, dict[int, float]],
+        threshold: float | None = None,
+    ) -> list[int]:
         if threshold is None:
             threshold = self.straggler_threshold
         if not section_times:
@@ -254,7 +255,7 @@ class StragglerDetector:
         self,
         section_name: str,
         num_samples: int = 1,
-    ) -> Optional[float]:
+    ) -> float | None:
         timings = self.section_timings.get(section_name, [])
         if not timings:
             return None
@@ -270,7 +271,7 @@ class StragglerDetector:
             count += 1
         return total_time / count if count > 0 else None
 
-    def get_section_statistics(self) -> Dict[str, Dict[str, float]]:
+    def get_section_statistics(self) -> dict[str, dict[str, float]]:
         stats = {}
         for section_name, timings in self.section_timings.items():
             if not timings:

--- a/flagscale/runner/straggler/detector.py
+++ b/flagscale/runner/straggler/detector.py
@@ -1,0 +1,307 @@
+"""Main detector implementation for FlagScale straggler analysis."""
+
+from collections import defaultdict
+import json
+import time
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import torch
+    import torch.distributed as dist
+
+    TORCH_DISTRIBUTED_AVAILABLE = True
+except ImportError:
+    torch = None
+    dist = None
+    TORCH_DISTRIBUTED_AVAILABLE = False
+
+from .config import StragglerConfig
+from .report import StragglerReport
+
+
+class StragglerDetector:
+    """Collect section timings and build straggler reports."""
+
+    def __init__(
+        self,
+        config: StragglerConfig,
+        rank: int = 0,
+        world_size: int = 1,
+        node_name: Optional[str] = None,
+    ):
+        self.config = config
+        self.rank = rank
+        self.world_size = world_size
+        self.node_name = node_name or f"rank-{rank}"
+        self.section_timings: Dict[str, List[Tuple[int, float, Optional[float]]]] = defaultdict(list)
+        self.current_step = 0
+        self.enabled = config.enabled
+        self.straggler_threshold = config.straggler_threshold
+
+    def record_section(
+        self,
+        name: str,
+        cpu_time: float,
+        gpu_time: Optional[float] = None,
+        step: Optional[int] = None,
+    ):
+        if not self.enabled:
+            return
+        if step is None:
+            step = self.current_step
+        if name not in self.config.monitor_sections:
+            return
+        self.section_timings[name].append((step, cpu_time, gpu_time))
+
+    def increment_step(self):
+        self.current_step += 1
+
+    def should_profile(self, step: Optional[int] = None) -> bool:
+        if not self.enabled:
+            return False
+        if step is None:
+            step = self.current_step
+        if step < self.config.warmup_steps:
+            return False
+        return (step - self.config.warmup_steps) % self.config.profiling_interval == 0
+
+    def should_report(self, step: Optional[int] = None) -> bool:
+        if not self.enabled:
+            return False
+        if step is None:
+            step = self.current_step
+        return step > 0 and step % self.config.report_interval_steps == 0
+
+    def compute_section_scores(
+        self,
+        section_name: str,
+        sample_size: Optional[int] = None,
+    ) -> Dict[int, float]:
+        if sample_size is None:
+            sample_size = self.config.sample_size
+        avg_time = self.get_recent_section_time(section_name, num_samples=sample_size)
+        if avg_time is None:
+            return {}
+        return {self.rank: avg_time}
+
+    def compute_all_section_scores(
+        self,
+        sample_size: Optional[int] = None,
+    ) -> Dict[str, Dict[int, float]]:
+        all_scores = {}
+        for section_name in self.config.monitor_sections:
+            scores = self.compute_section_scores(section_name, sample_size)
+            if scores:
+                all_scores[section_name] = scores
+        return all_scores
+
+    def compute_gpu_scores(self, sample_size: Optional[int] = None) -> Dict[int, float]:
+        if not self.config.enable_gpu_profile:
+            return {}
+
+        if sample_size is None:
+            sample_size = self.config.sample_size
+
+        total_time = 0.0
+        for section_name in ("forward_backward", "forward", "backward"):
+            recent = self.get_recent_section_time(section_name, num_samples=sample_size)
+            if recent is not None:
+                total_time += recent
+
+        if total_time <= 0:
+            return {}
+        return {self.rank: 1.0 / total_time}
+
+    def identify_stragglers(
+        self,
+        section_scores: Optional[Dict[str, Dict[int, float]]] = None,
+        threshold: Optional[float] = None,
+    ) -> List[int]:
+        if threshold is None:
+            threshold = self.straggler_threshold
+        if section_scores is None:
+            section_scores = self.compute_all_section_scores()
+        return self._identify_stragglers_from_times(section_scores, threshold)
+
+    def _get_collective_device(self):
+        if not TORCH_DISTRIBUTED_AVAILABLE or not dist.is_initialized():
+            return None
+
+        backend = ""
+        try:
+            backend = str(dist.get_backend())
+        except Exception:
+            backend = ""
+
+        if ("cuda" in backend or "nccl" in backend or "flagcx" in backend) and torch.cuda.is_available():
+            return torch.device("cuda", torch.cuda.current_device())
+        return torch.device("cpu")
+
+    def _gather_section_times_across_ranks(self) -> Dict[str, Dict[int, float]]:
+        if not TORCH_DISTRIBUTED_AVAILABLE or not dist.is_initialized():
+            result = {}
+            for section_name in self.config.monitor_sections:
+                avg_time = self.get_recent_section_time(section_name, num_samples=5)
+                if avg_time is not None:
+                    result[section_name] = {self.rank: avg_time}
+            return result
+
+        device = self._get_collective_device()
+        result = {}
+        for section_name in self.config.monitor_sections:
+            avg_time = self.get_recent_section_time(section_name, num_samples=5)
+            local_time = avg_time if avg_time is not None else -1.0
+            local_tensor = torch.tensor([local_time], dtype=torch.float64, device=device)
+            gathered_tensors = [
+                torch.zeros(1, dtype=torch.float64, device=device) for _ in range(self.world_size)
+            ]
+            dist.all_gather(gathered_tensors, local_tensor)
+
+            section_times = {}
+            for rank, tensor in enumerate(gathered_tensors):
+                time_val = tensor.item()
+                if time_val >= 0:
+                    section_times[rank] = time_val
+            if section_times:
+                result[section_name] = section_times
+
+        return result
+
+    def _gather_node_names_across_ranks(self) -> Dict[int, str]:
+        if not TORCH_DISTRIBUTED_AVAILABLE or not dist.is_initialized():
+            return {self.rank: self.node_name}
+
+        node_names_list = [None] * self.world_size
+        dist.all_gather_object(node_names_list, self.node_name)
+        return {rank: name for rank, name in enumerate(node_names_list) if name is not None}
+
+    def generate_report(
+        self,
+        step: Optional[int] = None,
+        gather_on_rank0: Optional[bool] = None,
+    ) -> StragglerReport:
+        if step is None:
+            step = self.current_step
+        if gather_on_rank0 is None:
+            gather_on_rank0 = self.config.gather_on_rank0
+
+        section_scores = self._gather_section_times_across_ranks()
+
+        gpu_scores = {}
+        for section_name in ("forward_backward", "forward", "backward"):
+            if section_name not in section_scores:
+                continue
+            for rank, time_val in section_scores[section_name].items():
+                if time_val <= 0:
+                    continue
+                gpu_scores[rank] = gpu_scores.get(rank, 0.0) + time_val
+        for rank, total_time in list(gpu_scores.items()):
+            gpu_scores[rank] = 1.0 / total_time if total_time > 0 else 0.0
+
+        straggler_ranks = self._identify_stragglers_from_times(section_scores)
+        node_names = self._gather_node_names_across_ranks()
+
+        report = StragglerReport(
+            step=step,
+            section_scores=section_scores,
+            gpu_scores=gpu_scores,
+            straggler_ranks=straggler_ranks,
+            node_names=node_names,
+        )
+        report.timestamp = time.time()
+        return report
+
+    def _identify_stragglers_from_times(
+        self,
+        section_times: Dict[str, Dict[int, float]],
+        threshold: Optional[float] = None,
+    ) -> List[int]:
+        if threshold is None:
+            threshold = self.straggler_threshold
+        if not section_times:
+            return []
+
+        total_times = defaultdict(float)
+        for rank_times in section_times.values():
+            for rank, time_val in rank_times.items():
+                total_times[rank] += time_val
+
+        if not total_times:
+            return []
+
+        fastest_rank = min(total_times.items(), key=lambda item: item[1])[0]
+        fastest_time = total_times[fastest_rank]
+        if fastest_time <= 0:
+            return []
+
+        stragglers = []
+        for rank, total_time in total_times.items():
+            if rank == fastest_rank:
+                continue
+            slowdown_ratio = total_time / fastest_time
+            if slowdown_ratio >= threshold:
+                stragglers.append(rank)
+        return sorted(stragglers)
+
+    def save_report(self, report: StragglerReport, filepath: str):
+        try:
+            with open(filepath, "w") as file_obj:
+                json.dump(report.to_dict(), file_obj, indent=2)
+        except Exception as exc:
+            print(f"Warning: Could not save report to {filepath}: {exc}")
+
+    def get_recent_section_time(
+        self,
+        section_name: str,
+        num_samples: int = 1,
+    ) -> Optional[float]:
+        timings = self.section_timings.get(section_name, [])
+        if not timings:
+            return None
+
+        recent = timings[-num_samples:]
+        if not recent:
+            return None
+
+        total_time = 0.0
+        count = 0
+        for _, cpu_time, gpu_time in recent:
+            total_time += gpu_time if gpu_time is not None else cpu_time
+            count += 1
+        return total_time / count if count > 0 else None
+
+    def get_section_statistics(self) -> Dict[str, Dict[str, float]]:
+        stats = {}
+        for section_name, timings in self.section_timings.items():
+            if not timings:
+                continue
+
+            cpu_times = []
+            gpu_times = []
+            for _, cpu_time, gpu_time in timings:
+                cpu_times.append(cpu_time)
+                if gpu_time is not None:
+                    gpu_times.append(gpu_time)
+
+            section_stats = {
+                "count": len(timings),
+                "cpu_avg": sum(cpu_times) / len(cpu_times),
+                "cpu_min": min(cpu_times),
+                "cpu_max": max(cpu_times),
+            }
+            if gpu_times:
+                section_stats["gpu_avg"] = sum(gpu_times) / len(gpu_times)
+                section_stats["gpu_min"] = min(gpu_times)
+                section_stats["gpu_max"] = max(gpu_times)
+            stats[section_name] = section_stats
+        return stats
+
+    def reset(self):
+        self.section_timings.clear()
+        self.current_step = 0
+
+    def is_enabled(self) -> bool:
+        return self.enabled
+
+    def set_enabled(self, enabled: bool):
+        self.enabled = enabled

--- a/flagscale/runner/straggler/healthcheck.py
+++ b/flagscale/runner/straggler/healthcheck.py
@@ -3,7 +3,6 @@
 import socket
 import subprocess
 import time
-from typing import Dict, List, Tuple
 
 
 class NetworkHealthChecker:
@@ -12,15 +11,15 @@ class NetworkHealthChecker:
     def __init__(self, rank: int = 0, world_size: int = 1):
         self.rank = rank
         self.world_size = world_size
-        self.node_health: Dict[int, bool] = {}
-        self.latency_matrix: Dict[Tuple[int, int], float] = {}
+        self.node_health: dict[int, bool] = {}
+        self.latency_matrix: dict[tuple[int, int], float] = {}
 
     def check_node_connectivity(
         self,
-        node_ips: List[str],
+        node_ips: list[str],
         port: int = 29500,
         timeout: float = 5.0,
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         results = {}
         for ip in node_ips:
             try:
@@ -35,17 +34,16 @@ class NetworkHealthChecker:
 
     def measure_latency(
         self,
-        node_ips: List[str],
+        node_ips: list[str],
         port: int = 29500,
         num_pings: int = 3,
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         latencies = {}
         for ip in node_ips:
             try:
                 result = subprocess.run(
                     ["ping", "-c", str(num_pings), "-W", "1", ip],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    capture_output=True,
                     text=True,
                 )
                 if result.returncode != 0:
@@ -67,9 +65,9 @@ class NetworkHealthChecker:
 
     def check_bandwidth(
         self,
-        node_ips: List[str],
+        node_ips: list[str],
         test_size: int = 1024 * 1024,
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         bandwidths = {}
         for ip in node_ips:
             try:
@@ -91,9 +89,9 @@ class NetworkHealthChecker:
 
     def comprehensive_health_check(
         self,
-        node_ips: List[str],
+        node_ips: list[str],
         port: int = 29500,
-    ) -> Dict[str, Dict[str, object]]:
+    ) -> dict[str, dict[str, object]]:
         results = {}
         connectivity = self.check_node_connectivity(node_ips, port)
         latencies = self.measure_latency(node_ips, port)
@@ -110,10 +108,10 @@ class NetworkHealthChecker:
 
     def identify_unhealthy_nodes(
         self,
-        health_results: Dict[str, Dict[str, object]],
+        health_results: dict[str, dict[str, object]],
         max_latency_ms: float = 100.0,
         min_bandwidth_mbps: float = 10.0,
-    ) -> List[str]:
+    ) -> list[str]:
         unhealthy = []
         for ip, metrics in health_results.items():
             if not metrics["connectivity"]:
@@ -126,9 +124,9 @@ class NetworkHealthChecker:
 
     def get_network_summary(
         self,
-        node_ips: List[str],
+        node_ips: list[str],
         port: int = 29500,
-    ) -> Dict[str, object]:
+    ) -> dict[str, object]:
         health_results = self.comprehensive_health_check(node_ips, port)
         unhealthy = self.identify_unhealthy_nodes(health_results)
 
@@ -160,7 +158,7 @@ class NetworkHealthChecker:
 
     def save_health_report(
         self,
-        health_results: Dict[str, Dict[str, object]],
+        health_results: dict[str, dict[str, object]],
         filepath: str,
     ):
         try:
@@ -183,15 +181,15 @@ class ElasticTrainingHealthChecker(NetworkHealthChecker):
 
     def __init__(self, rank: int = 0, world_size: int = 1):
         super().__init__(rank, world_size)
-        self.health_history: List[Dict[str, object]] = []
+        self.health_history: list[dict[str, object]] = []
 
     def monitor_elastic_health(
         self,
-        node_ips: List[str],
+        node_ips: list[str],
         port: int = 29500,
         check_interval: float = 30.0,
         num_checks: int = 10,
-    ) -> List[Dict[str, object]]:
+    ) -> list[dict[str, object]]:
         results = []
         for check_id in range(num_checks):
             check_result = {
@@ -207,9 +205,9 @@ class ElasticTrainingHealthChecker(NetworkHealthChecker):
 
     def detect_unstable_nodes(
         self,
-        health_history: List[Dict[str, object]],
+        health_history: list[dict[str, object]],
         instability_threshold: float = 0.3,
-    ) -> List[str]:
+    ) -> list[str]:
         node_failures = {}
         for check in health_history:
             for ip, metrics in check["health_results"].items():

--- a/flagscale/runner/straggler/healthcheck.py
+++ b/flagscale/runner/straggler/healthcheck.py
@@ -1,0 +1,225 @@
+"""Network health helpers for straggler workflows."""
+
+import socket
+import subprocess
+import time
+from typing import Dict, List, Tuple
+
+
+class NetworkHealthChecker:
+    """Check basic network reachability and quality."""
+
+    def __init__(self, rank: int = 0, world_size: int = 1):
+        self.rank = rank
+        self.world_size = world_size
+        self.node_health: Dict[int, bool] = {}
+        self.latency_matrix: Dict[Tuple[int, int], float] = {}
+
+    def check_node_connectivity(
+        self,
+        node_ips: List[str],
+        port: int = 29500,
+        timeout: float = 5.0,
+    ) -> Dict[str, bool]:
+        results = {}
+        for ip in node_ips:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(timeout)
+                result = sock.connect_ex((ip, port))
+                sock.close()
+                results[ip] = result == 0
+            except Exception:
+                results[ip] = False
+        return results
+
+    def measure_latency(
+        self,
+        node_ips: List[str],
+        port: int = 29500,
+        num_pings: int = 3,
+    ) -> Dict[str, float]:
+        latencies = {}
+        for ip in node_ips:
+            try:
+                result = subprocess.run(
+                    ["ping", "-c", str(num_pings), "-W", "1", ip],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                if result.returncode != 0:
+                    latencies[ip] = float("inf")
+                    continue
+
+                avg_latency = float("inf")
+                for line in result.stdout.splitlines():
+                    if "avg" not in line and "Average" not in line:
+                        continue
+                    parts = line.split("/")
+                    if len(parts) >= 5:
+                        avg_latency = float(parts[4])
+                        break
+                latencies[ip] = avg_latency if avg_latency != float("inf") else 0.0
+            except Exception:
+                latencies[ip] = float("inf")
+        return latencies
+
+    def check_bandwidth(
+        self,
+        node_ips: List[str],
+        test_size: int = 1024 * 1024,
+    ) -> Dict[str, float]:
+        bandwidths = {}
+        for ip in node_ips:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(10.0)
+                start_time = time.time()
+                sock.connect((ip, 29500))
+                end_time = time.time()
+                sock.close()
+
+                elapsed = end_time - start_time
+                if elapsed > 0:
+                    bandwidths[ip] = (test_size / elapsed) / (1024 * 1024)
+                else:
+                    bandwidths[ip] = 0.0
+            except Exception:
+                bandwidths[ip] = 0.0
+        return bandwidths
+
+    def comprehensive_health_check(
+        self,
+        node_ips: List[str],
+        port: int = 29500,
+    ) -> Dict[str, Dict[str, object]]:
+        results = {}
+        connectivity = self.check_node_connectivity(node_ips, port)
+        latencies = self.measure_latency(node_ips, port)
+        bandwidths = self.check_bandwidth(node_ips)
+
+        for ip in node_ips:
+            results[ip] = {
+                "connectivity": connectivity.get(ip, False),
+                "latency_ms": latencies.get(ip, float("inf")),
+                "bandwidth_mbps": bandwidths.get(ip, 0.0),
+                "healthy": connectivity.get(ip, False),
+            }
+        return results
+
+    def identify_unhealthy_nodes(
+        self,
+        health_results: Dict[str, Dict[str, object]],
+        max_latency_ms: float = 100.0,
+        min_bandwidth_mbps: float = 10.0,
+    ) -> List[str]:
+        unhealthy = []
+        for ip, metrics in health_results.items():
+            if not metrics["connectivity"]:
+                unhealthy.append(ip)
+            elif metrics["latency_ms"] > max_latency_ms:
+                unhealthy.append(ip)
+            elif metrics["bandwidth_mbps"] < min_bandwidth_mbps:
+                unhealthy.append(ip)
+        return unhealthy
+
+    def get_network_summary(
+        self,
+        node_ips: List[str],
+        port: int = 29500,
+    ) -> Dict[str, object]:
+        health_results = self.comprehensive_health_check(node_ips, port)
+        unhealthy = self.identify_unhealthy_nodes(health_results)
+
+        total_nodes = len(node_ips)
+        healthy_nodes = total_nodes - len(unhealthy)
+        reachable_nodes = [ip for ip, metrics in health_results.items() if metrics["connectivity"]]
+
+        avg_latency = 0.0
+        if reachable_nodes:
+            avg_latency = sum(health_results[ip]["latency_ms"] for ip in reachable_nodes) / len(
+                reachable_nodes
+            )
+
+        avg_bandwidth = 0.0
+        if reachable_nodes:
+            avg_bandwidth = sum(
+                health_results[ip]["bandwidth_mbps"] for ip in reachable_nodes
+            ) / len(reachable_nodes)
+
+        return {
+            "total_nodes": total_nodes,
+            "healthy_nodes": healthy_nodes,
+            "unhealthy_nodes": unhealthy,
+            "health_percentage": (healthy_nodes / total_nodes * 100) if total_nodes > 0 else 0,
+            "average_latency_ms": avg_latency,
+            "average_bandwidth_mbps": avg_bandwidth,
+            "network_healthy": len(unhealthy) == 0,
+        }
+
+    def save_health_report(
+        self,
+        health_results: Dict[str, Dict[str, object]],
+        filepath: str,
+    ):
+        try:
+            with open(filepath, "w") as file_obj:
+                file_obj.write("Network Health Check Report\n")
+                file_obj.write("=" * 50 + "\n\n")
+                for ip, metrics in health_results.items():
+                    file_obj.write(f"Node: {ip}\n")
+                    file_obj.write(f"  Connectivity: {metrics['connectivity']}\n")
+                    file_obj.write(f"  Latency: {metrics['latency_ms']:.2f} ms\n")
+                    file_obj.write(f"  Bandwidth: {metrics['bandwidth_mbps']:.2f} Mbps\n")
+                    file_obj.write(f"  Healthy: {metrics['healthy']}\n")
+                    file_obj.write("\n")
+        except Exception as exc:
+            print(f"Warning: Could not save health report: {exc}")
+
+
+class ElasticTrainingHealthChecker(NetworkHealthChecker):
+    """Health checker variant for elastic training."""
+
+    def __init__(self, rank: int = 0, world_size: int = 1):
+        super().__init__(rank, world_size)
+        self.health_history: List[Dict[str, object]] = []
+
+    def monitor_elastic_health(
+        self,
+        node_ips: List[str],
+        port: int = 29500,
+        check_interval: float = 30.0,
+        num_checks: int = 10,
+    ) -> List[Dict[str, object]]:
+        results = []
+        for check_id in range(num_checks):
+            check_result = {
+                "check_id": check_id,
+                "timestamp": time.time(),
+                "health_results": self.comprehensive_health_check(node_ips, port),
+            }
+            results.append(check_result)
+            self.health_history.append(check_result)
+            if check_id < num_checks - 1:
+                time.sleep(check_interval)
+        return results
+
+    def detect_unstable_nodes(
+        self,
+        health_history: List[Dict[str, object]],
+        instability_threshold: float = 0.3,
+    ) -> List[str]:
+        node_failures = {}
+        for check in health_history:
+            for ip, metrics in check["health_results"].items():
+                if not metrics["connectivity"]:
+                    node_failures[ip] = node_failures.get(ip, 0) + 1
+
+        unstable_nodes = []
+        total_checks = len(health_history)
+        for ip, failures in node_failures.items():
+            failure_rate = failures / total_checks
+            if failure_rate >= instability_threshold:
+                unstable_nodes.append(ip)
+        return unstable_nodes

--- a/flagscale/runner/straggler/report.py
+++ b/flagscale/runner/straggler/report.py
@@ -1,0 +1,138 @@
+"""Serialization and text formatting for straggler reports."""
+
+from typing import Any, Dict, List, Optional
+
+
+class StragglerReport:
+    """A lightweight report object for straggler findings."""
+
+    def __init__(
+        self,
+        step: int,
+        section_scores: Optional[Dict[str, Dict[int, float]]] = None,
+        comm_stats: Optional[Dict[str, Any]] = None,
+        gpu_scores: Optional[Dict[int, float]] = None,
+        straggler_ranks: Optional[List[int]] = None,
+        node_names: Optional[Dict[int, str]] = None,
+    ):
+        self.step = step
+        self.section_scores = section_scores or {}
+        self.comm_stats = comm_stats or {}
+        self.gpu_scores = gpu_scores or {}
+        self.straggler_ranks = straggler_ranks or []
+        self.node_names = node_names or {}
+        self.timestamp = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "step": self.step,
+            "section_scores": self.section_scores,
+            "comm_stats": self.comm_stats,
+            "gpu_scores": self.gpu_scores,
+            "straggler_ranks": self.straggler_ranks,
+            "node_names": self.node_names,
+            "timestamp": self.timestamp,
+        }
+
+    def to_text(self) -> str:
+        lines = [f"=== Straggler Report at Step {self.step} ==="]
+
+        if self.straggler_ranks:
+            lines.append("")
+            lines.append(f"Detected stragglers: {self.straggler_ranks}")
+            for rank in self.straggler_ranks:
+                node_name = self.node_names.get(rank, f"rank-{rank}")
+                lines.append(f"  Rank {rank} ({node_name})")
+        else:
+            lines.append("")
+            lines.append("No stragglers detected.")
+
+        if self.section_scores:
+            lines.append("")
+            lines.append("Section Timings (ms):")
+            for section_name, rank_times in self.section_scores.items():
+                if not rank_times:
+                    continue
+                times = list(rank_times.values())
+                min_time = min(times) * 1000
+                max_time = max(times) * 1000
+                avg_time = sum(times) / len(times) * 1000
+                slowdown = max_time / min_time if min_time > 0 else 1.0
+                lines.append("")
+                lines.append(f"  {section_name}:")
+                lines.append(
+                    f"    Min: {min_time:.2f}ms, Max: {max_time:.2f}ms, Avg: {avg_time:.2f}ms, Slowdown: {slowdown:.2f}x"
+                )
+                for rank, time_val in sorted(rank_times.items()):
+                    node_name = self.node_names.get(rank, f"rank-{rank}")
+                    lines.append(f"    Rank {rank} ({node_name}): {time_val * 1000:.2f}ms")
+
+        if self.gpu_scores:
+            lines.append("")
+            lines.append("GPU Performance Scores (higher is faster):")
+            for rank, score in sorted(self.gpu_scores.items()):
+                node_name = self.node_names.get(rank, f"rank-{rank}")
+                lines.append(f"  Rank {rank} ({node_name}): {score:.4f}")
+
+        if self.comm_stats:
+            lines.append("")
+            lines.append("Communication Statistics:")
+            for op_name, stats in self.comm_stats.items():
+                lines.append(f"  {op_name}:")
+                if isinstance(stats, dict):
+                    for key, value in stats.items():
+                        if isinstance(value, float):
+                            lines.append(f"    {key}: {value:.4f}")
+                        else:
+                            lines.append(f"    {key}: {value}")
+
+        return "\n".join(lines)
+
+    def identify_stragglers(self, threshold: float = 1.5) -> List[int]:
+        stragglers = []
+        for _, rank_scores in self.section_scores.items():
+            if not rank_scores:
+                continue
+            fastest_rank, fastest_score = max(rank_scores.items(), key=lambda item: item[1])
+            for rank, score in rank_scores.items():
+                if rank == fastest_rank:
+                    continue
+                relative_slowdown = fastest_score / score if score > 0 else float("inf")
+                if relative_slowdown >= threshold and rank not in stragglers:
+                    stragglers.append(rank)
+
+        for rank in self.identify_gpu_stragglers(threshold):
+            if rank not in stragglers:
+                stragglers.append(rank)
+        return sorted(stragglers)
+
+    def identify_gpu_stragglers(self, threshold: float = 1.5) -> List[int]:
+        if not self.gpu_scores:
+            return []
+
+        fastest_rank, fastest_score = max(self.gpu_scores.items(), key=lambda item: item[1])
+        stragglers = []
+        for rank, score in self.gpu_scores.items():
+            if rank == fastest_rank:
+                continue
+            relative_slowdown = fastest_score / score if score > 0 else float("inf")
+            if relative_slowdown >= threshold:
+                stragglers.append(rank)
+        return sorted(stragglers)
+
+    def get_worst_sections(self, top_k: int = 3) -> List[tuple]:
+        section_performance = []
+        for section_name, rank_scores in self.section_scores.items():
+            if len(rank_scores) < 2:
+                continue
+            scores = list(rank_scores.values())
+            slowest_score = max(scores)
+            fastest_score = min(scores)
+            worst_rank = max(rank_scores.items(), key=lambda item: item[1])[0]
+            section_performance.append((section_name, worst_rank, slowest_score, fastest_score))
+
+        section_performance.sort(
+            key=lambda item: item[2] / item[3] if item[3] > 0 else float("inf"),
+            reverse=True,
+        )
+        return section_performance[:top_k]

--- a/flagscale/runner/straggler/report.py
+++ b/flagscale/runner/straggler/report.py
@@ -1,6 +1,6 @@
 """Serialization and text formatting for straggler reports."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 class StragglerReport:
@@ -9,11 +9,11 @@ class StragglerReport:
     def __init__(
         self,
         step: int,
-        section_scores: Optional[Dict[str, Dict[int, float]]] = None,
-        comm_stats: Optional[Dict[str, Any]] = None,
-        gpu_scores: Optional[Dict[int, float]] = None,
-        straggler_ranks: Optional[List[int]] = None,
-        node_names: Optional[Dict[int, str]] = None,
+        section_scores: dict[str, dict[int, float]] | None = None,
+        comm_stats: dict[str, Any] | None = None,
+        gpu_scores: dict[int, float] | None = None,
+        straggler_ranks: list[int] | None = None,
+        node_names: dict[int, str] | None = None,
     ):
         self.step = step
         self.section_scores = section_scores or {}
@@ -23,7 +23,7 @@ class StragglerReport:
         self.node_names = node_names or {}
         self.timestamp = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "step": self.step,
             "section_scores": self.section_scores,
@@ -88,7 +88,7 @@ class StragglerReport:
 
         return "\n".join(lines)
 
-    def identify_stragglers(self, threshold: float = 1.5) -> List[int]:
+    def identify_stragglers(self, threshold: float = 1.5) -> list[int]:
         stragglers = []
         for _, rank_scores in self.section_scores.items():
             if not rank_scores:
@@ -106,7 +106,7 @@ class StragglerReport:
                 stragglers.append(rank)
         return sorted(stragglers)
 
-    def identify_gpu_stragglers(self, threshold: float = 1.5) -> List[int]:
+    def identify_gpu_stragglers(self, threshold: float = 1.5) -> list[int]:
         if not self.gpu_scores:
             return []
 
@@ -120,7 +120,7 @@ class StragglerReport:
                 stragglers.append(rank)
         return sorted(stragglers)
 
-    def get_worst_sections(self, top_k: int = 3) -> List[tuple]:
+    def get_worst_sections(self, top_k: int = 3) -> list[tuple]:
         section_performance = []
         for section_name, rank_scores in self.section_scores.items():
             if len(rank_scores) < 2:

--- a/flagscale/runner/straggler/section.py
+++ b/flagscale/runner/straggler/section.py
@@ -1,0 +1,125 @@
+"""Section-level timing utilities for straggler detection."""
+
+from functools import wraps
+import time
+from typing import Dict, Optional
+
+try:
+    import torch
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    torch = None
+    TORCH_AVAILABLE = False
+
+
+class SectionContext:
+    """Context manager that records a timed section."""
+
+    def __init__(self, detector, name: str, profile_cuda: bool = False):
+        self.detector = detector
+        self.name = name
+        self.profile_cuda = profile_cuda
+        self.start_time: Optional[float] = None
+        self.end_time: Optional[float] = None
+        self.cuda_start_event = None
+        self.cuda_end_event = None
+
+    def __enter__(self):
+        self.start_time = time.perf_counter()
+        if self.profile_cuda and TORCH_AVAILABLE and torch.cuda.is_available():
+            torch.cuda.synchronize()
+            self.cuda_start_event = torch.cuda.Event(enable_timing=True)
+            self.cuda_start_event.record()
+        else:
+            self.cuda_start_event = None
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.end_time = time.perf_counter()
+        cpu_elapsed = self.end_time - self.start_time
+
+        cuda_elapsed = None
+        if self.cuda_start_event is not None and TORCH_AVAILABLE and torch.cuda.is_available():
+            torch.cuda.synchronize()
+            self.cuda_end_event = torch.cuda.Event(enable_timing=True)
+            self.cuda_end_event.record()
+            cuda_elapsed = self.cuda_start_event.elapsed_time(self.cuda_end_event) / 1000.0
+
+        if hasattr(self.detector, "record_section"):
+            self.detector.record_section(
+                name=self.name,
+                cpu_time=cpu_elapsed,
+                gpu_time=cuda_elapsed,
+            )
+        return False
+
+
+class OptionalSectionContext:
+    """Conditionally enable section profiling."""
+
+    def __init__(
+        self,
+        detector,
+        name: str,
+        enabled: bool = True,
+        profile_cuda: bool = False,
+    ):
+        self.detector = detector
+        self.name = name
+        self.enabled = enabled
+        self.profile_cuda = profile_cuda
+        self.context: Optional[SectionContext] = None
+
+    def __enter__(self):
+        if self.enabled:
+            self.context = SectionContext(
+                detector=self.detector,
+                name=self.name,
+                profile_cuda=self.profile_cuda,
+            )
+            return self.context.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.context is not None:
+            return self.context.__exit__(exc_type, exc_val, exc_tb)
+        return False
+
+
+def create_section_decorator(detector, section_name: str, profile_cuda: bool = False):
+    """Create a decorator that measures function runtime as a section."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with SectionContext(detector, section_name, profile_cuda):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+class SectionProfiler:
+    """Manage multiple active section contexts."""
+
+    def __init__(self, detector):
+        self.detector = detector
+        self.active_sections: Dict[str, SectionContext] = {}
+
+    def start_section(self, name: str, profile_cuda: bool = False) -> SectionContext:
+        if name in self.active_sections:
+            raise ValueError(f"Section '{name}' is already active")
+
+        context = SectionContext(self.detector, name, profile_cuda)
+        self.active_sections[name] = context
+        context.__enter__()
+        return context
+
+    def end_section(self, name: str):
+        if name not in self.active_sections:
+            raise ValueError(f"Section '{name}' is not active")
+
+        context = self.active_sections.pop(name)
+        context.__exit__(None, None, None)

--- a/flagscale/runner/straggler/section.py
+++ b/flagscale/runner/straggler/section.py
@@ -1,8 +1,7 @@
 """Section-level timing utilities for straggler detection."""
 
-from functools import wraps
 import time
-from typing import Dict, Optional
+from functools import wraps
 
 try:
     import torch
@@ -20,8 +19,8 @@ class SectionContext:
         self.detector = detector
         self.name = name
         self.profile_cuda = profile_cuda
-        self.start_time: Optional[float] = None
-        self.end_time: Optional[float] = None
+        self.start_time: float | None = None
+        self.end_time: float | None = None
         self.cuda_start_event = None
         self.cuda_end_event = None
 
@@ -69,7 +68,7 @@ class OptionalSectionContext:
         self.name = name
         self.enabled = enabled
         self.profile_cuda = profile_cuda
-        self.context: Optional[SectionContext] = None
+        self.context: SectionContext | None = None
 
     def __enter__(self):
         if self.enabled:
@@ -106,7 +105,7 @@ class SectionProfiler:
 
     def __init__(self, detector):
         self.detector = detector
-        self.active_sections: Dict[str, SectionContext] = {}
+        self.active_sections: dict[str, SectionContext] = {}
 
     def start_section(self, name: str, profile_cuda: bool = False) -> SectionContext:
         if name in self.active_sections:

--- a/flagscale/train/megatron/training/arguments_fs.py
+++ b/flagscale/train/megatron/training/arguments_fs.py
@@ -763,6 +763,72 @@ def _add_regularization_args(parser):
                        help='If set, disable Nesterov momentum for muon')
     return parser
 
+def _add_straggler_args(parser):
+    group = parser.add_argument_group(title="flagscale straggler")
+
+    group.add_argument(
+        "--enable-straggler-detection",
+        action="store_true",
+        default=False,
+        help="Enable FlagScale straggler detection.",
+    )
+    group.add_argument(
+        "--straggler-profiling-interval",
+        type=int,
+        default=10,
+        help="Record straggler samples every N steps after warmup.",
+    )
+    group.add_argument(
+        "--straggler-report-interval",
+        type=int,
+        default=100,
+        help="Generate a straggler report every N steps.",
+    )
+    group.add_argument(
+        "--straggler-threshold",
+        type=float,
+        default=1.5,
+        help="Slowdown ratio used to mark a rank as a straggler.",
+    )
+    group.add_argument(
+        "--straggler-warmup-steps",
+        type=int,
+        default=10,
+        help="Skip the first N steps before profiling stragglers.",
+    )
+    group.add_argument(
+        "--straggler-enable-comm-logging",
+        dest="straggler_enable_comm_logging",
+        action="store_true",
+        help="Enable communication logging in the FlagScale straggler detector.",
+    )
+    group.add_argument(
+        "--no-straggler-enable-comm-logging",
+        dest="straggler_enable_comm_logging",
+        action="store_false",
+        help="Disable communication logging in the FlagScale straggler detector.",
+    )
+    group.set_defaults(straggler_enable_comm_logging=True)
+    group.add_argument(
+        "--straggler-enable-gpu-profile",
+        dest="straggler_enable_gpu_profile",
+        action="store_true",
+        help="Enable CUDA event timing for straggler profiling when available.",
+    )
+    group.add_argument(
+        "--no-straggler-enable-gpu-profile",
+        dest="straggler_enable_gpu_profile",
+        action="store_false",
+        help="Disable CUDA event timing for straggler profiling.",
+    )
+    group.set_defaults(straggler_enable_gpu_profile=True)
+    group.add_argument(
+        "--straggler-log-dir",
+        type=str,
+        default=None,
+        help="Directory used to save FlagScale straggler reports.",
+    )
+    return parser
 
 def _add_flagos_args(parser):
     group = parser.add_argument_group(title="flagscale transformer engine fl")
@@ -878,6 +944,7 @@ def add_flagscale_arguments(parser):
     parser = _add_auto_skip_spiky_loss(parser)
     parser = _add_peft_args(parser)
     parser = _add_regularization_args(parser)
+    parser = _add_straggler_args(parser)
     parser = _add_flagos_args(parser)
     parser = _add_engram_args(parser)
     return parser

--- a/flagscale/train/megatron/training/training.py
+++ b/flagscale/train/megatron/training/training.py
@@ -7,9 +7,11 @@ from datetime import datetime
 import functools
 import gc
 import inspect
+import json
 import logging
 import math
 import os
+import socket
 import sys
 from typing import Any, Optional
 
@@ -138,8 +140,70 @@ from megatron.training.stablelm2_scheduler import StableLM2SchedulerConfig
 from megatron.training.global_vars import get_spiky_loss_detector
 from megatron.training.fs_theoretical_memory_usage import report_theoretical_memory as fs_report_theoretical_memory
 from megatron.plugin.hetero.parallel_context import get_parallel_context
+from flagscale.runner.straggler import (
+    OptionalSectionContext,
+    StragglerConfig as FSStragglerConfig,
+    StragglerDetector as FSStragglerDetector,
+)
 
 stimer = StragglerDetector()
+_fs_straggler_detector = None
+
+
+def get_fs_straggler_detector():
+    """Get the global FlagScale straggler detector."""
+    return _fs_straggler_detector
+
+
+def init_fs_straggler_detector(args):
+    """Initialize the FlagScale straggler detector from parsed args."""
+    global _fs_straggler_detector
+
+    if not getattr(args, "enable_straggler_detection", False):
+        _fs_straggler_detector = None
+        return None
+
+    config = FSStragglerConfig(
+        enabled=True,
+        profiling_interval=getattr(args, "straggler_profiling_interval", 10),
+        report_interval_steps=getattr(args, "straggler_report_interval", 100),
+        straggler_threshold=getattr(args, "straggler_threshold", 1.5),
+        warmup_steps=getattr(args, "straggler_warmup_steps", 10),
+        gather_on_rank0=True,
+        enable_comm_logging=getattr(args, "straggler_enable_comm_logging", True),
+        enable_gpu_profile=getattr(args, "straggler_enable_gpu_profile", True),
+    )
+
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    world_size = torch.distributed.get_world_size() if torch.distributed.is_initialized() else 1
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    hostname = os.environ.get("HOSTNAME") or socket.gethostname()
+
+    _fs_straggler_detector = FSStragglerDetector(
+        config=config,
+        rank=rank,
+        world_size=world_size,
+        node_name=f"{hostname}:gpu{local_rank}",
+    )
+    return _fs_straggler_detector
+
+
+def _save_straggler_report(report, log_dir: Optional[str], iteration: int):
+    """Persist a straggler report and print a text summary."""
+    if log_dir is None:
+        return
+
+    os.makedirs(log_dir, exist_ok=True)
+    hostname = os.environ.get("HOSTNAME") or socket.gethostname()
+    report_path = os.path.join(log_dir, f"straggler_report_{hostname}_step_{iteration}.json")
+
+    try:
+        with open(report_path, "w") as file_obj:
+            json.dump(report.to_dict(), file_obj, indent=2)
+    except Exception as exc:
+        print(f"[{hostname}] Warning: Could not save straggler report: {exc}")
+
+    print(f"\n{report.to_text()}")
 
 from megatron.core.msc_utils import MultiStorageClientFeature, open_file
 
@@ -827,6 +891,13 @@ def pretrain(
             flag_gems.enable(record=True, once=True, unused=args.flag_gems_unused, path=args.flag_gems_log_path)
         except Exception as e:
             raise RuntimeError(f"Failed to enable 'flag_gems': {e}.")
+
+    fs_straggler = init_fs_straggler_detector(args)
+    if fs_straggler is not None:
+        print_rank_0(
+            "FlagScale straggler detection enabled "
+            f"(threshold={args.straggler_threshold}, log_dir={args.straggler_log_dir})"
+        )
     ###### FlagScale End   ######
 
     if args.log_progress:
@@ -1572,6 +1643,13 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     """Single training step."""
     args = get_args()
     timers = get_timers()
+    fs_straggler = get_fs_straggler_detector()
+    should_profile_straggler = (
+        fs_straggler is not None
+        and fs_straggler.is_enabled()
+        and fs_straggler.should_profile(fs_straggler.current_step + 1)
+    )
+    profile_cuda = getattr(args, "straggler_enable_gpu_profile", True)
 
     rerun_state_machine = get_rerun_state_machine()
     while rerun_state_machine.should_run_forward_backward(data_iterator):
@@ -1597,17 +1675,23 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
                     optim_instance._copy_main_params_to_param_buffer()
 
         # Forward pass.
-        losses_reduced = forward_backward_func(
-            forward_step_func=forward_step_func,
-            data_iterator=data_iterator,
-            model=model,
-            num_microbatches=get_num_microbatches(),
-            seq_length=args.seq_length,
-            micro_batch_size=args.micro_batch_size,
-            decoder_seq_length=args.decoder_seq_length,
-            forward_only=False,
-            adjust_tensor_shapes_fn=adjust_tensor_shapes_fn,
-        )
+        with OptionalSectionContext(
+            fs_straggler,
+            "forward_backward",
+            enabled=should_profile_straggler,
+            profile_cuda=profile_cuda,
+        ):
+            losses_reduced = forward_backward_func(
+                forward_step_func=forward_step_func,
+                data_iterator=data_iterator,
+                model=model,
+                num_microbatches=get_num_microbatches(),
+                seq_length=args.seq_length,
+                micro_batch_size=args.micro_batch_size,
+                decoder_seq_length=args.decoder_seq_length,
+                forward_only=False,
+                adjust_tensor_shapes_fn=adjust_tensor_shapes_fn,
+            )
     should_checkpoint, should_exit, exit_code = rerun_state_machine.should_checkpoint_and_exit()
     if should_exit:
         return {}, True, should_checkpoint, should_exit, exit_code, None, None
@@ -1634,10 +1718,16 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         unwrapped_model.cancel_gradients_last_layer(args.curr_iteration)
 
     # Update parameters.
-
-    timers('optimizer', log_level=1).start(barrier=args.barrier_with_L1_time)
-    update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
-    timers('optimizer').stop()
+    
+    with OptionalSectionContext(
+        fs_straggler,
+        "optimizer",
+        enabled=should_profile_straggler,
+        profile_cuda=profile_cuda,
+    ):
+        timers('optimizer', log_level=1).start(barrier=args.barrier_with_L1_time)
+        update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
+        timers('optimizer').stop()
 
     # when freezing sub-models we may have a mixture of successful and unsucessful ranks,
     # so we must gather across mp ranks
@@ -2761,6 +2851,14 @@ def train(
             params_norm,
             num_zeros_in_grad,
         )
+
+        fs_straggler = get_fs_straggler_detector()
+        if fs_straggler is not None and fs_straggler.is_enabled():
+            fs_straggler.increment_step()
+            if fs_straggler.should_report(iteration):
+                report = fs_straggler.generate_report(step=iteration)
+                if int(os.environ.get("LOCAL_RANK", 0)) == 0:
+                    _save_straggler_report(report, getattr(args, "straggler_log_dir", None), iteration)
 
         # Evaluation.
         if args.eval_interval and iteration % args.eval_interval == 0 and args.do_valid:

--- a/tests/unit_tests/runner/straggler/__init__.py
+++ b/tests/unit_tests/runner/straggler/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for FlagScale straggler utilities."""

--- a/tests/unit_tests/runner/straggler/test_config.py
+++ b/tests/unit_tests/runner/straggler/test_config.py
@@ -1,0 +1,48 @@
+"""Unit tests for straggler configuration."""
+
+from flagscale.runner.straggler.config import StragglerConfig
+
+
+class TestStragglerConfig:
+    def test_default_values(self):
+        config = StragglerConfig()
+        assert config.enabled is True
+        assert config.profiling_interval == 10
+        assert config.report_interval_steps == 100
+        assert config.straggler_threshold == 1.5
+        assert config.warmup_steps == 10
+        assert config.sample_size == 100
+        assert config.gather_on_rank0 is True
+        assert config.enable_gpu_profile is True
+
+    def test_custom_values(self):
+        config = StragglerConfig(
+            enabled=False,
+            profiling_interval=5,
+            report_interval_steps=50,
+            straggler_threshold=2.0,
+            warmup_steps=20,
+            sample_size=5,
+            gather_on_rank0=False,
+            enable_gpu_profile=False,
+        )
+
+        assert config.enabled is False
+        assert config.profiling_interval == 5
+        assert config.report_interval_steps == 50
+        assert config.straggler_threshold == 2.0
+        assert config.warmup_steps == 20
+        assert config.sample_size == 5
+        assert config.gather_on_rank0 is False
+        assert config.enable_gpu_profile is False
+
+    def test_monitor_sections_default(self):
+        config = StragglerConfig()
+        assert isinstance(config.monitor_sections, list)
+        assert "forward_backward" in config.monitor_sections
+        assert "optimizer" in config.monitor_sections
+
+    def test_monitor_sections_custom(self):
+        custom_sections = ["custom_section1", "custom_section2"]
+        config = StragglerConfig(monitor_sections=custom_sections)
+        assert config.monitor_sections == custom_sections

--- a/tests/unit_tests/runner/straggler/test_detector.py
+++ b/tests/unit_tests/runner/straggler/test_detector.py
@@ -206,7 +206,9 @@ class TestStragglerDetectorWithMockedDistributed:
         mock_dist.is_initialized.return_value = True
         mock_dist.get_backend.return_value = "gloo"
         detector = StragglerDetector(
-            config=StragglerConfig(enabled=True, monitor_sections=["forward_backward", "optimizer"]),
+            config=StragglerConfig(
+                enabled=True, monitor_sections=["forward_backward", "optimizer"]
+            ),
             rank=0,
             world_size=4,
             node_name="node0:gpu0",

--- a/tests/unit_tests/runner/straggler/test_detector.py
+++ b/tests/unit_tests/runner/straggler/test_detector.py
@@ -1,0 +1,244 @@
+"""Unit tests for straggler detector."""
+
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+import flagscale.runner.straggler.detector as detector_module
+from flagscale.runner.straggler.config import StragglerConfig
+from flagscale.runner.straggler.detector import StragglerDetector
+
+
+class TestStragglerDetector:
+    @pytest.fixture
+    def default_config(self):
+        return StragglerConfig(
+            enabled=True,
+            profiling_interval=10,
+            report_interval_steps=100,
+            straggler_threshold=1.5,
+            warmup_steps=10,
+            monitor_sections=["forward_backward", "optimizer"],
+        )
+
+    @pytest.fixture
+    def detector(self, default_config):
+        return StragglerDetector(
+            config=default_config,
+            rank=0,
+            world_size=8,
+            node_name="test-node:gpu0",
+        )
+
+    def test_init(self, default_config):
+        detector = StragglerDetector(
+            config=default_config,
+            rank=0,
+            world_size=8,
+            node_name="test-node:gpu0",
+        )
+        assert detector.rank == 0
+        assert detector.world_size == 8
+        assert detector.node_name == "test-node:gpu0"
+        assert detector.enabled is True
+        assert detector.current_step == 0
+
+    def test_init_default_node_name(self, default_config):
+        detector = StragglerDetector(config=default_config, rank=3, world_size=8)
+        assert detector.node_name == "rank-3"
+
+    def test_set_enabled(self, detector):
+        detector.set_enabled(False)
+        assert detector.is_enabled() is False
+        detector.set_enabled(True)
+        assert detector.is_enabled() is True
+
+    def test_increment_step(self, detector):
+        detector.increment_step()
+        detector.increment_step()
+        assert detector.current_step == 2
+
+    def test_record_section(self, detector):
+        detector.record_section("forward_backward", cpu_time=0.5, gpu_time=0.45)
+        assert detector.section_timings["forward_backward"][0] == (0, 0.5, 0.45)
+
+    def test_record_section_unmonitored(self, detector):
+        detector.record_section("unmonitored_section", cpu_time=0.5)
+        assert "unmonitored_section" not in detector.section_timings
+
+    def test_record_section_disabled(self, default_config):
+        default_config.enabled = False
+        detector = StragglerDetector(config=default_config, rank=0, world_size=1)
+        detector.record_section("forward_backward", cpu_time=0.5)
+        assert len(detector.section_timings) == 0
+
+    def test_should_profile(self, detector):
+        for step in range(10):
+            detector.current_step = step
+            assert detector.should_profile() is False
+        detector.current_step = 10
+        assert detector.should_profile() is True
+        detector.current_step = 15
+        assert detector.should_profile() is False
+        detector.current_step = 20
+        assert detector.should_profile() is True
+
+    def test_should_report(self, detector):
+        detector.current_step = 0
+        assert detector.should_report() is False
+        detector.current_step = 100
+        assert detector.should_report() is True
+
+    def test_get_recent_section_time(self, detector):
+        detector.record_section("forward_backward", cpu_time=0.1, step=1)
+        detector.record_section("forward_backward", cpu_time=0.2, step=2)
+        detector.record_section("forward_backward", cpu_time=0.3, step=3)
+        assert detector.get_recent_section_time("forward_backward", num_samples=2) == pytest.approx(
+            0.25, rel=1e-3
+        )
+        assert detector.get_recent_section_time("forward_backward", num_samples=1) == pytest.approx(
+            0.3, rel=1e-3
+        )
+
+    def test_get_section_statistics(self, detector):
+        detector.record_section("forward_backward", cpu_time=0.1)
+        detector.record_section("forward_backward", cpu_time=0.2)
+        detector.record_section("forward_backward", cpu_time=0.3)
+        stats = detector.get_section_statistics()
+        assert stats["forward_backward"]["count"] == 3
+        assert stats["forward_backward"]["cpu_avg"] == pytest.approx(0.2, rel=1e-3)
+
+    def test_reset(self, detector):
+        detector.record_section("forward_backward", cpu_time=0.5)
+        detector.increment_step()
+        detector.reset()
+        assert len(detector.section_timings) == 0
+        assert detector.current_step == 0
+
+
+class TestStragglerDetection:
+    @pytest.fixture
+    def detector(self):
+        return StragglerDetector(
+            config=StragglerConfig(
+                enabled=True,
+                straggler_threshold=1.5,
+                monitor_sections=["forward_backward", "optimizer"],
+            ),
+            rank=0,
+            world_size=8,
+            node_name="test-node:gpu0",
+        )
+
+    def test_identify_stragglers_single_straggler(self, detector):
+        section_times = {
+            "forward_backward": {
+                0: 0.100,
+                1: 0.100,
+                2: 0.200,
+                3: 0.100,
+            }
+        }
+        assert detector._identify_stragglers_from_times(section_times) == [2]
+
+    def test_identify_stragglers_multiple_sections(self, detector):
+        section_times = {
+            "forward_backward": {0: 0.100, 1: 0.100, 2: 0.200, 3: 0.100},
+            "optimizer": {0: 0.010, 1: 0.010, 2: 0.010, 3: 0.010},
+        }
+        assert detector._identify_stragglers_from_times(section_times) == [2]
+
+    def test_identify_stragglers_empty_data(self, detector):
+        assert detector._identify_stragglers_from_times({}) == []
+
+
+class TestStragglerDetectorReportGeneration:
+    @pytest.fixture
+    def detector(self):
+        return StragglerDetector(
+            config=StragglerConfig(
+                enabled=True,
+                straggler_threshold=1.5,
+                monitor_sections=["forward_backward", "optimizer"],
+            ),
+            rank=0,
+            world_size=1,
+            node_name="test-node:gpu0",
+        )
+
+    def test_generate_report_local(self, detector):
+        for idx in range(5):
+            detector.record_section("forward_backward", cpu_time=0.1 + idx * 0.01)
+            detector.record_section("optimizer", cpu_time=0.01)
+            detector.increment_step()
+
+        report = detector.generate_report(step=10)
+        assert report.step == 10
+        assert report.node_names[0] == "test-node:gpu0"
+
+    def test_save_report(self, detector):
+        detector.record_section("forward_backward", cpu_time=0.1)
+        report = detector.generate_report(step=1)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as file_obj:
+            temp_path = file_obj.name
+
+        try:
+            detector.save_report(report, temp_path)
+            with open(temp_path, "r") as file_obj:
+                data = json.load(file_obj)
+            assert "step" in data
+            assert "section_scores" in data
+            assert "node_names" in data
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+
+class TestStragglerDetectorWithMockedDistributed:
+    @pytest.mark.skipif(detector_module.torch is None, reason="torch is not installed")
+    @patch("flagscale.runner.straggler.detector.dist")
+    @patch("flagscale.runner.straggler.detector.TORCH_DISTRIBUTED_AVAILABLE", True)
+    def test_gather_section_times_across_ranks(self, mock_dist):
+        mock_dist.is_initialized.return_value = True
+        mock_dist.get_backend.return_value = "gloo"
+        detector = StragglerDetector(
+            config=StragglerConfig(enabled=True, monitor_sections=["forward_backward", "optimizer"]),
+            rank=0,
+            world_size=4,
+            node_name="node0:gpu0",
+        )
+        detector.record_section("forward_backward", cpu_time=0.1)
+
+        def mock_all_gather(gathered_list, local_tensor):
+            for idx, value in enumerate([0.10, 0.11, 0.15, 0.12]):
+                gathered_list[idx].fill_(value)
+
+        mock_dist.all_gather.side_effect = mock_all_gather
+        result = detector._gather_section_times_across_ranks()
+        assert "forward_backward" in result
+        assert len(result["forward_backward"]) == 4
+
+    @pytest.mark.skipif(detector_module.torch is None, reason="torch is not installed")
+    @patch("flagscale.runner.straggler.detector.dist")
+    @patch("flagscale.runner.straggler.detector.TORCH_DISTRIBUTED_AVAILABLE", True)
+    def test_gather_node_names_across_ranks(self, mock_dist):
+        mock_dist.is_initialized.return_value = True
+        detector = StragglerDetector(
+            config=StragglerConfig(enabled=True),
+            rank=0,
+            world_size=4,
+            node_name="node0:gpu0",
+        )
+
+        def mock_all_gather_object(output_list, local_obj):
+            for idx, name in enumerate(["node0:gpu0", "node0:gpu1", "node1:gpu0", "node1:gpu1"]):
+                output_list[idx] = name
+
+        mock_dist.all_gather_object.side_effect = mock_all_gather_object
+        result = detector._gather_node_names_across_ranks()
+        assert result[0] == "node0:gpu0"
+        assert result[2] == "node1:gpu0"

--- a/tests/unit_tests/runner/straggler/test_healthcheck.py
+++ b/tests/unit_tests/runner/straggler/test_healthcheck.py
@@ -1,0 +1,115 @@
+"""Unit tests for straggler health checks."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flagscale.runner.straggler.healthcheck import (
+    ElasticTrainingHealthChecker,
+    NetworkHealthChecker,
+)
+
+
+class TestNetworkHealthChecker:
+    @pytest.fixture
+    def checker(self):
+        return NetworkHealthChecker(rank=0, world_size=4)
+
+    @patch("socket.socket")
+    def test_check_node_connectivity_success(self, mock_socket_class, checker):
+        mock_socket = MagicMock()
+        mock_socket.connect_ex.return_value = 0
+        mock_socket_class.return_value = mock_socket
+        results = checker.check_node_connectivity(["192.168.1.1", "192.168.1.2"])
+        assert results["192.168.1.1"] is True
+        assert results["192.168.1.2"] is True
+
+    @patch("subprocess.run")
+    def test_measure_latency_failure(self, mock_run, checker):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        results = checker.measure_latency(["192.168.1.1"])
+        assert results["192.168.1.1"] == float("inf")
+
+    def test_identify_unhealthy_nodes(self, checker):
+        unhealthy = checker.identify_unhealthy_nodes(
+            {
+                "192.168.1.1": {"connectivity": True, "latency_ms": 50.0, "bandwidth_mbps": 100.0},
+                "192.168.1.2": {"connectivity": False, "latency_ms": 0.0, "bandwidth_mbps": 0.0},
+                "192.168.1.3": {"connectivity": True, "latency_ms": 200.0, "bandwidth_mbps": 50.0},
+            },
+            max_latency_ms=100.0,
+            min_bandwidth_mbps=10.0,
+        )
+        assert unhealthy == ["192.168.1.2", "192.168.1.3"]
+
+    def test_get_network_summary(self, checker):
+        with patch.object(checker, "comprehensive_health_check") as mock_check:
+            mock_check.return_value = {
+                "192.168.1.1": {
+                    "connectivity": True,
+                    "latency_ms": 10.0,
+                    "bandwidth_mbps": 100.0,
+                    "healthy": True,
+                },
+                "192.168.1.2": {
+                    "connectivity": True,
+                    "latency_ms": 15.0,
+                    "bandwidth_mbps": 90.0,
+                    "healthy": True,
+                },
+            }
+            summary = checker.get_network_summary(["192.168.1.1", "192.168.1.2"])
+            assert summary["total_nodes"] == 2
+            assert summary["healthy_nodes"] == 2
+            assert summary["network_healthy"] is True
+
+    def test_save_health_report(self, checker):
+        health_results = {
+            "192.168.1.1": {
+                "connectivity": True,
+                "latency_ms": 10.0,
+                "bandwidth_mbps": 100.0,
+                "healthy": True,
+            },
+        }
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as file_obj:
+            temp_path = file_obj.name
+
+        try:
+            checker.save_health_report(health_results, temp_path)
+            with open(temp_path, "r") as file_obj:
+                content = file_obj.read()
+            assert "192.168.1.1" in content
+            assert "Network Health Check Report" in content
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+
+class TestElasticTrainingHealthChecker:
+    def test_detect_unstable_nodes(self):
+        checker = ElasticTrainingHealthChecker(rank=0, world_size=4)
+        unstable = checker.detect_unstable_nodes(
+            [
+                {
+                    "check_id": 0,
+                    "timestamp": 1000.0,
+                    "health_results": {
+                        "192.168.1.1": {"connectivity": True},
+                        "192.168.1.2": {"connectivity": False},
+                    },
+                },
+                {
+                    "check_id": 1,
+                    "timestamp": 1030.0,
+                    "health_results": {
+                        "192.168.1.1": {"connectivity": True},
+                        "192.168.1.2": {"connectivity": False},
+                    },
+                },
+            ],
+            instability_threshold=0.5,
+        )
+        assert unstable == ["192.168.1.2"]

--- a/tests/unit_tests/runner/straggler/test_report.py
+++ b/tests/unit_tests/runner/straggler/test_report.py
@@ -1,0 +1,84 @@
+"""Unit tests for straggler reports."""
+
+import json
+
+import pytest
+
+from flagscale.runner.straggler.report import StragglerReport
+
+
+class TestStragglerReport:
+    @pytest.fixture
+    def sample_section_scores(self):
+        return {
+            "forward_backward": {0: 0.100, 1: 0.105, 2: 0.098, 3: 0.102},
+            "optimizer": {0: 0.010, 1: 0.011, 2: 0.009, 3: 0.010},
+        }
+
+    @pytest.fixture
+    def sample_gpu_scores(self):
+        return {0: 10.0, 1: 9.5, 2: 10.2, 3: 9.8}
+
+    @pytest.fixture
+    def sample_node_names(self):
+        return {
+            0: "node0:gpu0",
+            1: "node0:gpu1",
+            2: "node1:gpu0",
+            3: "node1:gpu1",
+        }
+
+    def test_to_dict_json_serializable(
+        self, sample_section_scores, sample_gpu_scores, sample_node_names
+    ):
+        report = StragglerReport(
+            step=100,
+            section_scores=sample_section_scores,
+            gpu_scores=sample_gpu_scores,
+            straggler_ranks=[2, 3],
+            node_names=sample_node_names,
+        )
+        parsed = json.loads(json.dumps(report.to_dict()))
+        assert parsed["step"] == 100
+
+    def test_to_text_no_stragglers(
+        self, sample_section_scores, sample_gpu_scores, sample_node_names
+    ):
+        report = StragglerReport(
+            step=100,
+            section_scores=sample_section_scores,
+            gpu_scores=sample_gpu_scores,
+            straggler_ranks=[],
+            node_names=sample_node_names,
+        )
+        text = report.to_text()
+        assert "Step 100" in text
+        assert "No stragglers detected" in text
+        assert "forward_backward" in text
+        assert "optimizer" in text
+
+    def test_to_text_with_stragglers(
+        self, sample_section_scores, sample_gpu_scores, sample_node_names
+    ):
+        report = StragglerReport(
+            step=100,
+            section_scores=sample_section_scores,
+            gpu_scores=sample_gpu_scores,
+            straggler_ranks=[2, 3],
+            node_names=sample_node_names,
+        )
+        text = report.to_text()
+        assert "Detected stragglers" in text
+        assert "node1:gpu0" in text
+
+    def test_slowdown_calculation(self):
+        report = StragglerReport(
+            step=100,
+            section_scores={"forward_backward": {0: 0.100, 1: 0.200}},
+        )
+        assert "Slowdown" in report.to_text()
+
+    def test_timestamp_is_set(self):
+        report = StragglerReport(step=100)
+        report.timestamp = 1234567890.0
+        assert report.to_dict()["timestamp"] == 1234567890.0

--- a/tests/unit_tests/runner/straggler/test_section.py
+++ b/tests/unit_tests/runner/straggler/test_section.py
@@ -28,9 +28,8 @@ class TestSectionContext:
         assert call_args.kwargs["cpu_time"] >= 0.01
 
     def test_exception_handling(self, mock_detector):
-        with pytest.raises(ValueError):
-            with SectionContext(mock_detector, "error_section"):
-                raise ValueError("Test error")
+        with pytest.raises(ValueError), SectionContext(mock_detector, "error_section"):
+            raise ValueError("Test error")
         mock_detector.record_section.assert_called_once()
 
     def test_nested_contexts(self, mock_detector):

--- a/tests/unit_tests/runner/straggler/test_section.py
+++ b/tests/unit_tests/runner/straggler/test_section.py
@@ -1,0 +1,109 @@
+"""Unit tests for section profiling helpers."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flagscale.runner.straggler.section import (
+    OptionalSectionContext,
+    SectionContext,
+    SectionProfiler,
+    create_section_decorator,
+)
+
+
+class TestSectionContext:
+    @pytest.fixture
+    def mock_detector(self):
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        return detector
+
+    def test_basic_timing(self, mock_detector):
+        with SectionContext(mock_detector, "test_section"):
+            time.sleep(0.01)
+        call_args = mock_detector.record_section.call_args
+        assert call_args.kwargs["name"] == "test_section"
+        assert call_args.kwargs["cpu_time"] >= 0.01
+
+    def test_exception_handling(self, mock_detector):
+        with pytest.raises(ValueError):
+            with SectionContext(mock_detector, "error_section"):
+                raise ValueError("Test error")
+        mock_detector.record_section.assert_called_once()
+
+    def test_nested_contexts(self, mock_detector):
+        with SectionContext(mock_detector, "outer"):
+            time.sleep(0.01)
+            with SectionContext(mock_detector, "inner"):
+                time.sleep(0.01)
+        calls = mock_detector.record_section.call_args_list
+        assert calls[0].kwargs["name"] == "inner"
+        assert calls[1].kwargs["name"] == "outer"
+
+
+class TestOptionalSectionContext:
+    @pytest.fixture
+    def mock_detector(self):
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        return detector
+
+    def test_enabled_profiles(self, mock_detector):
+        with OptionalSectionContext(mock_detector, "test", enabled=True):
+            time.sleep(0.01)
+        mock_detector.record_section.assert_called_once()
+
+    def test_disabled_does_not_profile(self, mock_detector):
+        with OptionalSectionContext(mock_detector, "test", enabled=False):
+            time.sleep(0.01)
+        mock_detector.record_section.assert_not_called()
+
+
+class TestSectionProfiler:
+    def test_start_and_end_section(self):
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        profiler = SectionProfiler(detector)
+        profiler.start_section("test_section")
+        time.sleep(0.01)
+        profiler.end_section("test_section")
+        detector.record_section.assert_called_once()
+
+    def test_start_duplicate_section_raises(self):
+        profiler = SectionProfiler(MagicMock())
+        profiler.start_section("test")
+        with pytest.raises(ValueError, match="already active"):
+            profiler.start_section("test")
+
+
+class TestCreateSectionDecorator:
+    def test_decorator_wraps_function(self):
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+
+        @create_section_decorator(detector, "decorated_section")
+        def my_function(a, b):
+            return a + b
+
+        assert my_function(1, 2) == 3
+        detector.record_section.assert_called_once()
+
+
+class TestSectionContextWithCuda:
+    @patch("flagscale.runner.straggler.section.TORCH_AVAILABLE", True)
+    @patch("flagscale.runner.straggler.section.torch")
+    def test_cuda_profiling_enabled(self, mock_torch):
+        detector = MagicMock()
+        detector.record_section = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_event = MagicMock()
+        mock_event.elapsed_time.return_value = 10.0
+        mock_torch.cuda.Event.return_value = mock_event
+
+        with SectionContext(detector, "cuda_section", profile_cuda=True):
+            time.sleep(0.01)
+
+        detector.record_section.assert_called_once()
+        assert mock_torch.cuda.synchronize.called

--- a/tests/unit_tests/runner/test_runner_train_straggler.py
+++ b/tests/unit_tests/runner/test_runner_train_straggler.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import types
+
+from omegaconf import OmegaConf
+
+hydra_module = types.ModuleType("hydra")
+hydra_core_module = types.ModuleType("hydra.core")
+hydra_config_module = types.ModuleType("hydra.core.hydra_config")
+
+
+class _HydraConfig:
+    @staticmethod
+    def get():
+        raise RuntimeError("HydraConfig.get() is not expected in this test")
+
+
+hydra_config_module.HydraConfig = _HydraConfig
+sys.modules.setdefault("hydra", hydra_module)
+sys.modules.setdefault("hydra.core", hydra_core_module)
+sys.modules.setdefault("hydra.core.hydra_config", hydra_config_module)
+
+from flagscale.runner.runner_train import _update_config_train
+
+
+def test_update_config_train_sets_default_straggler_dirs(tmp_path):
+    config = OmegaConf.create(
+        {
+            "experiment": {
+                "exp_dir": str(tmp_path / "exp"),
+                "runner": {},
+                "task": {"backend": "megatron"},
+            },
+            "train": {
+                "system": {
+                    "checkpoint": {},
+                    "logging": {},
+                },
+                "model": {},
+                "data": {},
+            },
+        }
+    )
+
+    _update_config_train(config)
+
+    assert config.train.system.logging.straggler_dir == os.path.join(
+        config.train.system.logging.log_dir, "straggler"
+    )
+    assert config.train.system.straggler_log_dir == config.train.system.logging.straggler_dir

--- a/tools/straggler/gpu_burner.py
+++ b/tools/straggler/gpu_burner.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Simple external GPU burner used to trigger straggler behavior."""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import torch
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="External GPU burner for straggler tests.")
+    parser.add_argument(
+        "--size",
+        type=int,
+        default=12288,
+        help="Square matrix size used for the burn loop.",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bfloat16",
+        choices=["bfloat16", "float16", "float32"],
+        help="Tensor dtype used for the burn loop.",
+    )
+    parser.add_argument(
+        "--log-interval",
+        type=int,
+        default=50,
+        help="Print a progress line every N iterations.",
+    )
+    return parser.parse_args()
+
+
+def resolve_dtype(name: str):
+    if name == "bfloat16":
+        return torch.bfloat16
+    if name == "float16":
+        return torch.float16
+    return torch.float32
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required for gpu_burner.py")
+
+    args = parse_args()
+    dtype = resolve_dtype(args.dtype)
+    device = torch.device("cuda", 0)
+
+    a = torch.randn(args.size, args.size, device=device, dtype=dtype)
+    b = torch.randn(args.size, args.size, device=device, dtype=dtype)
+
+    print(
+        f"Starting GPU burner on device={torch.cuda.get_device_name(device)} "
+        f"size={args.size} dtype={args.dtype}",
+        flush=True,
+    )
+
+    iteration = 0
+    while True:
+        _ = a @ b
+        torch.cuda.synchronize()
+        iteration += 1
+        if iteration % args.log_interval == 0:
+            print(f"burn iterations={iteration} ts={time.time():.0f}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/straggler/straggler_smoke.py
+++ b/tools/straggler/straggler_smoke.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Standalone smoke test for FlagScale straggler detection.
+
+This script does not depend on ``run.py`` or Megatron training startup.
+It initializes torch.distributed directly, records a couple of synthetic
+sections, and periodically emits a FlagScale straggler report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import socket
+import time
+
+import torch
+import torch.distributed as dist
+
+from flagscale.runner.straggler import OptionalSectionContext, StragglerConfig, StragglerDetector
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Standalone FlagScale straggler smoke test.")
+    parser.add_argument("--steps", type=int, default=12, help="Total synthetic steps to run.")
+    parser.add_argument(
+        "--profiling-interval",
+        type=int,
+        default=5,
+        help="Profile every N steps.",
+    )
+    parser.add_argument(
+        "--report-interval",
+        type=int,
+        default=10,
+        help="Emit a report every N steps.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=1.5,
+        help="Slowdown ratio threshold used to mark a rank as a straggler.",
+    )
+    parser.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=0,
+        help="Skip the first N steps before profiling.",
+    )
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=8,
+        help="Recent sample count used when averaging section timings.",
+    )
+    parser.add_argument(
+        "--matmul-size",
+        type=int,
+        default=4096,
+        help="Square matrix size used for synthetic GPU work.",
+    )
+    parser.add_argument(
+        "--matmul-iters",
+        type=int,
+        default=2,
+        help="Number of matmuls in the forward_backward section.",
+    )
+    parser.add_argument(
+        "--forward-sleep-ms",
+        type=float,
+        default=8.0,
+        help="Extra CPU sleep in forward_backward section.",
+    )
+    parser.add_argument(
+        "--optimizer-sleep-ms",
+        type=float,
+        default=3.0,
+        help="Extra CPU sleep in optimizer section.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        required=True,
+        help="Directory used to save report json files.",
+    )
+    return parser.parse_args()
+
+
+def init_dist():
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        return 0, 1, 0, False
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+
+    use_cuda = torch.cuda.is_available()
+    backend = "nccl" if use_cuda else "gloo"
+    if use_cuda:
+        torch.cuda.set_device(local_rank)
+
+    dist.init_process_group(backend=backend, init_method="env://")
+    return rank, world_size, local_rank, use_cuda
+
+
+def cleanup_dist():
+    if dist.is_available() and dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+def make_detector(args, rank: int, world_size: int, local_rank: int, use_cuda: bool):
+    hostname = socket.gethostname()
+    node_name = f"{hostname}:gpu{local_rank}" if use_cuda else hostname
+    config = StragglerConfig(
+        enabled=True,
+        profiling_interval=args.profiling_interval,
+        report_interval_steps=args.report_interval,
+        warmup_steps=args.warmup_steps,
+        sample_size=args.sample_size,
+        straggler_threshold=args.threshold,
+        enable_gpu_profile=use_cuda,
+        monitor_sections=["forward_backward", "optimizer"],
+    )
+    return StragglerDetector(config=config, rank=rank, world_size=world_size, node_name=node_name)
+
+
+def allocate_work_tensors(size: int, use_cuda: bool, local_rank: int):
+    if not use_cuda:
+        return None, None
+    device = torch.device("cuda", local_rank)
+    a = torch.randn(size, size, device=device, dtype=torch.bfloat16)
+    b = torch.randn(size, size, device=device, dtype=torch.bfloat16)
+    return a, b
+
+
+def run_forward_backward(a, b, matmul_iters: int, forward_sleep_ms: float, use_cuda: bool):
+    if use_cuda:
+        for _ in range(matmul_iters):
+            _ = a @ b
+        torch.cuda.synchronize()
+    if forward_sleep_ms > 0:
+        time.sleep(forward_sleep_ms / 1000.0)
+
+
+def run_optimizer(optimizer_sleep_ms: float):
+    if optimizer_sleep_ms > 0:
+        time.sleep(optimizer_sleep_ms / 1000.0)
+
+
+def main():
+    args = parse_args()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    rank, world_size, local_rank, use_cuda = init_dist()
+    detector = make_detector(args, rank, world_size, local_rank, use_cuda)
+    a, b = allocate_work_tensors(args.matmul_size, use_cuda, local_rank)
+
+    if rank == 0:
+        print(
+            f"[rank0] Starting straggler smoke test: world_size={world_size}, "
+            f"profiling_interval={args.profiling_interval}, report_interval={args.report_interval}, "
+            f"output_dir={output_dir}"
+        )
+
+    try:
+        for step in range(1, args.steps + 1):
+            detector.current_step = step
+            should_profile = detector.should_profile(step)
+
+            with OptionalSectionContext(
+                detector,
+                "forward_backward",
+                enabled=should_profile,
+                profile_cuda=use_cuda,
+            ):
+                run_forward_backward(
+                    a=a,
+                    b=b,
+                    matmul_iters=args.matmul_iters,
+                    forward_sleep_ms=args.forward_sleep_ms,
+                    use_cuda=use_cuda,
+                )
+
+            with OptionalSectionContext(
+                detector,
+                "optimizer",
+                enabled=should_profile,
+                profile_cuda=False,
+            ):
+                run_optimizer(optimizer_sleep_ms=args.optimizer_sleep_ms)
+
+            if dist.is_available() and dist.is_initialized():
+                dist.barrier()
+
+            if detector.should_report(step):
+                report = detector.generate_report(step=step)
+                if rank == 0:
+                    hostname = socket.gethostname()
+                    report_path = output_dir / f"straggler_report_{hostname}_step_{step}.json"
+                    detector.save_report(report, str(report_path))
+                    print(report.to_text(), flush=True)
+                    print(f"[rank0] Saved report to {report_path}", flush=True)
+    finally:
+        cleanup_dist()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/straggler/straggler_smoke.py
+++ b/tools/straggler/straggler_smoke.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import argparse
 import os
-from pathlib import Path
 import socket
 import time
+from pathlib import Path
 
 import torch
 import torch.distributed as dist


### PR DESCRIPTION
### PR Category
Train

### PR Types
New Features

### PR Description
Straggler Detection is used to monitor the performance of each node and GPU during distributed training, and to detect whether there are any “stragglers” (i.e., workers that are significantly slower than others). If a GPU or node runs noticeably slower, it will become a bottleneck and slow down the overall distributed training process.

#### Quick Start
Single-node example (using GPT-2)

When running run.py, enable the Straggler Detection feature by overriding system configuration parameters:
```
python run.py \
  --config-path ./examples/gpt2/conf \
  --config-name train_single \
  action=run \
  +train.system.enable_straggler_detection=true \
  +train.system.straggler_profiling_interval=5 \
  +train.system.straggler_report_interval=10 \
  +train.system.straggler_log_dir=./outputs_gpt2/logs/straggler
```
Multi-node example (2 nodes × 4 GPUs)

The multi-node setup is similar to the single-node case. You just need to additionally specify parameters such as hostfile and the master node address in the runner configuration:
```
python run.py \
  --config-path ./examples/gpt2/conf \
  --config-name train_single \
  action=run \
  +train.system.enable_straggler_detection=true \
  +train.system.straggler_profiling_interval=5 \
  +train.system.straggler_report_interval=10 \
  +train.system.straggler_log_dir=./outputs_gpt2/logs/straggler
```
Note

The program automatically identifies the physical machine where each rank is located (by retrieving the node name via os.environ.get('HOSTNAME') or socket.gethostname()).

#### Core Configuration Parameters

These parameters can be overridden via the command line (as shown above) or modified in the YAML configuration file:

- `enable_straggler_detection` (bool): Whether to enable Straggler detection (default: False).
- `straggler_profiling_interval` (int): Profiling interval, i.e., how many steps between recording runtime statistics (default: 10).
- `straggler_report_interval` (int): Reporting interval, i.e., how many steps between generating and saving a statistical analysis report (default: 100).
- `straggler_threshold` (float): Relative latency threshold for identifying a straggler. For example, 1.5 means a node is considered a straggler if it is 50% slower or more than the fastest node (default: 1.5).
- `straggler_log_dir` (str): Directory where Straggler JSON report files are saved.

#### Interpreting Output Reports

When the configured straggler_report_interval is reached:

A text-based report is printed to the console on Rank 0.
A JSON report file is periodically generated in the specified straggler_log_dir.

1. Console Output Example
```
=== Straggler Report at Step 10 ===

✓ No stragglers detected.

Section Timings (ms):

  optimizer:
    Min: 9.17ms, Max: 10.12ms, Avg: 9.55ms, Slowdown: 1.10x
    Rank 0: 9.98ms
    Rank 1: 10.12ms
    ...

  forward_backward:
    Min: 281.94ms, Max: 343.19ms, Avg: 314.23ms, Slowdown: 1.22x
    Rank 0: 343.19ms
    Rank 1: 341.51ms
    ...

GPU Performance Scores (higher = faster):
  Rank 0 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 2.9138
  Rank 1 (p-phy-zy-daxing-kt-lc-a800-node-prod-15-128): 2.9282
  ...
```
2. JSON Report Format

A file such as straggler_report_step_10.json contains detailed aggregated data:
```
{
  "step": 10,
  "section_scores": {
    "optimizer": {
      "0": 0.004562,
      "1": 0.004560
    },
    "forward_backward": {
      "0": 0.391165,
      "1": 0.391496
    }
  },
  "comm_stats": {},
  "gpu_scores": {
    "0": 2.556464,
    "1": 2.554298
  },
  "straggler_ranks": [],
  "node_names": {
    "0": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128",
    "1": "p-phy-zy-daxing-kt-lc-a800-node-prod-15-128"
  },
  "timestamp": 1764885816.7089095
}
```
JSON Field Descriptions

- step: The iteration/step index at which the report is generated.
- section_scores: Average execution time (in seconds) for each rank (i.e., GPU/node) across specific code sections (e.g., forward_backward, optimizer).
- gpu_scores: Aggregated GPU performance scores, computed based on inverse execution times of different sections.
Higher values indicate better performance.
- straggler_ranks: Ranks identified as severe stragglers based on the threshold. [] → no stragglers detected
e.g., [2, 7] → these ranks are significantly slower
- node_names: Mapping from rank to machine hostname. This is critical for diagnosing issues in multi-node multi-GPU training, as it pinpoints which server a problematic rank resides on.
- timestamp: Timestamp when the report was generated.

#### Custom Monitoring (for Advanced / Secondary Development)

In addition to the default monitored sections (forward_backward and optimizer), users can instrument custom code regions for profiling.

Use case:
If you implement complex logic (e.g., custom loss functions or data preprocessing) and want to analyze its performance across GPUs or detect stragglers, you can manually instrument the code as follows:
```
from flagscale.runner.straggler import get_fs_straggler_detector
import time

fs_straggler = get_fs_straggler_detector()

# Start
if fs_straggler is not None and fs_straggler.should_profile():
    my_section_start = time.perf_counter()
    
# ... your code logic ...

# Stop & Profiling
if fs_straggler is not None and fs_straggler.should_profile():
    my_section_end = time.perf_counter()
    fs_straggler.record_section(
        name="my_custom_processing",
        cpu_time=my_section_end - my_section_start
    )
```
Alternatively, you can use lower-level utilities such as SectionContext or decorators.

The recorded section data will be collected and reported when the report_interval is reached.