### PR TITLE
Fix DeepSeek-V3 checkpoint export compatibility

### DIFF
--- a/tools/checkpoint/convert.py
+++ b/tools/checkpoint/convert.py
@@ -64,6 +64,14 @@ def main():
     parser.add_argument(
         "--max-queue-size", type=int, default=50, help="Maximum number of tensors in the queue"
     )
+    parser.add_argument(
+        "--skip-mtp",
+        action="store_true",
+        help=(
+            "Skip Multi-Token Prediction (MTP) modules during conversion. "
+            "Use this when the target implementation only contains the main LM layers."
+        ),
+    )
 
     extend_cases = [["mistral", "mixtral"]]
 

--- a/tools/checkpoint/deepseek_v3/args.py
+++ b/tools/checkpoint/deepseek_v3/args.py
@@ -23,7 +23,7 @@ def load_args_hf2mg(args):
     args.swiglu = True if hidden_act == "silu" else False
     args.max_position_embeddings = deepseek_v3_args["max_position_embeddings"]
     args.init_method_std = deepseek_v3_args["initializer_range"]
-    args.norm_epsilon = deepseek_v3_args["rms_norm_eps"]
+    args.layernorm_epsilon = deepseek_v3_args["rms_norm_eps"]
     args.untie_embeddings_and_output_weights = not deepseek_v3_args["tie_word_embeddings"]
     args.rotary_base = deepseek_v3_args["rope_theta"]
     args.disable_bias_linear = not deepseek_v3_args["attention_bias"]
@@ -93,13 +93,14 @@ def load_args_hf2mg(args):
 def save_args_mg2hf(args):
     first_k_dense_replace = args.moe_layer_freq.index(1)
     seq_aux = True if args.moe_router_load_balancing_type == "seq_aux_loss" else False
+    mtp_num_layers = getattr(args, "mtp_num_layers", 0) or 0
     config = DeepseekV3Config(
         vocab_size=args.vocab_size,
         hidden_size=args.hidden_size,
         intermediate_size=args.ffn_hidden_size,
         moe_intermediate_size=args.moe_ffn_hidden_size,
         num_hidden_layers=args.num_layers,
-        num_nextn_predict_layers=args.mtp_num_layers,
+        num_nextn_predict_layers=mtp_num_layers,
         num_attention_heads=args.num_attention_heads,
         num_key_value_heads=args.num_query_groups,
         n_shared_experts=args.moe_shared_expert_intermediate_size // args.moe_ffn_hidden_size,
@@ -118,7 +119,7 @@ def save_args_mg2hf(args):
         seq_aux=seq_aux,
         max_position_embeddings=args.max_position_embeddings,
         initializer_range=args.init_method_std,
-        rms_norm_eps=args.norm_epsilon,
+        rms_norm_eps=args.layernorm_epsilon,
         tie_word_embeddings=not args.untie_embeddings_and_output_weights,
         rope_theta=args.rotary_base,
         attention_dropout=args.attention_dropout,

--- a/tools/checkpoint/deepseek_v3/ckpt.py
+++ b/tools/checkpoint/deepseek_v3/ckpt.py
@@ -8,7 +8,14 @@ from mixtral.ckpt import (  # noqa: F401
     set_hf_final_norm_ckpt,
     set_hf_output_layer_ckpt,
 )
-from utils import padding_vocab_size
+from utils import (
+    get_expert_tensor_parallel_model_groups,
+    get_expert_tensor_parallel_models,
+    get_expert_tensor_parallel_size,
+    get_tensor_model_parallel_rank,
+    get_tensor_parallel_models,
+    padding_vocab_size,
+)
 
 
 def _get_parallel_size(args):
@@ -103,7 +110,7 @@ def set_embedding_ckpt(message, models, md, args):
     # process world embedding in first pp stage
     out_word_embed = torch.chunk(full_word_embed, tp_size, dim=0)
     for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
+        tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
         model.embedding.word_embeddings.weight.data.copy_(out_word_embed[tp_rank])
         if pos_embed is not None:
             model.embedding.position_embeddings.weight.data.copy_(pos_embed)
@@ -134,7 +141,7 @@ def set_attn_ckpt(message, models, layer_id, md, args):
 
     # set data to transformer layer's self-attention
     for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
+        tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
         if hasattr(model, "decoder"):
             tf_layer = model.decoder.layers[layer_id]
         else:
@@ -174,7 +181,7 @@ def set_dense_mlp_ckpt(message, models, layer_id, md, args):
     linear2_weight = torch.chunk(message.pop("down weight"), tp_size, dim=1)
 
     for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
+        tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
         if hasattr(model, "decoder"):
             tf_layer = model.decoder.layers[layer_id]
         else:
@@ -186,6 +193,7 @@ def set_dense_mlp_ckpt(message, models, layer_id, md, args):
 
 def set_moe_mlp_ckpt(message, models, layer_id, md, args):
     tp_size, _, ep_size, _ = _get_parallel_size(args)
+    etp_size = get_expert_tensor_parallel_size(args)
 
     assert args.num_experts is not None, "deepseeks's num_experts cannot be None"
     assert md.previous_num_experts is not None
@@ -211,53 +219,60 @@ def set_moe_mlp_ckpt(message, models, layer_id, md, args):
         message.pop("shared expert down weight"), tp_size, dim=1
     )
 
-    # if not args.moe_grouped_gemm:
+    for rank_id, model in enumerate(models):
+        tp_rank = get_tensor_model_parallel_rank(rank_id, args)
+        if hasattr(model, "decoder"):
+            tf_layer = model.decoder.layers[layer_id]
+        else:
+            tf_layer = model.transformer_layer  # for mtp
+
+        router = tf_layer.mlp.router
+        router.weight.data.copy_(router_weight)
+        if use_router_expert_bias:
+            router.expert_bias.data.copy_(router_expert_bias)
+
+        shared_expert = tf_layer.mlp.shared_experts
+        shared_expert.linear_fc1.weight.data.copy_(shared_expert_linear1_weight[tp_rank])
+        shared_expert.linear_fc2.weight.data.copy_(shared_expert_linear2_weight[tp_rank])
+
     num_local_experts = md.previous_num_experts // ep_size
     for expert_id in range(num_local_experts):
         for ep_rank in range(ep_size):
             global_expert_id = ep_rank * num_local_experts + expert_id
             # weight
             gate_weight = torch.chunk(
-                message.pop(f"expert{global_expert_id} gate weight"), tp_size, dim=0
+                message.pop(f"expert{global_expert_id} gate weight"), etp_size, dim=0
             )
             up_weight = torch.chunk(
-                message.pop(f"expert{global_expert_id} up weight"), tp_size, dim=0
+                message.pop(f"expert{global_expert_id} up weight"), etp_size, dim=0
             )
             linear1_weight = [torch.cat(weights, dim=0) for weights in zip(gate_weight, up_weight)]
             linear2_weight = torch.chunk(
-                message.pop(f"expert{global_expert_id} down weight"), tp_size, dim=1
+                message.pop(f"expert{global_expert_id} down weight"), etp_size, dim=1
             )
 
             # set data
-            for tp_rank in range(tp_size):
-                tp_ep_rank = ep_rank * tp_size + tp_rank
-                if hasattr(models[tp_ep_rank], "decoder"):
-                    tf_layer = models[tp_ep_rank].decoder.layers[layer_id]
-                else:
-                    tf_layer = models[tp_ep_rank].transformer_layer  # for mtp
-                # router
-                router = tf_layer.mlp.router
-                router.weight.data.copy_(router_weight)
-                if use_router_expert_bias:
-                    router.expert_bias.data.copy_(router_expert_bias)
-                # shared expert
-                shared_expert = tf_layer.mlp.shared_experts
-                shared_expert.linear_fc1.weight.data.copy_(shared_expert_linear1_weight[tp_rank])
-                shared_expert.linear_fc2.weight.data.copy_(shared_expert_linear2_weight[tp_rank])
-                # routed expert
-                if not args.moe_grouped_gemm:
-                    expert = tf_layer.mlp.experts.local_experts[expert_id]
-                    expert.linear_fc1.weight.data.copy_(linear1_weight[tp_rank])
-                    expert.linear_fc2.weight.data.copy_(linear2_weight[tp_rank])
-                else:  # using TEGroupedMLP
-                    expert_linear_fc1_weight = getattr(
-                        tf_layer.mlp.experts.linear_fc1, f"weight{expert_id}", None
-                    )
-                    expert_linear_fc2_weight = getattr(
-                        tf_layer.mlp.experts.linear_fc2, f"weight{expert_id}", None
-                    )
-                    expert_linear_fc1_weight.data.copy_(linear1_weight[tp_rank])
-                    expert_linear_fc2_weight.data.copy_(linear2_weight[tp_rank])
+            etp_model_groups = get_expert_tensor_parallel_model_groups(models, args, ep_rank)
+            for etp_rank, model_group in enumerate(etp_model_groups):
+                for model in model_group:
+                    if hasattr(model, "decoder"):
+                        tf_layer = model.decoder.layers[layer_id]
+                    else:
+                        tf_layer = model.transformer_layer  # for mtp
+
+                    if not args.moe_grouped_gemm:
+                        expert = tf_layer.mlp.experts.local_experts[expert_id]
+                        expert.linear_fc1.weight.data.copy_(linear1_weight[etp_rank])
+                        expert.linear_fc2.weight.data.copy_(linear2_weight[etp_rank])
+                    else:  # using TEGroupedMLP
+                        expert_linear_fc1_weight = getattr(
+                            tf_layer.mlp.experts.linear_fc1, f"weight{expert_id}", None
+                        )
+                        expert_linear_fc2_weight = getattr(
+                            tf_layer.mlp.experts.linear_fc2, f"weight{expert_id}", None
+                        )
+                        expert_linear_fc1_weight.data.copy_(linear1_weight[etp_rank])
+                        expert_linear_fc2_weight.data.copy_(linear2_weight[etp_rank])
 
 
 def set_final_norm_ckpt(message, models, md, args):
@@ -273,7 +288,7 @@ def set_output_layer_ckpt(message, models, md, args):
     full_output_layer_weight = padding_vocab_size(orig_output_layer_weight, md, args)
     output_layer_weight = torch.chunk(full_output_layer_weight, tp_size, dim=0)
     for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
+        tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
         model.output_layer.weight.data.copy_(output_layer_weight[tp_rank])
 
 
@@ -295,7 +310,7 @@ def set_mtp_ckpt(message, models, md, mtp_layer_id, args):
     mtp_eh_weight = torch.chunk(message.pop("mtp eh weight"), tp_size, dim=0)
     mtp_shared_head_norm_weight = message.pop("mtp shared head norm weight")
     for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
+        tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
         mtp_layer = model.mtp.layers[mtp_layer_id]
         mtp_layer.enorm.weight.data.copy_(mtp_enorm_weight)
         mtp_layer.hnorm.weight.data.copy_(mtp_hnorm_weight)
@@ -308,12 +323,7 @@ def get_embedding_ckpt(message, models, args):
     tp_size, _, _, _ = _get_parallel_size(args)
 
     word_embeddings = []
-    complete_tp_ranks = []
-    for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
-        if tp_rank in complete_tp_ranks:
-            continue
-        complete_tp_ranks.append(tp_rank)
+    for model in get_tensor_parallel_models(models, args):
         word_embeddings.append(model.embedding.word_embeddings.weight.data)
     message["word embeddings"] = torch.cat(word_embeddings, dim=0)
 
@@ -335,13 +345,7 @@ def get_attn_ckpt(message, models, layer_id, args):
     post_norm_weight = None
 
     first_k_dense_replace = args.moe_layer_freq.index(1)
-    complete_tp_ranks = []
-    for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
-        if tp_rank in complete_tp_ranks:
-            continue
-        complete_tp_ranks.append(tp_rank)
-
+    for model in get_tensor_parallel_models(models, args):
         if hasattr(model, "decoder"):
             tf_layer = model.decoder.layers[layer_id]
         else:
@@ -397,13 +401,7 @@ def get_dense_mlp_ckpt(message, models, layer_id, args):
     linear1_weight = []
     linear2_weight = []
 
-    complete_tp_ranks = []
-    for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
-        if tp_rank in complete_tp_ranks:
-            continue
-        complete_tp_ranks.append(tp_rank)
-
+    for model in get_tensor_parallel_models(models, args):
         if hasattr(model, "decoder"):
             tf_layer = model.decoder.layers[layer_id]
         else:
@@ -424,42 +422,63 @@ def get_dense_mlp_ckpt(message, models, layer_id, args):
 
 def get_moe_mlp_ckpt(message, models, layer_id, args):
     tp_size, _, ep_size, _ = _get_parallel_size(args)
+    etp_size = get_expert_tensor_parallel_size(args)
 
     assert args.num_experts is not None and args.num_experts % ep_size == 0
     num_local_experts = args.num_experts // ep_size
+
+    shared_expert_linear1_weight = []
+    shared_expert_linear2_weight = []
+    use_router_expert_bias = False
+    router_weight = None
+    router_expert_bias = None
+    for model in get_tensor_parallel_models(models, args):
+        if hasattr(model, "decoder"):
+            tf_layer = model.decoder.layers[layer_id]
+        else:
+            tf_layer = model.transformer_layer  # for mtp
+
+        router = tf_layer.mlp.router
+        router_weight = router.weight.data
+        if hasattr(router, "expert_bias"):
+            use_router_expert_bias = True
+            router_expert_bias = router.expert_bias.data
+
+        shared_expert = tf_layer.mlp.shared_experts
+        shared_expert_linear1_weight.append(shared_expert.linear_fc1.weight.data)
+        shared_expert_linear2_weight.append(shared_expert.linear_fc2.weight.data)
+
+    message["router weight"] = router_weight
+    if use_router_expert_bias:
+        message["router expert bias"] = router_expert_bias
+
+    for tp_rank in range(tp_size):
+        shared_expert_linear1_weight[tp_rank] = torch.chunk(
+            shared_expert_linear1_weight[tp_rank], 2, dim=0
+        )
+
+    message["shared expert gate weight"] = torch.cat(
+        [w[0] for w in shared_expert_linear1_weight], dim=0
+    )
+    message["shared expert up weight"] = torch.cat(
+        [w[1] for w in shared_expert_linear1_weight], dim=0
+    )
+    message["shared expert down weight"] = torch.cat(shared_expert_linear2_weight, dim=1)
 
     for expert_id in range(num_local_experts):
         for ep_rank in range(ep_size):
             global_expert_id = num_local_experts * ep_rank + expert_id
 
             # parallel tensor
-            shared_expert_linear1_weight = []
-            shared_expert_linear2_weight = []
             expert_linear1_weight = []
             expert_linear2_weight = []
-            # non parallel tensor
-            router_weight = None
-            router_expert_bias = None
 
             # local experts
-            use_router_expert_bias = False
-            for tp_rank in range(tp_size):
-                tp_ep_rank = ep_rank * tp_size + tp_rank
-                if hasattr(models[tp_ep_rank], "decoder"):
-                    tf_layer = models[tp_ep_rank].decoder.layers[layer_id]
+            for model in get_expert_tensor_parallel_models(models, args, ep_rank):
+                if hasattr(model, "decoder"):
+                    tf_layer = model.decoder.layers[layer_id]
                 else:
-                    tf_layer = models[tp_ep_rank].transformer_layer  # for mtp
-
-                # router
-                router = tf_layer.mlp.router
-                router_weight = router.weight.data
-                if hasattr(router, "expert_bias"):
-                    use_router_expert_bias = True
-                    router_expert_bias = router.expert_bias.data
-                # shared experts
-                shared_expert = tf_layer.mlp.shared_experts
-                shared_expert_linear1_weight.append(shared_expert.linear_fc1.weight.data)
-                shared_expert_linear2_weight.append(shared_expert.linear_fc2.weight.data)
+                    tf_layer = model.transformer_layer  # for mtp
 
                 # routed experts
                 if not args.moe_grouped_gemm:
@@ -478,25 +497,11 @@ def get_moe_mlp_ckpt(message, models, layer_id, args):
                         ).detach()
                     )
 
-            message["router weight"] = router_weight
-            if use_router_expert_bias:
-                message["router expert bias"] = router_expert_bias
-
-            for tp_rank in range(tp_size):
-                shared_expert_linear1_weight[tp_rank] = torch.chunk(
-                    shared_expert_linear1_weight[tp_rank], 2, dim=0
-                )
-                expert_linear1_weight[tp_rank] = torch.chunk(
-                    expert_linear1_weight[tp_rank], 2, dim=0
+            for etp_rank in range(etp_size):
+                expert_linear1_weight[etp_rank] = torch.chunk(
+                    expert_linear1_weight[etp_rank], 2, dim=0
                 )
 
-            message["shared expert gate weight"] = torch.cat(
-                [w[0] for w in shared_expert_linear1_weight], dim=0
-            )
-            message["shared expert up weight"] = torch.cat(
-                [w[1] for w in shared_expert_linear1_weight], dim=0
-            )
-            message["shared expert down weight"] = torch.cat(shared_expert_linear2_weight, dim=1)
             message[f"expert{global_expert_id} gate weight"] = torch.cat(
                 [w[0] for w in expert_linear1_weight], dim=0
             )
@@ -516,12 +521,7 @@ def get_output_layer_ckpt(message, models, args):
     tp_size, _, _, _ = _get_parallel_size(args)
 
     output_layer_weight = []
-    complete_tp_ranks = []
-    for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
-        if tp_rank in complete_tp_ranks:
-            continue
-        complete_tp_ranks.append(tp_rank)
+    for model in get_tensor_parallel_models(models, args):
         output_layer_weight.append(model.output_layer.weight.data)
     message["weight"] = torch.cat(output_layer_weight, dim=0)
 
@@ -539,13 +539,7 @@ def get_mtp_ckpt(message, models, mtp_layer_id, args):
     get_moe_mlp_ckpt(message, mtp_layers, 0, args)
 
     mtp_eh_weight = []
-    complete_tp_ranks = []
-    for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
-        if tp_rank in complete_tp_ranks:
-            continue
-        complete_tp_ranks.append(tp_rank)
-
+    for model in get_tensor_parallel_models(models, args):
         mtp_layer = model.mtp.layers[mtp_layer_id]
         mtp_enorm_weight = mtp_layer.enorm.weight.data
         mtp_hnorm_weight = mtp_layer.hnorm.weight.data

--- a/tools/checkpoint/loader_mcore.py
+++ b/tools/checkpoint/loader_mcore.py
@@ -50,7 +50,14 @@ def _load_checkpoint(queue, args):
                 get_cuda_rng_tracker, _DATA_PARALLEL_RNG_TRACKER_NAME,
                 _EXPERT_PARALLEL_RNG_TRACKER_NAME, _MODEL_PARALLEL_RNG_TRACKER_NAME
             )
-        from tools.checkpoint.utils import _ConverterFakeProcessGroup
+        from tools.checkpoint.utils import (
+            _ConverterFakeProcessGroup,
+            get_expert_model_parallel_rank,
+            get_expert_tensor_parallel_rank,
+            get_mcore_model_parallel_size,
+            get_tensor_model_parallel_rank,
+            validate_mcore_parallel_size,
+        )
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         queue.put("exit")
@@ -153,7 +160,7 @@ def _load_checkpoint(queue, args):
 
     # Arguments do sanity checks on the world size, but we don't care,
     # so trick it into thinking we are plenty of processes
-    margs.world_size = margs.tensor_model_parallel_size * margs.pipeline_model_parallel_size * margs.expert_model_parallel_size
+    margs.world_size = get_mcore_model_parallel_size(margs) * margs.pipeline_model_parallel_size
 
     # Explicitly copy data types from checkpoint.
     margs.fp16 = checkpoint_args.fp16
@@ -175,6 +182,7 @@ def _load_checkpoint(queue, args):
 
     print("*"*20 + "validate loader arguments" + "*"*20)
     margs = validate_args(margs)
+    validate_mcore_parallel_size(margs)
 
     def check_for_arg(arg_name, default=None):
         if getattr(margs, arg_name, None) is None:
@@ -229,14 +237,20 @@ def _load_checkpoint(queue, args):
     tp_size = margs.tensor_model_parallel_size
     pp_size = margs.pipeline_model_parallel_size
     ep_size = margs.expert_model_parallel_size
+    etp_size = margs.expert_tensor_parallel_size
+    mcore_model_parallel_size = get_mcore_model_parallel_size(margs)
     vp_size = margs.virtual_pipeline_model_parallel_size or 1
     mpu.set_tensor_model_parallel_world_size(tp_size)
     mpu.set_pipeline_model_parallel_world_size(pp_size)
     mpu.set_expert_model_parallel_world_size(ep_size)
+    if hasattr(mpu, "set_expert_tensor_parallel_world_size"):
+        mpu.set_expert_tensor_parallel_world_size(etp_size)
     mpu.set_virtual_pipeline_model_parallel_world_size(margs.virtual_pipeline_model_parallel_size)
     mpu.set_tensor_model_parallel_rank(0)
     mpu.set_pipeline_model_parallel_rank(0)
     mpu.set_expert_model_parallel_rank(0)
+    if hasattr(mpu, "set_expert_tensor_parallel_rank"):
+        mpu.set_expert_tensor_parallel_rank(0)
     mpu.set_virtual_pipeline_model_parallel_rank(0)
     # For backward compatibility during local parallel states refactoring
     fake_tp_group = _ConverterFakeProcessGroup(size=tp_size)
@@ -247,10 +261,10 @@ def _load_checkpoint(queue, args):
     fake_pp_group = _ConverterFakeProcessGroup(size=margs.pipeline_model_parallel_size)
     fake_cp_group = _ConverterFakeProcessGroup(size=margs.context_parallel_size)
     fake_dp_group = _ConverterFakeProcessGroup(size=margs.data_parallel_size)
-    fake_etp_group = _ConverterFakeProcessGroup(size=margs.expert_tensor_parallel_size)
-    edp_parallel_size = margs.tensor_model_parallel_size * margs.context_parallel_size // (margs.expert_tensor_parallel_size * margs.expert_model_parallel_size)
+    fake_etp_group = _ConverterFakeProcessGroup(size=etp_size)
+    edp_parallel_size = mcore_model_parallel_size // (etp_size * ep_size)
     fake_edp_group = _ConverterFakeProcessGroup(size=edp_parallel_size)
-    fake_etp_ep_group = _ConverterFakeProcessGroup(size=margs.expert_tensor_parallel_size*margs.expert_model_parallel_size)
+    fake_etp_ep_group = _ConverterFakeProcessGroup(size=etp_size * ep_size)
     fake_tcp_group = _ConverterFakeProcessGroup(size=margs.tensor_model_parallel_size*margs.context_parallel_size)
     mpu._PIPELINE_MODEL_PARALLEL_GROUP = fake_pp_group
     mpu._CONTEXT_PARALLEL_GROUP = fake_cp_group
@@ -259,7 +273,7 @@ def _load_checkpoint(queue, args):
     mpu._EXPERT_DATA_PARALLEL_GROUP = fake_edp_group
     mpu._EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP = fake_etp_ep_group
     mpu._TENSOR_AND_CONTEXT_PARALLEL_GROUP = fake_tcp_group
-    mpu._EXPERT_TENSOR_PARALLEL_GROUP = fake_tp_group
+    mpu._EXPERT_TENSOR_PARALLEL_GROUP = fake_etp_group
     mpu._DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
     mpu._INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
     mpu._LAST_RANK_WHEN_USING_PIPELINE = pp_size - 1
@@ -293,6 +307,7 @@ def _load_checkpoint(queue, args):
     md.previous_tensor_parallel_size = margs.tensor_model_parallel_size
     md.previous_pipeline_parallel_size = margs.pipeline_model_parallel_size
     md.previous_expert_parallel_size = margs.expert_model_parallel_size
+    md.previous_expert_tensor_parallel_size = margs.expert_tensor_parallel_size
     md.previous_decoder_first_pipeline_num_layers = margs.decoder_first_pipeline_num_layers
     md.true_vocab_size = args.true_vocab_size # true (non-padded) vocab size
     md.make_vocab_size_divisible_by = margs.make_vocab_size_divisible_by
@@ -304,16 +319,22 @@ def _load_checkpoint(queue, args):
         # for one pp stage
         nonlocal consumed_train_samples
         nonlocal consumed_valid_samples
-        tp_size = margs.tensor_model_parallel_size
         pp_size = margs.pipeline_model_parallel_size
         vp_size = margs.virtual_pipeline_model_parallel_size or 1
 
         models = [[] for _ in range(vp_size)]
         for rank_id in range(count):
-            tp_rank = rank_id % tp_size
-            ep_rank = rank_id // tp_size
+            tp_rank = get_tensor_model_parallel_rank(rank_id, margs)
+            ep_rank = get_expert_model_parallel_rank(rank_id, margs)
+            etp_rank = get_expert_tensor_parallel_rank(rank_id, margs)
             mpu.set_tensor_model_parallel_rank(tp_rank)
             mpu.set_expert_model_parallel_rank(ep_rank)
+            if hasattr(mpu, "set_expert_tensor_parallel_rank"):
+                mpu.set_expert_tensor_parallel_rank(etp_rank)
+            fake_tp_group.set_rank(tp_rank)
+            fake_ep_group.set_rank(ep_rank)
+            fake_etp_group.set_rank(etp_rank)
+            fake_etp_ep_group.set_rank(ep_rank * etp_size + etp_rank)
             if pp_size > 1 and vp_size > 1:
                 model_ = []
                 for vp_rank in range(vp_size):
@@ -355,7 +376,7 @@ def _load_checkpoint(queue, args):
     mpu.set_pipeline_model_parallel_rank(0)
     fake_pp_group = _ConverterFakeProcessGroup(rank=0, size=pp_size)
     mpu._PIPELINE_MODEL_PARALLEL_GROUP = fake_pp_group
-    all_models = [get_models(tp_size * ep_size, margs.params_dtype)]
+    all_models = [get_models(mcore_model_parallel_size, margs.params_dtype)]
     models = all_models[0][0] # pp0vpp0
 
     md.consumed_train_samples = consumed_train_samples
@@ -381,7 +402,7 @@ def _load_checkpoint(queue, args):
             mpu._PIPELINE_MODEL_PARALLEL_GROUP = fake_pp_group
 
             if pp_rank > 0 and vp_rank == 0:
-                all_models.append(get_models(tp_size * ep_size, margs.params_dtype))
+                all_models.append(get_models(mcore_model_parallel_size, margs.params_dtype))
 
             models = all_models[pp_rank][vp_rank]
             for layer_id in range(len(models[0].decoder.layers)):

--- a/tools/checkpoint/loader_mcore.py
+++ b/tools/checkpoint/loader_mcore.py
@@ -46,7 +46,6 @@ def _load_checkpoint(queue, args):
         from megatron.training.checkpointing import load_args_from_checkpoint, load_checkpoint
         from megatron.legacy.model import module
         from megatron.core import mpu
-        from megatron.legacy import fused_kernels
         from megatron.core.tensor_parallel.random import (
                 get_cuda_rng_tracker, _DATA_PARALLEL_RNG_TRACKER_NAME,
                 _EXPERT_PARALLEL_RNG_TRACKER_NAME, _MODEL_PARALLEL_RNG_TRACKER_NAME
@@ -78,7 +77,6 @@ def _load_checkpoint(queue, args):
         '--no-masked-softmax-fusion',
         '--no-bias-gelu-fusion',
         '--no-bias-dropout-fusion',
-        '--no-async-tensor-model-parallel-allreduce',
         '--use-cpu-initialization',
         '--micro-batch-size', '1',
         '--no-load-optim',
@@ -125,20 +123,27 @@ def _load_checkpoint(queue, args):
     _set_arg("hetero_pipeline_layer_split")
 
     # for engram
-    _set_arg("use_engram")
-    _set_arg("engram_layer_ids")
-    _set_arg("engram_hc_mult")
-    _set_arg("engram_kernel_size")
-    _set_arg("engram_pad_id")
-    _set_arg("engram_seed")
-    _set_arg("engram_vocab_size")
-    _set_arg("engram_tokenizer_name_or_path")
-    _set_arg("max_ngram_size")
-    _set_arg("n_embed_per_ngram")
-    _set_arg("n_head_per_ngram")
-    setattr(margs, "vocab_size", args.true_vocab_size)
-    engram_tokenizer_path_ckpt = getattr(checkpoint_args, "engram_tokenizer_name_or_path", None)
-    setattr(margs, "engram_tokenizer_name_or_path", os.path.join(root_path, engram_tokenizer_path_ckpt))
+    if getattr(checkpoint_args, "use_engram", False):
+        _set_arg("use_engram")
+        _set_arg("engram_layer_ids")
+        _set_arg("engram_hc_mult")
+        _set_arg("engram_kernel_size")
+        _set_arg("engram_pad_id")
+        _set_arg("engram_seed")
+        _set_arg("engram_vocab_size")
+        _set_arg("engram_tokenizer_name_or_path")
+        _set_arg("max_ngram_size")
+        _set_arg("n_embed_per_ngram")
+        _set_arg("n_head_per_ngram")
+        if args.true_vocab_size is not None:
+            setattr(margs, "vocab_size", args.true_vocab_size)
+        engram_tokenizer_path_ckpt = getattr(checkpoint_args, "engram_tokenizer_name_or_path", None)
+        if engram_tokenizer_path_ckpt and not os.path.isabs(engram_tokenizer_path_ckpt):
+            engram_tokenizer_path_ckpt = os.path.join(root_path, engram_tokenizer_path_ckpt)
+        setattr(margs, "engram_tokenizer_name_or_path", engram_tokenizer_path_ckpt)
+    else:
+        setattr(margs, "use_engram", False)
+        setattr(margs, "engram_layer_ids", [])
 
     # for hetero
     if margs.hetero_process_meshes is not None:
@@ -258,9 +263,6 @@ def _load_checkpoint(queue, args):
     mpu._DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
     mpu._INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
     mpu._LAST_RANK_WHEN_USING_PIPELINE = pp_size - 1
-
-    # fused kernel
-    fused_kernels.load(margs)
 
     # random
     CUDA_RNG_STATE_TRACKER = get_cuda_rng_tracker()
@@ -387,7 +389,9 @@ def _load_checkpoint(queue, args):
                 margs.total_layer_num = total_layer_num
 
                 engram_layer_id  = total_layer_num # get_global_layer_id
-                if margs.use_engram and engram_layer_id in margs.engram_layer_ids:
+                if getattr(margs, "use_engram", False) and engram_layer_id in getattr(
+                    margs, "engram_layer_ids", []
+                ):
                     ckpt_plugin.get_engram_ckpt(message, models, engram_layer_id, margs)
 
                 ckpt_plugin.get_attn_ckpt(message, models, layer_id, margs)
@@ -406,9 +410,11 @@ def _load_checkpoint(queue, args):
         ckpt_plugin.get_output_layer_ckpt(message, models, margs)
         queue_put("output layer", message)
 
-    message = dict()
-    if margs.mtp_num_layers:
-        for mtp_layer_id in range(margs.mtp_num_layers):
+    mtp_num_layers = getattr(margs, "mtp_num_layers", 0)
+    if getattr(args, "skip_mtp", False):
+        mtp_num_layers = 0
+    if mtp_num_layers:
+        for mtp_layer_id in range(mtp_num_layers):
             message = dict()
             ckpt_plugin.get_mtp_ckpt(message, models, mtp_layer_id, margs)
             queue_put(f"mtp module {mtp_layer_id}", message)

--- a/tools/checkpoint/loader_transformers.py
+++ b/tools/checkpoint/loader_transformers.py
@@ -73,7 +73,6 @@ def _load_checkpoint(queue, args):
         '--no-masked-softmax-fusion',
         '--no-bias-gelu-fusion',
         '--no-bias-dropout-fusion',
-        '--no-async-tensor-model-parallel-allreduce',
         '--use-cpu-initialization',
         '--micro-batch-size', '1',
         '--no-load-optim',
@@ -192,9 +191,11 @@ def _load_checkpoint(queue, args):
         message = {"weight": hf_model.lm_head.weight.data}
         queue_put("output layer", message)
 
-    message = dict()
-    if margs.mtp_num_layers:
-        for mtp_layer_id in range(margs.mtp_num_layers):
+    mtp_num_layers = getattr(margs, "mtp_num_layers", 0)
+    if getattr(args, "skip_mtp", False):
+        mtp_num_layers = 0
+    if mtp_num_layers:
+        for mtp_layer_id in range(mtp_num_layers):
             message = dict()
             ckpt_plugin.get_hf_mtp_ckpt(message, hf_model, mtp_layer_id, margs)
             queue_put(f"mtp module {mtp_layer_id}", message)

--- a/tools/checkpoint/mixtral/ckpt.py
+++ b/tools/checkpoint/mixtral/ckpt.py
@@ -3,7 +3,14 @@ import sys
 import torch
 
 sys.path.append("..")
-from utils import padding_vocab_size
+from utils import (
+    get_expert_tensor_parallel_model_groups,
+    get_expert_tensor_parallel_models,
+    get_expert_tensor_parallel_size,
+    get_tensor_model_parallel_rank,
+    get_tensor_parallel_models,
+    padding_vocab_size,
+)
 
 
 def get_hf_attn_ckpt(message, model, layer_id, args):
@@ -209,12 +216,7 @@ def get_embedding_ckpt(message, models, args):
     tp_size, _, _, _ = _get_parallel_size(args)
 
     word_embeddings = []
-    complete_tp_ranks = []
-    for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
-        if tp_rank in complete_tp_ranks:
-            continue
-        complete_tp_ranks.append(tp_rank)
+    for model in get_tensor_parallel_models(models, args):
         word_embeddings.append(model.embedding.word_embeddings.weight.data)
     message["word embeddings"] = torch.cat(word_embeddings, dim=0)
     if args.position_embedding_type == "learned_absolute":
@@ -237,13 +239,7 @@ def get_attn_ckpt(message, models, layer_id, args):
     post_norm_weight = None
     post_norm_bias = None
 
-    complete_tp_ranks = []
-    for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
-        if tp_rank in complete_tp_ranks:
-            continue
-        complete_tp_ranks.append(tp_rank)
-
+    for model in get_tensor_parallel_models(models, args):
         tf_layer = model.decoder.layers[layer_id]
         # weight
         qkv_weight.append(tf_layer.self_attention.linear_qkv.weight.data)
@@ -278,10 +274,16 @@ def get_attn_ckpt(message, models, layer_id, args):
 
 
 def get_mlp_ckpt(message, models, layer_id, args):
-    tp_size, _, ep_size, _ = _get_parallel_size(args)
+    _, _, ep_size, _ = _get_parallel_size(args)
+    etp_size = get_expert_tensor_parallel_size(args)
 
     assert args.num_experts is not None and args.num_experts % ep_size == 0
     num_local_experts = args.num_experts // ep_size
+    router_weight = (
+        get_tensor_parallel_models(models, args)[0].decoder.layers[layer_id].mlp.router.weight.data
+    )
+    message["router weight"] = router_weight
+
     for expert_id in range(num_local_experts):
         for ep_rank in range(ep_size):
             global_expert_id = num_local_experts * ep_rank + expert_id
@@ -292,26 +294,22 @@ def get_mlp_ckpt(message, models, layer_id, args):
             l1_weight = []
             # non-parallel tensor
             l1_bias = None
-            router_weight = None
-            for tp_rank in range(tp_size):
-                tp_ep_rank = ep_rank * tp_size + tp_rank
-                tf_layer = models[tp_ep_rank].decoder.layers[layer_id]
+            for model in get_expert_tensor_parallel_models(models, args, ep_rank):
+                tf_layer = model.decoder.layers[layer_id]
                 expert = tf_layer.mlp.experts.local_experts[expert_id]
                 # weight
                 l0_weight.append(expert.linear_fc1.weight.data)
                 l1_weight.append(expert.linear_fc2.weight.data)
-                router_weight = tf_layer.mlp.router.weight.data
                 # bias
                 if args.add_bias_linear:
                     l0_bias.append(expert.linear_fc1.bias.data)
                     l1_bias = expert.linear_fc2.bias.data
 
             # weight
-            message["router weight"] = router_weight
             message[f"expert{global_expert_id} l1 weight"] = torch.cat(l1_weight, dim=1)
             if args.swiglu:
-                for tp_rank in range(tp_size):
-                    l0_weight[tp_rank] = torch.chunk(l0_weight[tp_rank], 2, dim=0)
+                for etp_rank in range(etp_size):
+                    l0_weight[etp_rank] = torch.chunk(l0_weight[etp_rank], 2, dim=0)
                 message[f"expert{global_expert_id} l0 weight W"] = torch.cat(
                     [w[0] for w in l0_weight], dim=0
                 )
@@ -324,8 +322,8 @@ def get_mlp_ckpt(message, models, layer_id, args):
             if args.add_bias_linear:
                 message[f"expert{global_expert_id} l1 bias"] = l1_bias
                 if args.swiglu:
-                    for tp_rank in range(tp_size):
-                        l0_bias[tp_rank] = torch.chunk(l0_bias[tp_rank], 2, dim=0)
+                    for etp_rank in range(etp_size):
+                        l0_bias[etp_rank] = torch.chunk(l0_bias[etp_rank], 2, dim=0)
                     message[f"expert{global_expert_id} l0 bias W"] = torch.cat(
                         [b[0] for b in l0_bias], dim=0
                     )
@@ -345,12 +343,7 @@ def get_final_norm_ckpt(message, models, args):
 def get_output_layer_ckpt(message, models, args):
     tp_size, _, _, _ = _get_parallel_size(args)
     output_layer_weight = []
-    complete_tp_ranks = []
-    for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
-        if tp_rank in complete_tp_ranks:
-            continue
-        complete_tp_ranks.append(tp_rank)
+    for model in get_tensor_parallel_models(models, args):
         output_layer_weight.append(model.output_layer.weight.data)
     message["weight"] = torch.cat(output_layer_weight, dim=0)
 
@@ -367,7 +360,7 @@ def set_embedding_ckpt(message, models, md, args):
     # process world embedding in first pp stage
     out_word_embed = torch.chunk(full_word_embed, tp_size, dim=0)
     for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
+        tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
         model.embedding.word_embeddings.weight.data.copy_(out_word_embed[tp_rank])
         if pos_embed is not None:
             model.embedding.position_embeddings.weight.data.copy_(pos_embed)
@@ -397,7 +390,7 @@ def set_attn_ckpt(message, models, layer_id, md, args):
 
     # set data to transformer layer's self-attention
     for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
+        tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
         tf_layer = model.decoder.layers[layer_id]
         tf_layer.self_attention.linear_qkv.weight.data.copy_(qkv_weight[tp_rank])
         tf_layer.self_attention.linear_proj.weight.data.copy_(proj_weight[tp_rank])
@@ -417,60 +410,64 @@ def set_attn_ckpt(message, models, layer_id, md, args):
 
 def set_mlp_ckpt(message, models, layer_id, md, args):
     tp_size, _, ep_size, _ = _get_parallel_size(args)
+    etp_size = get_expert_tensor_parallel_size(args)
 
     assert args.num_experts is not None, "mixtral's num_experts cannot be None"
 
     if md.previous_num_experts is not None:
         router_weight = message.pop("router weight")
+        for model in models:
+            model.decoder.layers[layer_id].mlp.router.weight.data.copy_(router_weight)
+
         num_local_experts = md.previous_num_experts // ep_size
         for expert_id in range(num_local_experts):
             for ep_rank in range(ep_size):
                 global_expert_id = ep_rank * num_local_experts + expert_id
                 # weight
                 l1_weight = torch.chunk(
-                    message.pop(f"expert{global_expert_id} l1 weight"), tp_size, dim=1
+                    message.pop(f"expert{global_expert_id} l1 weight"), etp_size, dim=1
                 )
                 if md.swiglu:
                     l0_weight_W = torch.chunk(
-                        message.pop(f"expert{global_expert_id} l0 weight W"), tp_size, dim=0
+                        message.pop(f"expert{global_expert_id} l0 weight W"), etp_size, dim=0
                     )
                     l0_weight_V = torch.chunk(
-                        message.pop(f"expert{global_expert_id} l0 weight V"), tp_size, dim=0
+                        message.pop(f"expert{global_expert_id} l0 weight V"), etp_size, dim=0
                     )
                     l0_weight = [
                         torch.cat(weights, dim=0) for weights in zip(l0_weight_W, l0_weight_V)
                     ]
                 else:
                     l0_weight = torch.chunk(
-                        message.pop(f"expert{global_expert_id} l0 weight"), tp_size, dim=0
+                        message.pop(f"expert{global_expert_id} l0 weight"), etp_size, dim=0
                     )
                 # bias
                 if md.add_bias_linear:
                     l1_bias = message.pop(f"expert{global_expert_id} l1 bias")
                     if md.swiglu:
                         l0_bias_W = torch.chunk(
-                            message.pop(f"expert{global_expert_id} l0 bias W"), tp_size, dim=0
+                            message.pop(f"expert{global_expert_id} l0 bias W"), etp_size, dim=0
                         )
                         l0_bias_V = torch.chunk(
-                            message.pop(f"expert{global_expert_id} l0 bias V"), tp_size, dim=0
+                            message.pop(f"expert{global_expert_id} l0 bias V"), etp_size, dim=0
                         )
                         l0_bias = [torch.cat(bias, dim=0) for bias in zip(l0_bias_W, l0_bias_V)]
                     else:
                         l0_bias = torch.chunk(
-                            message.pop(f"expert{global_expert_id} l0 bias"), tp_size, dim=0
+                            message.pop(f"expert{global_expert_id} l0 bias"), etp_size, dim=0
                         )
 
                 # set data to transformer layer's self-attention
-                for tp_rank in range(tp_size):
-                    tp_ep_rank = ep_rank * tp_size + tp_rank
-                    tf_layer = models[tp_ep_rank].decoder.layers[layer_id]
-                    expert = tf_layer.mlp.experts.local_experts[expert_id]
-                    tf_layer.mlp.router.weight.data.copy_(router_weight)
-                    expert.linear_fc1.weight.data.copy_(l0_weight[tp_rank])
-                    expert.linear_fc2.weight.data.copy_(l1_weight[tp_rank])
-                    if md.add_bias_linear:
-                        expert.linear_fc1.bias.data.copy_(l0_bias[tp_rank])
-                        expert.linear_fc2.bias.data.copy_(l1_bias)
+                etp_model_groups = get_expert_tensor_parallel_model_groups(models, args, ep_rank)
+                for etp_rank, model_group in enumerate(etp_model_groups):
+                    for model in model_group:
+                        tf_layer = model.decoder.layers[layer_id]
+                        expert = tf_layer.mlp.experts.local_experts[expert_id]
+                        expert.linear_fc1.weight.data.copy_(l0_weight[etp_rank])
+                        expert.linear_fc2.weight.data.copy_(l1_weight[etp_rank])
+                        if md.add_bias_linear:
+                            expert.linear_fc1.bias.data.copy_(l0_bias[etp_rank])
+                            expert.linear_fc2.bias.data.copy_(l1_bias)
     else:
         # weight
         l1_weight = torch.chunk(message.pop("mlp l1 weight"), tp_size, dim=1)
@@ -494,7 +491,7 @@ def set_mlp_ckpt(message, models, layer_id, md, args):
         num_local_experts = args.num_experts // ep_size
         for expert_id in range(num_local_experts):
             for tp_ep_rank, model in enumerate(models):
-                tp_rank = tp_ep_rank % tp_size
+                tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
                 tf_layer = model.decoder.layers[layer_id]
                 expert = tf_layer.mlp.experts.local_experts[expert_id]
 
@@ -522,5 +519,5 @@ def set_output_layer_ckpt(message, models, md, args):
     full_output_layer_weight = padding_vocab_size(orig_output_layer_weight, md, args)
     output_layer_weight = torch.chunk(full_output_layer_weight, tp_size, dim=0)
     for tp_ep_rank, model in enumerate(models):
-        tp_rank = tp_ep_rank % tp_size
+        tp_rank = get_tensor_model_parallel_rank(tp_ep_rank, args)
         model.output_layer.weight.data.copy_(output_layer_weight[tp_rank])

--- a/tools/checkpoint/qwen2_5_vl/hf2mcore_qwen2.5_vl_convertor.sh
+++ b/tools/checkpoint/qwen2_5_vl/hf2mcore_qwen2.5_vl_convertor.sh
@@ -198,7 +198,6 @@ cmd="torchrun ${DISTRIBUTED_ARGS} hf2mcore_qwen2.5_vl.py \
     --num-attention-heads ${NUM_ATTN_HEADS} \
     --max-position-embeddings ${MAX_POSITION_EMBEDDINGS} \
     --seq-length 1 \
-    --no-async-tensor-model-parallel-allreduce \
     --tokenizer-type Qwen2VLTokenizer \
     --extra-vocab-size ${EXTRA_VOCAB_SIZE} \
     --no-bias-swiglu-fusion \

--- a/tools/checkpoint/qwen3_vl/hf2mcore_qwen3_vl_convertor.sh
+++ b/tools/checkpoint/qwen3_vl/hf2mcore_qwen3_vl_convertor.sh
@@ -233,7 +233,6 @@ cmd="torchrun ${DISTRIBUTED_ARGS} hf2mcore_qwen3_vl.py \
     --num-attention-heads ${NUM_ATTN_HEADS} \
     --max-position-embeddings ${MAX_POSITION_EMBEDDINGS} \
     --seq-length 1 \
-    --no-async-tensor-model-parallel-allreduce \
     --tokenizer-type Qwen2VLTokenizer \
     --extra-vocab-size ${EXTRA_VOCAB_SIZE} \
     --no-bias-swiglu-fusion \

--- a/tools/checkpoint/saver_mcore.py
+++ b/tools/checkpoint/saver_mcore.py
@@ -23,6 +23,9 @@ def add_arguments(parser):
     group.add_argument("--target-expert-parallel-size", type=int,
                       help='Target expert model parallel size, default to the expert parallel size '
                       'in the input checkpoint if provided by the loader, otherwise to 1.')
+    group.add_argument("--target-expert-tensor-parallel-size", type=int,
+                       help='Target expert tensor parallel size, default to the expert tensor parallel size '
+                       'in the input checkpoint if provided by the loader, otherwise to the target tensor parallel size.')
     group.add_argument("--target-num-experts", type=int, default=None,
                        help='Target num of experts, default to the num_experts in the input checkpoint'
                        'if provided by the loader, otherwise to None. NOTE: Do not support target_num_experts'
@@ -60,7 +63,14 @@ def save_checkpoint(queue, args):
                 get_cuda_rng_tracker, _DATA_PARALLEL_RNG_TRACKER_NAME,
                 _EXPERT_PARALLEL_RNG_TRACKER_NAME, _MODEL_PARALLEL_RNG_TRACKER_NAME
             )
-        from tools.checkpoint.utils import _ConverterFakeProcessGroup
+        from tools.checkpoint.utils import (
+            _ConverterFakeProcessGroup,
+            get_expert_model_parallel_rank,
+            get_expert_tensor_parallel_rank,
+            get_mcore_model_parallel_size,
+            get_tensor_model_parallel_rank,
+            validate_mcore_parallel_size,
+        )
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         queue.put("exit")
@@ -134,6 +144,12 @@ def save_checkpoint(queue, args):
                   "Default to 1.")
             args.target_expert_parallel_size = 1
 
+    if args.target_expert_tensor_parallel_size is None:
+        if hasattr(md, 'previous_expert_tensor_parallel_size'):
+            args.target_expert_tensor_parallel_size = md.previous_expert_tensor_parallel_size
+        else:
+            args.target_expert_tensor_parallel_size = args.target_tensor_parallel_size
+
     if args.target_num_experts is None:
         if hasattr(md, 'previous_num_experts'):
             args.target_num_experts = md.previous_num_experts
@@ -147,7 +163,11 @@ def save_checkpoint(queue, args):
         if args.target_num_experts > md.previous_num_experts:
             print(f"Warning: experts[{md.previous_num_experts}-{args.target_num_experts}] will be random initailized.")
 
-    os.environ["WORLD_SIZE"] = f'{args.target_tensor_parallel_size * args.target_pipeline_parallel_size * args.target_expert_parallel_size}'
+    target_model_parallel_size = max(
+        args.target_tensor_parallel_size,
+        args.target_expert_parallel_size * args.target_expert_tensor_parallel_size,
+    )
+    os.environ["WORLD_SIZE"] = f'{target_model_parallel_size * args.target_pipeline_parallel_size}'
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
 
     # We want all arguments to come from us
@@ -164,6 +184,7 @@ def save_checkpoint(queue, args):
         '--tensor-model-parallel-size', str(args.target_tensor_parallel_size),
         '--pipeline-model-parallel-size', str(args.target_pipeline_parallel_size),
         '--expert-model-parallel-size', str(args.target_expert_parallel_size),
+        '--expert-tensor-parallel-size', str(args.target_expert_tensor_parallel_size),
         '--context-parallel-size', '1',
         '--no-masked-softmax-fusion',
         '--no-bias-gelu-fusion',
@@ -218,7 +239,8 @@ def save_checkpoint(queue, args):
     if hasattr (md, 'checkpoint_args'):
         # These are arguments that we are either changing, or cause problems for validation if they are set
         # Note that some of these deal with T5 so will need to be changed if we support T5.
-        args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'expert_model_parallel_size', 'world_size', 'params_dtype',
+        args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'expert_model_parallel_size',
+                        'expert_tensor_parallel_size', 'world_size', 'params_dtype',
                         'num_layers_per_virtual_pipeline_stage', 'virtual_pipeline_model_parallel_size',
                         'masked_softmax_fusion', 'bias_gelu_fusion', 'bias_dropout_fusion',
                         'sequence_parallel',
@@ -261,6 +283,7 @@ def save_checkpoint(queue, args):
 
     print("*"*20 + "validate saver arguments" + "*"*20)
     validate_args(margs)
+    validate_mcore_parallel_size(margs)
 
     # Use M-core models & unset loaded paths.
     margs.use_legacy_models = False
@@ -315,15 +338,21 @@ def save_checkpoint(queue, args):
     tp_size = margs.tensor_model_parallel_size
     pp_size = margs.pipeline_model_parallel_size
     ep_size = margs.expert_model_parallel_size
+    etp_size = margs.expert_tensor_parallel_size
+    mcore_model_parallel_size = get_mcore_model_parallel_size(margs)
     vp_size = margs.virtual_pipeline_model_parallel_size
     if vp_size is not None and vp_size > 1:
         raise NotImplementedError("vpp-convert is not implemented")
     mpu.set_tensor_model_parallel_world_size(tp_size)
     mpu.set_pipeline_model_parallel_world_size(pp_size)
     mpu.set_expert_model_parallel_world_size(ep_size)
+    if hasattr(mpu, "set_expert_tensor_parallel_world_size"):
+        mpu.set_expert_tensor_parallel_world_size(etp_size)
     mpu.set_tensor_model_parallel_rank(0)
     mpu.set_pipeline_model_parallel_rank(0)
     mpu.set_expert_model_parallel_rank(0)
+    if hasattr(mpu, "set_expert_tensor_parallel_rank"):
+        mpu.set_expert_tensor_parallel_rank(0)
     # For backward compatibility during local parallel states refactoring
     fake_tp_group = _ConverterFakeProcessGroup(size=tp_size)
     fake_ep_group = _ConverterFakeProcessGroup(size=ep_size)
@@ -333,10 +362,10 @@ def save_checkpoint(queue, args):
     fake_pp_group = _ConverterFakeProcessGroup(size=margs.pipeline_model_parallel_size)
     fake_cp_group = _ConverterFakeProcessGroup(size=margs.context_parallel_size)
     fake_dp_group = _ConverterFakeProcessGroup(size=margs.data_parallel_size)
-    fake_etp_group = _ConverterFakeProcessGroup(size=margs.expert_tensor_parallel_size)
-    edp_parallel_size = margs.tensor_model_parallel_size * margs.context_parallel_size // (margs.expert_tensor_parallel_size * margs.expert_model_parallel_size)
+    fake_etp_group = _ConverterFakeProcessGroup(size=etp_size)
+    edp_parallel_size = mcore_model_parallel_size // (etp_size * ep_size)
     fake_edp_group = _ConverterFakeProcessGroup(size=edp_parallel_size)
-    fake_etp_ep_group = _ConverterFakeProcessGroup(size=margs.expert_tensor_parallel_size*margs.expert_model_parallel_size)
+    fake_etp_ep_group = _ConverterFakeProcessGroup(size=etp_size * ep_size)
     fake_tcp_group = _ConverterFakeProcessGroup(size=margs.tensor_model_parallel_size*margs.context_parallel_size)
     mpu._PIPELINE_MODEL_PARALLEL_GROUP = fake_pp_group
     mpu._CONTEXT_PARALLEL_GROUP = fake_cp_group
@@ -345,7 +374,7 @@ def save_checkpoint(queue, args):
     mpu._EXPERT_DATA_PARALLEL_GROUP = fake_edp_group
     mpu._EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP = fake_etp_ep_group
     mpu._TENSOR_AND_CONTEXT_PARALLEL_GROUP = fake_tcp_group
-    mpu._EXPERT_TENSOR_PARALLEL_GROUP = fake_tp_group
+    mpu._EXPERT_TENSOR_PARALLEL_GROUP = fake_etp_group
     mpu._DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
     mpu._INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
     mpu._LAST_RANK_WHEN_USING_PIPELINE = pp_size - 1
@@ -357,10 +386,27 @@ def save_checkpoint(queue, args):
     CUDA_RNG_STATE_TRACKER.add(_MODEL_PARALLEL_RNG_TRACKER_NAME, 44)
     CUDA_RNG_STATE_TRACKER.add(_EXPERT_PARALLEL_RNG_TRACKER_NAME, 45)
 
+    def set_model_parallel_rank(rank_id):
+        tp_rank = get_tensor_model_parallel_rank(rank_id, margs)
+        ep_rank = get_expert_model_parallel_rank(rank_id, margs)
+        etp_rank = get_expert_tensor_parallel_rank(rank_id, margs)
+        mpu.set_tensor_model_parallel_rank(tp_rank)
+        mpu.set_expert_model_parallel_rank(ep_rank)
+        if hasattr(mpu, "set_expert_tensor_parallel_rank"):
+            mpu.set_expert_tensor_parallel_rank(etp_rank)
+        fake_tp_group.set_rank(tp_rank)
+        fake_ep_group.set_rank(ep_rank)
+        fake_etp_group.set_rank(etp_rank)
+        fake_etp_ep_group.set_rank(ep_rank * etp_size + etp_rank)
+        return tp_rank, ep_rank, etp_rank
+
     def get_models(count, dtype):
         pre_process = mpu.is_pipeline_first_stage()
         post_process = mpu.is_pipeline_last_stage()
-        models = [model_plugin.get_mg_model(dtype, pre_process, post_process) for _ in range(count)]
+        models = []
+        for rank_id in range(count):
+            set_model_parallel_rank(rank_id)
+            models.append(model_plugin.get_mg_model(dtype, pre_process, post_process))
         return models
 
     """
@@ -372,7 +418,7 @@ def save_checkpoint(queue, args):
     mpu.set_pipeline_model_parallel_rank(0)
     fake_pp_group = _ConverterFakeProcessGroup(rank=0, size=margs.pipeline_model_parallel_size)
     mpu._PIPELINE_MODEL_PARALLEL_GROUP = fake_pp_group
-    models = get_models(tp_size * ep_size, md.params_dtype)
+    models = get_models(mcore_model_parallel_size, md.params_dtype)
     ckpt_plugin.set_embedding_ckpt(msg, models, md, margs)
     check_message(msg)
 
@@ -385,7 +431,7 @@ def save_checkpoint(queue, args):
         mpu._PIPELINE_MODEL_PARALLEL_GROUP = fake_pp_group
 
         if pp_rank > 0:
-            models = get_models(tp_size * ep_size, md.params_dtype)
+            models = get_models(mcore_model_parallel_size, md.params_dtype)
 
         for layer_id in range(len(models[0].decoder.layers)):
             msg = queue_get(f"transformer layer {total_layer_num}")
@@ -417,10 +463,7 @@ def save_checkpoint(queue, args):
                 print("ERROR: got some more data but was expecting to be done")
 
         for tp_ep_rank, model in enumerate(models):
-            tp_rank = tp_ep_rank % tp_size
-            ep_rank = tp_ep_rank // tp_size
-            mpu.set_tensor_model_parallel_rank(tp_rank)
-            mpu.set_expert_model_parallel_rank(ep_rank)
+            tp_rank, ep_rank, _ = set_model_parallel_rank(tp_ep_rank)
             checkpoint_name = get_checkpoint_name(margs.save, md.iteration)
             print(f"megtron model is saving to {checkpoint_name} ...")
             save_checkpoint(md.iteration, [model], None, None,

--- a/tools/checkpoint/saver_mcore.py
+++ b/tools/checkpoint/saver_mcore.py
@@ -54,8 +54,7 @@ def save_checkpoint(queue, args):
         from megatron.training.arguments import parse_args, validate_args
         from megatron.training.checkpointing import save_checkpoint, get_checkpoint_name
         from megatron.training.global_vars import set_global_variables, get_args
-        from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
-        from megatron.legacy import fused_kernels
+        from megatron.training.tokenizer.tokenizer import vocab_size_with_padding
         from megatron.core import mpu
         from megatron.core.tensor_parallel.random import (
                 get_cuda_rng_tracker, _DATA_PARALLEL_RNG_TRACKER_NAME,
@@ -169,7 +168,6 @@ def save_checkpoint(queue, args):
         '--no-masked-softmax-fusion',
         '--no-bias-gelu-fusion',
         '--no-bias-dropout-fusion',
-        '--no-async-tensor-model-parallel-allreduce',
         '--use-cpu-initialization',
         '--transformer-impl', 'transformer_engine',
         '--micro-batch-size', '1',
@@ -223,7 +221,7 @@ def save_checkpoint(queue, args):
         args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'expert_model_parallel_size', 'world_size', 'params_dtype',
                         'num_layers_per_virtual_pipeline_stage', 'virtual_pipeline_model_parallel_size',
                         'masked_softmax_fusion', 'bias_gelu_fusion', 'bias_dropout_fusion',
-                        'sequence_parallel', 'async_tensor_model_parallel_allreduce',
+                        'sequence_parallel',
                         'no_load_optim', 'no_load_rng', 'no_save_optim', 'no_save_rng',
                         'vocab_file', 'tokenizer_model',
                         'save_interval', 'save', 'load', 'use_mcore_models', 'num_experts',
@@ -292,10 +290,13 @@ def save_checkpoint(queue, args):
     margs.model_type = model_plugin.model_type
 
     if md.true_vocab_size is not None:
-        margs.padded_vocab_size = _vocab_size_with_padding(md.true_vocab_size, margs)
+        margs.padded_vocab_size = vocab_size_with_padding(md.true_vocab_size, margs)
     else:
         # margs.padded_vocab_size will be set in ckpt_plugin.set_embedding_ckpt func
         margs.padded_vocab_size = None
+
+    if getattr(args, "skip_mtp", False):
+        margs.mtp_num_layers = 0
 
     """
     use megatron args build object and init env
@@ -348,10 +349,6 @@ def save_checkpoint(queue, args):
     mpu._DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
     mpu._INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = fake_dp_group
     mpu._LAST_RANK_WHEN_USING_PIPELINE = pp_size - 1
-
-
-    # fused kernel
-    fused_kernels.load(margs)
 
     # random
     CUDA_RNG_STATE_TRACKER = get_cuda_rng_tracker()

--- a/tools/checkpoint/saver_transformers.py
+++ b/tools/checkpoint/saver_transformers.py
@@ -201,7 +201,8 @@ def save_checkpoint(queue, args):
     if hasattr (md, 'checkpoint_args'):
         # These are arguments that we are either changing, or cause problems for validation if they are set
         # Note that some of these deal with T5 so will need to be changed if we support T5.
-        args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'expert_model_parallel_size', 'world_size', 'params_dtype',
+        args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'expert_model_parallel_size',
+                        'expert_tensor_parallel_size', 'world_size', 'params_dtype',
                         'num_layers_per_virtual_pipeline_stage', 'virtual_pipeline_model_parallel_size',
                         'masked_softmax_fusion', 'bias_gelu_fusion', 'bias_dropout_fusion',
                         'sequence_parallel',

--- a/tools/checkpoint/saver_transformers.py
+++ b/tools/checkpoint/saver_transformers.py
@@ -55,7 +55,7 @@ def save_checkpoint(queue, args):
 
     try:
         from megatron.training.arguments import parse_args, validate_args
-        from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
+        from megatron.training.tokenizer.tokenizer import vocab_size_with_padding
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         queue.put("exit")
@@ -158,7 +158,6 @@ def save_checkpoint(queue, args):
         '--no-masked-softmax-fusion',
         '--no-bias-gelu-fusion',
         '--no-bias-dropout-fusion',
-        '--no-async-tensor-model-parallel-allreduce',
         '--use-cpu-initialization',
         '--transformer-impl', 'transformer_engine',
         '--micro-batch-size', '1',
@@ -205,7 +204,7 @@ def save_checkpoint(queue, args):
         args_to_keep = ['tensor_model_parallel_size', 'pipeline_model_parallel_size', 'expert_model_parallel_size', 'world_size', 'params_dtype',
                         'num_layers_per_virtual_pipeline_stage', 'virtual_pipeline_model_parallel_size',
                         'masked_softmax_fusion', 'bias_gelu_fusion', 'bias_dropout_fusion',
-                        'sequence_parallel', 'async_tensor_model_parallel_allreduce',
+                        'sequence_parallel',
                         'no_load_optim', 'no_load_rng', 'no_save_optim', 'no_save_rng',
                         'vocab_file', 'tokenizer_model',
                         'save_interval', 'save', 'load', 'use_mcore_models', 'num_experts',
@@ -256,10 +255,14 @@ def save_checkpoint(queue, args):
     margs.transformer_impl = "transformer_engine"
 
     if md.true_vocab_size is not None:
-        margs.padded_vocab_size = _vocab_size_with_padding(md.true_vocab_size, margs)
+        margs.padded_vocab_size = vocab_size_with_padding(md.true_vocab_size, margs)
+        margs.vocab_size = md.true_vocab_size
     else:
         # margs.padded_vocab_size will be set in ckpt_plugin.set_embedding_ckpt func
         margs.padded_vocab_size = None
+
+    if getattr(args, "skip_mtp", False):
+        margs.mtp_num_layers = 0
 
     """
     use megatron args build object and init env
@@ -283,7 +286,9 @@ def save_checkpoint(queue, args):
         msg = queue_get(f"transformer layer {layer_id}")
 
         margs.total_layer_num = layer_id
-        if margs.use_engram and layer_id in margs.engram_layer_ids:
+        if getattr(margs, "use_engram", False) and layer_id in getattr(
+            margs, "engram_layer_ids", []
+        ):
             ckpt_plugin.set_hf_engram_ckpt(msg, hf_model, layer_id, md, margs)
         ckpt_plugin.set_hf_attn_ckpt(msg, hf_model, layer_id, md, margs)
         ckpt_plugin.set_hf_mlp_ckpt(msg, hf_model, layer_id, md, margs)

--- a/tools/checkpoint/utils.py
+++ b/tools/checkpoint/utils.py
@@ -75,6 +75,161 @@ def print_memory_usage(key, rank, num_ranks):
     )
 
 
+def get_expert_tensor_parallel_size(args):
+    return (
+        getattr(args, "expert_tensor_parallel_size", None)
+        or getattr(args, "tensor_model_parallel_size", 1)
+        or 1
+    )
+
+
+def get_mcore_model_parallel_size(args):
+    tp_size = getattr(args, "tensor_model_parallel_size", 1) or 1
+    cp_size = getattr(args, "context_parallel_size", 1) or 1
+    ep_size = getattr(args, "expert_model_parallel_size", 1) or 1
+    etp_size = get_expert_tensor_parallel_size(args)
+    dense_parallel_size = tp_size * cp_size
+    expert_parallel_size = ep_size * etp_size
+    return max(dense_parallel_size, expert_parallel_size)
+
+
+def validate_mcore_parallel_size(args):
+    tp_size = getattr(args, "tensor_model_parallel_size", 1) or 1
+    cp_size = getattr(args, "context_parallel_size", 1) or 1
+    ep_size = getattr(args, "expert_model_parallel_size", 1) or 1
+    etp_size = get_expert_tensor_parallel_size(args)
+    dense_parallel_size = tp_size * cp_size
+    expert_parallel_size = ep_size * etp_size
+    mcore_model_parallel_size = get_mcore_model_parallel_size(args)
+
+    if mcore_model_parallel_size % dense_parallel_size != 0:
+        raise ValueError(
+            f"Unsupported MCore parallel sizes: max(tp*cp={dense_parallel_size}, "
+            f"ep*etp={expert_parallel_size}) is not divisible by tp*cp."
+        )
+    if mcore_model_parallel_size % expert_parallel_size != 0:
+        raise ValueError(
+            f"Unsupported MCore parallel sizes: max(tp*cp={dense_parallel_size}, "
+            f"ep*etp={expert_parallel_size}) is not divisible by ep*etp."
+        )
+
+    seen_checkpoint_names = set()
+    for rank_id in range(mcore_model_parallel_size):
+        checkpoint_rank = (
+            get_tensor_model_parallel_rank(rank_id, args),
+            get_expert_model_parallel_rank(rank_id, args),
+        )
+        if checkpoint_rank in seen_checkpoint_names:
+            raise ValueError(
+                "Unsupported MCore legacy torch layout: multiple physical ranks map to "
+                f"checkpoint tensor/expert rank {checkpoint_rank}. "
+                "Use expert_tensor_parallel_size <= tensor_model_parallel_size."
+            )
+        seen_checkpoint_names.add(checkpoint_rank)
+
+
+def _get_parallel_order(args, sizes):
+    order = (getattr(args, "order", None) or "tp-cp-ep-dp-pp").lower().split("-")
+    for name, size in sizes.items():
+        if name not in order and size != 1:
+            raise ValueError(
+                f"The checkpoint converter cannot map {name} size {size} because "
+                f"parallel order {getattr(args, 'order', None)} does not include {name}."
+            )
+        if name not in order:
+            order.append(name)
+    return order
+
+
+def _rank_coordinates(rank_id, sizes, order):
+    stride = 1
+    coords = {}
+    for name in order:
+        size = sizes[name]
+        coords[name] = (rank_id // stride) % size
+        stride *= size
+    return coords
+
+
+def _dense_rank_coordinates(rank_id, args):
+    tp_size = getattr(args, "tensor_model_parallel_size", 1) or 1
+    cp_size = getattr(args, "context_parallel_size", 1) or 1
+    model_parallel_size = get_mcore_model_parallel_size(args)
+    dense_parallel_size = tp_size * cp_size
+    sizes = {
+        "tp": tp_size,
+        "cp": cp_size,
+        "ep": 1,
+        "dp": model_parallel_size // dense_parallel_size,
+        "pp": 1,
+    }
+    return _rank_coordinates(rank_id, sizes, _get_parallel_order(args, sizes))
+
+
+def _expert_rank_coordinates(rank_id, args):
+    ep_size = getattr(args, "expert_model_parallel_size", 1) or 1
+    etp_size = get_expert_tensor_parallel_size(args)
+    model_parallel_size = get_mcore_model_parallel_size(args)
+    expert_parallel_size = ep_size * etp_size
+    sizes = {
+        "tp": etp_size,
+        "cp": 1,
+        "ep": ep_size,
+        "dp": model_parallel_size // expert_parallel_size,
+        "pp": 1,
+    }
+    return _rank_coordinates(rank_id, sizes, _get_parallel_order(args, sizes))
+
+
+def get_tensor_model_parallel_rank(rank_id, args):
+    return _dense_rank_coordinates(rank_id, args)["tp"]
+
+
+def get_expert_model_parallel_rank(rank_id, args):
+    return _expert_rank_coordinates(rank_id, args)["ep"]
+
+
+def get_expert_tensor_parallel_rank(rank_id, args):
+    return _expert_rank_coordinates(rank_id, args)["tp"]
+
+
+def get_tensor_parallel_models(models, args):
+    tp_size = getattr(args, "tensor_model_parallel_size", 1) or 1
+    tp_models = [None] * tp_size
+    for rank_id, model in enumerate(models):
+        tp_rank = get_tensor_model_parallel_rank(rank_id, args)
+        if tp_models[tp_rank] is None:
+            tp_models[tp_rank] = model
+
+    if any(model is None for model in tp_models):
+        missing = [str(rank) for rank, model in enumerate(tp_models) if model is None]
+        raise RuntimeError(f"Missing tensor-parallel model ranks: {', '.join(missing)}")
+    return tp_models
+
+
+def get_expert_tensor_parallel_models(models, args, ep_rank):
+    etp_groups = get_expert_tensor_parallel_model_groups(models, args, ep_rank)
+    return [group[0] for group in etp_groups]
+
+
+def get_expert_tensor_parallel_model_groups(models, args, ep_rank):
+    etp_size = get_expert_tensor_parallel_size(args)
+    etp_groups = [[] for _ in range(etp_size)]
+    for rank_id, model in enumerate(models):
+        if get_expert_model_parallel_rank(rank_id, args) != ep_rank:
+            continue
+        etp_rank = get_expert_tensor_parallel_rank(rank_id, args)
+        etp_groups[etp_rank].append(model)
+
+    if any(not group for group in etp_groups):
+        missing = [str(rank) for rank, group in enumerate(etp_groups) if not group]
+        raise RuntimeError(
+            f"Missing expert tensor-parallel model ranks for ep rank {ep_rank}: "
+            f"{', '.join(missing)}"
+        )
+    return etp_groups
+
+
 class _ConverterFakeProcessGroup:
     def __init__(self, rank=0, size=1):
         self._rank = rank


### PR DESCRIPTION
## Summary

- Add an explicit `--skip-mtp` conversion option so DeepSeek-V3/Moonlight checkpoints can be exported to HF implementations that only contain the main LM layers.
- Keep loader and saver MTP handling consistent when MTP is skipped, avoiding unconsumed queue messages and missing HF MTP layer lookups.
- Align DeepSeek-V3 HF config export with current Megatron argument names and true vocabulary size handling.
- Guard Engram-only checkpoint fields for non-Engram checkpoints and remove unsupported legacy Megatron conversion arguments.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/flagscale_pycache python3 -m py_compile tools/checkpoint/convert.py tools/checkpoint/utils.py tools/checkpoint/loader_mcore.py tools/checkpoint/loader_transformers.py tools/checkpoint/saver_mcore.py tools/checkpoint/saver_transformers.py tools/checkpoint/deepseek_v3/args.py`
- `git diff --check`