### PR TITLE
[CICD]hygon: add BW1000 training image

### DIFF
--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -1,0 +1,51 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Hygon BW1000 hardware configuration. Training cases are selected in
+# tests/test_utils/config/platforms/hygon.yaml.
+hardware_name: hygon
+display_name: "Hygon BW1000 Tests"
+
+# The runner and registry share the same host, avoiding a 32 GB remote push.
+ci_image: localhost:5000/flagscale-hygon-train:8b5c7f1-finalized
+ci_train_image: localhost:5000/flagscale-hygon-train:8b5c7f1-finalized
+ci_inference_image: localhost:5000/flagscale-hygon-train:8b5c7f1-finalized
+
+runner_labels: ["flagscale-hygon-bw1000-gpu8"]
+
+container_volumes:
+  - /opt/hyhal:/opt/hyhal:ro
+  - /public-flash/lihongyang/data:/home/gitlab-runner/data:ro
+  - /public-flash/lihongyang/qwentokenizer:/home/gitlab-runner/tokenizers/qwentokenizer:ro
+
+# DTK exposes BW1000 devices through the KFD/DRI compatibility interfaces.
+container_options: >-
+  --device=/dev/kfd
+  --device=/dev/dri
+  --group-add video
+  --ipc=host
+  --network=host
+  --shm-size=64g
+  --user root
+  --ulimit nofile=1048576:1048576
+  --cap-add SYS_PTRACE
+  --security-opt seccomp=unconfined
+
+pkg_mgr: "pip"
+env_path: "/usr/local"
+env_names:
+  train: ""
+  hetero_train: ""
+  inference: ""
+  rl: ""

--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -113,8 +113,9 @@ jobs:
     name: Hygon BW1000 tests
     needs: check_docker_changes
     if: >-
-      (github.event_name == 'workflow_dispatch' && (inputs.platform == 'all' || inputs.platform == 'hygon')) ||
-      (github.event_name == 'pull_request' && needs.check_docker_changes.outputs.has_hygon_changes == 'true')
+      always() &&
+      ((github.event_name == 'workflow_dispatch' && (inputs.platform == 'all' || inputs.platform == 'hygon')) ||
+      (github.event_name == 'pull_request' && needs.check_docker_changes.outputs.has_hygon_changes == 'true'))
     uses: ./.github/workflows/all_tests_common.yml
     with:
       platform: hygon

--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -46,6 +46,7 @@ on:
           - all
           - cuda
           - ascend
+          - hygon
           - metax
 
 concurrency:
@@ -64,6 +65,7 @@ jobs:
     if: github.event_name == 'pull_request'
     outputs:
       has_docker_changes: ${{ steps.check.outputs.has_docker_changes }}
+      has_hygon_changes: ${{ steps.check.outputs.has_hygon_changes }}
     steps:
       - name: Check for docker-related file changes
         id: check
@@ -75,6 +77,11 @@ jobs:
             echo "has_docker_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_docker_changes=false" >> $GITHUB_OUTPUT
+          fi
+          if echo "$CHANGED" | grep -qE '^(docker/hygon/|\.github/configs/hygon\.yml$|tests/test_utils/config/platforms/hygon\.yaml$|tests/functional_tests/train/qwen3/.+hygon)'; then
+            echo "has_hygon_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_hygon_changes=false" >> $GITHUB_OUTPUT
           fi
 
   cuda_tests:
@@ -102,6 +109,16 @@ jobs:
     with:
       platform: metax
 
+  hygon_tests:
+    name: Hygon BW1000 tests
+    needs: check_docker_changes
+    if: >-
+      (github.event_name == 'workflow_dispatch' && (inputs.platform == 'all' || inputs.platform == 'hygon')) ||
+      (github.event_name == 'pull_request' && needs.check_docker_changes.outputs.has_hygon_changes == 'true')
+    uses: ./.github/workflows/all_tests_common.yml
+    with:
+      platform: hygon
+
   all_tests:
     name: all_tests
     needs:
@@ -109,6 +126,7 @@ jobs:
       - cuda_tests
       # - ascend_tests
       - metax_tests
+      - hygon_tests
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -133,6 +151,12 @@ jobs:
           if [ "${{ needs.metax_tests.result }}" != "success" ] && \
              [ "${{ needs.metax_tests.result }}" != "skipped" ]; then
             echo "❌ MetaX C550 tests failed"
+            failed=true
+          fi
+
+          if [ "${{ needs.hygon_tests.result }}" != "success" ] && \
+             [ "${{ needs.hygon_tests.result }}" != "skipped" ]; then
+            echo "Hygon BW1000 tests failed"
             failed=true
           fi
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -47,7 +47,6 @@ log_error() {
 # =============================================================================
 # Default versions (same as tools/install, override via environment variables)
 # =============================================================================
-PYTHON_VERSION_WAS_SET="${PYTHON_VERSION+x}"
 PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
 UV_VERSION="${UV_VERSION:-0.7.2}"
 OPENMPI_VERSION="${OPENMPI_VERSION:-4.1.6}"
@@ -264,11 +263,6 @@ build_image() {
 # =============================================================================
 main() {
     parse_args "$@"
-
-    # The validated Hygon DTK base image provides Python 3.10.
-    if [ "$PLATFORM" = "hygon" ] && [ -z "$PYTHON_VERSION_WAS_SET" ]; then
-        PYTHON_VERSION=3.10
-    fi
 
     # Validate platform
     validate_platform "$PLATFORM"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -47,6 +47,7 @@ log_error() {
 # =============================================================================
 # Default versions (same as tools/install, override via environment variables)
 # =============================================================================
+PYTHON_VERSION_WAS_SET="${PYTHON_VERSION+x}"
 PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
 UV_VERSION="${UV_VERSION:-0.7.2}"
 OPENMPI_VERSION="${OPENMPI_VERSION:-4.1.6}"
@@ -263,6 +264,11 @@ build_image() {
 # =============================================================================
 main() {
     parse_args "$@"
+
+    # The validated Hygon DTK base image provides Python 3.10.
+    if [ "$PLATFORM" = "hygon" ] && [ -z "$PYTHON_VERSION_WAS_SET" ]; then
+        PYTHON_VERSION=3.10
+    fi
 
     # Validate platform
     validate_platform "$PLATFORM"

--- a/docker/hygon/Dockerfile.train
+++ b/docker/hygon/Dockerfile.train
@@ -60,6 +60,7 @@ RUN apt-get update && \
         ninja-build \
         python3-dev && \
     rm -rf /var/lib/apt/lists/* && \
+    git config --system http.version HTTP/1.1 && \
     python -c "import sys; expected='${PYTHON_VERSION}'; actual=f'{sys.version_info.major}.{sys.version_info.minor}'; assert actual == expected, f'expected Python {expected}, found {actual}'"
 
 WORKDIR /workspace

--- a/docker/hygon/Dockerfile.train
+++ b/docker/hygon/Dockerfile.train
@@ -1,0 +1,114 @@
+# syntax=docker/dockerfile:1.6
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# FlagScale training image for Hygon BW1000 DCUs. The DTK runtime and
+# PyTorch stack are supplied by the vendor base image. FlagScale itself is
+# intentionally checked out at runtime so the same image can test PR branches.
+
+ARG BASE_IMAGE=harbor.sourcefind.cn:5443/dcu/admin/base/vllm:0.15.1-ubuntu22.04-dtk26.04-py3.10
+ARG PYTHON_VERSION=3.10
+
+ARG MEGATRON_REPO=https://github.com/flagos-ai/Megatron-LM-FL.git
+ARG MEGATRON_REF=e2174161fa6e6ae844fc5e05a17b5ea64e492c59cd
+ARG FLAGGEMS_REPO=https://github.com/flagos-ai/FlagGems.git
+ARG FLAGGEMS_REF=66a4ddb3656bf2fc4d305f610a5c49c26192bb04cd
+ARG TRANSFORMER_ENGINE_REPO=https://github.com/flagos-ai/TransformerEngine-FL.git
+ARG TRANSFORMER_ENGINE_REF=b7f65d1b4a4c73b554e5b8f5ce0547eab0c3c35acd
+ARG FLAGCX_REPO=https://github.com/flagos-ai/FlagCX.git
+ARG FLAGCX_REF=0beba7aa7e76cc0885a9929f1975857bcd310d5ecd
+
+FROM ${BASE_IMAGE} AS base
+
+ARG PYTHON_VERSION
+ARG MEGATRON_REF
+ARG FLAGGEMS_REF
+ARG TRANSFORMER_ENGINE_REF
+ARG FLAGCX_REF
+
+LABEL io.flagscale.platform=hygon-bw1000 \
+      io.flagscale.megatron-lm-fl.revision=${MEGATRON_REF} \
+      io.flagscale.flaggems.revision=${FLAGGEMS_REF} \
+      io.flagscale.transformer-engine-fl.revision=${TRANSFORMER_ENGINE_REF} \
+      io.flagscale.flagcx.revision=${FLAGCX_REF}
+
+ENV FLAGSCALE_HOME=/opt/flagscale \
+    FLAGSCALE_DEPS=/opt/flagscale/deps \
+    GEMS_VENDOR=amd \
+    TE_FL_SKIP_CUDA=1 \
+    TORCHINDUCTOR_WORKER_START=spawn \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        git \
+        ninja-build \
+        python3-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -c "import sys; expected='${PYTHON_VERSION}'; actual=f'{sys.version_info.major}.{sys.version_info.minor}'; assert actual == expected, f'expected Python {expected}, found {actual}'"
+
+WORKDIR /workspace
+
+FROM base AS deps
+
+ARG MEGATRON_REPO
+ARG MEGATRON_REF
+ARG FLAGGEMS_REPO
+ARG FLAGGEMS_REF
+ARG TRANSFORMER_ENGINE_REPO
+ARG TRANSFORMER_ENGINE_REF
+ARG FLAGCX_REPO
+ARG FLAGCX_REF
+ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
+
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    set -eux; \
+    mkdir -p "${FLAGSCALE_DEPS}"; \
+    git clone --filter=blob:none --no-checkout "${MEGATRON_REPO}" "${FLAGSCALE_DEPS}/Megatron-LM-FL"; \
+    git -C "${FLAGSCALE_DEPS}/Megatron-LM-FL" checkout --detach "${MEGATRON_REF}"; \
+    python -c "from pathlib import Path; p=Path('${FLAGSCALE_DEPS}/Megatron-LM-FL/pyproject.toml'); s=p.read_text(); q=chr(34); old='requires-python = '+q+'>=3.12'+q; new='requires-python = '+q+'>=3.10'+q; assert s.count(old) == 1, 'unexpected Megatron-LM-FL Python constraint'; p.write_text(s.replace(old, new))"; \
+    python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/Megatron-LM-FL"
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    set -eux; \
+    git clone --filter=blob:none --no-checkout "${FLAGGEMS_REPO}" "${FLAGSCALE_DEPS}/FlagGems"; \
+    git -C "${FLAGSCALE_DEPS}/FlagGems" checkout --detach "${FLAGGEMS_REF}"; \
+    python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/FlagGems"
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    set -eux; \
+    git clone --filter=blob:none --no-checkout "${TRANSFORMER_ENGINE_REPO}" "${FLAGSCALE_DEPS}/TransformerEngine-FL"; \
+    git -C "${FLAGSCALE_DEPS}/TransformerEngine-FL" checkout --detach "${TRANSFORMER_ENGINE_REF}"; \
+    TE_FL_SKIP_CUDA=1 python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/TransformerEngine-FL"
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    set -eux; \
+    git clone --filter=blob:none --no-checkout "${FLAGCX_REPO}" "${FLAGSCALE_DEPS}/FlagCX"; \
+    git -C "${FLAGSCALE_DEPS}/FlagCX" checkout --detach "${FLAGCX_REF}"; \
+    git -C "${FLAGSCALE_DEPS}/FlagCX" submodule update --init --recursive; \
+    python -m pip install --no-build-isolation -v "${FLAGSCALE_DEPS}/FlagCX"
+
+FROM deps AS dev
+
+CMD ["/bin/bash"]
+
+FROM deps AS release
+
+CMD ["/bin/bash"]

--- a/docker/hygon/Dockerfile.train
+++ b/docker/hygon/Dockerfile.train
@@ -79,28 +79,24 @@ ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 
 ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    set -eux; \
+RUN set -eux; \
     mkdir -p "${FLAGSCALE_DEPS}"; \
     git clone --filter=blob:none --no-checkout "${MEGATRON_REPO}" "${FLAGSCALE_DEPS}/Megatron-LM-FL"; \
     git -C "${FLAGSCALE_DEPS}/Megatron-LM-FL" checkout --detach "${MEGATRON_REF}"; \
     python -c "from pathlib import Path; p=Path('${FLAGSCALE_DEPS}/Megatron-LM-FL/pyproject.toml'); s=p.read_text(); q=chr(34); old='requires-python = '+q+'>=3.12'+q; new='requires-python = '+q+'>=3.10'+q; assert s.count(old) == 1, 'unexpected Megatron-LM-FL Python constraint'; p.write_text(s.replace(old, new))"; \
     python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/Megatron-LM-FL"
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    set -eux; \
+RUN set -eux; \
     git clone --filter=blob:none --no-checkout "${FLAGGEMS_REPO}" "${FLAGSCALE_DEPS}/FlagGems"; \
     git -C "${FLAGSCALE_DEPS}/FlagGems" checkout --detach "${FLAGGEMS_REF}"; \
     python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/FlagGems"
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    set -eux; \
+RUN set -eux; \
     git clone --filter=blob:none --no-checkout "${TRANSFORMER_ENGINE_REPO}" "${FLAGSCALE_DEPS}/TransformerEngine-FL"; \
     git -C "${FLAGSCALE_DEPS}/TransformerEngine-FL" checkout --detach "${TRANSFORMER_ENGINE_REF}"; \
     TE_FL_SKIP_CUDA=1 python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/TransformerEngine-FL"
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    set -eux; \
+RUN set -eux; \
     git clone --filter=blob:none --no-checkout "${FLAGCX_REPO}" "${FLAGSCALE_DEPS}/FlagCX"; \
     git -C "${FLAGSCALE_DEPS}/FlagCX" checkout --detach "${FLAGCX_REF}"; \
     git -C "${FLAGSCALE_DEPS}/FlagCX" submodule update --init --recursive; \

--- a/docker/hygon/Dockerfile.train
+++ b/docker/hygon/Dockerfile.train
@@ -93,7 +93,7 @@ RUN set -eux; \
     mkdir -p "${FLAGSCALE_DEPS}/Megatron-LM-FL"; \
     curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
         --output /tmp/megatron-lm-fl.tar.gz \
-        "${MEGATRON_REPO%.git}/archive/${MEGATRON_REF}.tar.gz"; \
+        "https://codeload.github.com/flagos-ai/Megatron-LM-FL/tar.gz/${MEGATRON_REF}"; \
     tar -xzf /tmp/megatron-lm-fl.tar.gz --strip-components=1 \
         -C "${FLAGSCALE_DEPS}/Megatron-LM-FL"; \
     rm /tmp/megatron-lm-fl.tar.gz; \
@@ -104,7 +104,7 @@ RUN set -eux; \
     mkdir -p "${FLAGSCALE_DEPS}/FlagGems"; \
     curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
         --output /tmp/flag-gems.tar.gz \
-        "${FLAGGEMS_REPO%.git}/archive/${FLAGGEMS_REF}.tar.gz"; \
+        "https://codeload.github.com/flagos-ai/FlagGems/tar.gz/${FLAGGEMS_REF}"; \
     tar -xzf /tmp/flag-gems.tar.gz --strip-components=1 \
         -C "${FLAGSCALE_DEPS}/FlagGems"; \
     rm /tmp/flag-gems.tar.gz; \
@@ -120,7 +120,7 @@ RUN set -eux; \
     mkdir -p "${FLAGSCALE_DEPS}/TransformerEngine-FL"; \
     curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
         --output /tmp/transformer-engine-fl.tar.gz \
-        "${TRANSFORMER_ENGINE_REPO%.git}/archive/${TRANSFORMER_ENGINE_REF}.tar.gz"; \
+        "https://codeload.github.com/flagos-ai/TransformerEngine-FL/tar.gz/${TRANSFORMER_ENGINE_REF}"; \
     tar -xzf /tmp/transformer-engine-fl.tar.gz --strip-components=1 \
         -C "${FLAGSCALE_DEPS}/TransformerEngine-FL"; \
     rm /tmp/transformer-engine-fl.tar.gz; \
@@ -133,13 +133,13 @@ RUN set -eux; \
         "${FLAGSCALE_DEPS}/FlagCX/third-party/json"; \
     curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
         --output /tmp/flagcx.tar.gz \
-        "${FLAGCX_REPO%.git}/archive/${FLAGCX_REF}.tar.gz"; \
+        "https://codeload.github.com/flagos-ai/FlagCX/tar.gz/${FLAGCX_REF}"; \
     curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
         --output /tmp/googletest.tar.gz \
-        "https://github.com/google/googletest/archive/${GOOGLETEST_REF}.tar.gz"; \
+        "https://codeload.github.com/google/googletest/tar.gz/${GOOGLETEST_REF}"; \
     curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
         --output /tmp/json.tar.gz \
-        "https://github.com/nlohmann/json/archive/${JSON_REF}.tar.gz"; \
+        "https://codeload.github.com/nlohmann/json/tar.gz/${JSON_REF}"; \
     tar -xzf /tmp/flagcx.tar.gz --strip-components=1 \
         -C "${FLAGSCALE_DEPS}/FlagCX"; \
     tar -xzf /tmp/googletest.tar.gz --strip-components=1 \

--- a/docker/hygon/Dockerfile.train
+++ b/docker/hygon/Dockerfile.train
@@ -169,8 +169,10 @@ RUN set -eux; \
 
 FROM deps AS dev
 
+ENTRYPOINT []
 CMD ["/bin/bash"]
 
 FROM deps AS release
 
+ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/docker/hygon/Dockerfile.train
+++ b/docker/hygon/Dockerfile.train
@@ -108,6 +108,12 @@ RUN set -eux; \
     tar -xzf /tmp/flag-gems.tar.gz --strip-components=1 \
         -C "${FLAGSCALE_DEPS}/FlagGems"; \
     rm /tmp/flag-gems.tar.gz; \
+    python -m pip install \
+        "setuptools>=64.0,<80.0" \
+        "cmake>=3.20,<4.0" \
+        "ninja==1.13.0" \
+        "scikit-build-core==0.12.2" \
+        "pybind11==3.0.3"; \
     python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/FlagGems"
 
 RUN set -eux; \

--- a/docker/hygon/Dockerfile.train
+++ b/docker/hygon/Dockerfile.train
@@ -29,6 +29,8 @@ ARG TRANSFORMER_ENGINE_REPO=https://github.com/flagos-ai/TransformerEngine-FL.gi
 ARG TRANSFORMER_ENGINE_REF=b7f65d1b4a4c73b554e5b8f5ce0547eab0c3c35acd
 ARG FLAGCX_REPO=https://github.com/flagos-ai/FlagCX.git
 ARG FLAGCX_REF=0beba7aa7e76cc0885a9929f1975857bcd310d5ecd
+ARG GOOGLETEST_REF=e90fe2485641bab0d6af4500192dc503384950d1
+ARG JSON_REF=a0e9fb1e638cfbb5b8b556b7c51eaa81977bad48
 
 FROM ${BASE_IMAGE} AS base
 
@@ -37,12 +39,16 @@ ARG MEGATRON_REF
 ARG FLAGGEMS_REF
 ARG TRANSFORMER_ENGINE_REF
 ARG FLAGCX_REF
+ARG GOOGLETEST_REF
+ARG JSON_REF
 
 LABEL io.flagscale.platform=hygon-bw1000 \
       io.flagscale.megatron-lm-fl.revision=${MEGATRON_REF} \
       io.flagscale.flaggems.revision=${FLAGGEMS_REF} \
       io.flagscale.transformer-engine-fl.revision=${TRANSFORMER_ENGINE_REF} \
-      io.flagscale.flagcx.revision=${FLAGCX_REF}
+      io.flagscale.flagcx.revision=${FLAGCX_REF} \
+      io.flagscale.googletest.revision=${GOOGLETEST_REF} \
+      io.flagscale.json.revision=${JSON_REF}
 
 ENV FLAGSCALE_HOME=/opt/flagscale \
     FLAGSCALE_DEPS=/opt/flagscale/deps \
@@ -56,6 +62,7 @@ RUN apt-get update && \
         build-essential \
         ca-certificates \
         cmake \
+        curl \
         git \
         ninja-build \
         python3-dev && \
@@ -75,31 +82,65 @@ ARG TRANSFORMER_ENGINE_REPO
 ARG TRANSFORMER_ENGINE_REF
 ARG FLAGCX_REPO
 ARG FLAGCX_REF
+ARG GOOGLETEST_REF
+ARG JSON_REF
 ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 
 ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 
 RUN set -eux; \
     mkdir -p "${FLAGSCALE_DEPS}"; \
-    git clone --filter=blob:none --no-checkout "${MEGATRON_REPO}" "${FLAGSCALE_DEPS}/Megatron-LM-FL"; \
-    git -C "${FLAGSCALE_DEPS}/Megatron-LM-FL" checkout --detach "${MEGATRON_REF}"; \
+    mkdir -p "${FLAGSCALE_DEPS}/Megatron-LM-FL"; \
+    curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
+        --output /tmp/megatron-lm-fl.tar.gz \
+        "${MEGATRON_REPO%.git}/archive/${MEGATRON_REF}.tar.gz"; \
+    tar -xzf /tmp/megatron-lm-fl.tar.gz --strip-components=1 \
+        -C "${FLAGSCALE_DEPS}/Megatron-LM-FL"; \
+    rm /tmp/megatron-lm-fl.tar.gz; \
     python -c "from pathlib import Path; p=Path('${FLAGSCALE_DEPS}/Megatron-LM-FL/pyproject.toml'); s=p.read_text(); q=chr(34); old='requires-python = '+q+'>=3.12'+q; new='requires-python = '+q+'>=3.10'+q; assert s.count(old) == 1, 'unexpected Megatron-LM-FL Python constraint'; p.write_text(s.replace(old, new))"; \
     python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/Megatron-LM-FL"
 
 RUN set -eux; \
-    git clone --filter=blob:none --no-checkout "${FLAGGEMS_REPO}" "${FLAGSCALE_DEPS}/FlagGems"; \
-    git -C "${FLAGSCALE_DEPS}/FlagGems" checkout --detach "${FLAGGEMS_REF}"; \
+    mkdir -p "${FLAGSCALE_DEPS}/FlagGems"; \
+    curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
+        --output /tmp/flag-gems.tar.gz \
+        "${FLAGGEMS_REPO%.git}/archive/${FLAGGEMS_REF}.tar.gz"; \
+    tar -xzf /tmp/flag-gems.tar.gz --strip-components=1 \
+        -C "${FLAGSCALE_DEPS}/FlagGems"; \
+    rm /tmp/flag-gems.tar.gz; \
     python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/FlagGems"
 
 RUN set -eux; \
-    git clone --filter=blob:none --no-checkout "${TRANSFORMER_ENGINE_REPO}" "${FLAGSCALE_DEPS}/TransformerEngine-FL"; \
-    git -C "${FLAGSCALE_DEPS}/TransformerEngine-FL" checkout --detach "${TRANSFORMER_ENGINE_REF}"; \
+    mkdir -p "${FLAGSCALE_DEPS}/TransformerEngine-FL"; \
+    curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
+        --output /tmp/transformer-engine-fl.tar.gz \
+        "${TRANSFORMER_ENGINE_REPO%.git}/archive/${TRANSFORMER_ENGINE_REF}.tar.gz"; \
+    tar -xzf /tmp/transformer-engine-fl.tar.gz --strip-components=1 \
+        -C "${FLAGSCALE_DEPS}/TransformerEngine-FL"; \
+    rm /tmp/transformer-engine-fl.tar.gz; \
     TE_FL_SKIP_CUDA=1 python -m pip install --no-build-isolation -e "${FLAGSCALE_DEPS}/TransformerEngine-FL"
 
 RUN set -eux; \
-    git clone --filter=blob:none --no-checkout "${FLAGCX_REPO}" "${FLAGSCALE_DEPS}/FlagCX"; \
-    git -C "${FLAGSCALE_DEPS}/FlagCX" checkout --detach "${FLAGCX_REF}"; \
-    git -C "${FLAGSCALE_DEPS}/FlagCX" submodule update --init --recursive; \
+    mkdir -p \
+        "${FLAGSCALE_DEPS}/FlagCX" \
+        "${FLAGSCALE_DEPS}/FlagCX/third-party/googletest" \
+        "${FLAGSCALE_DEPS}/FlagCX/third-party/json"; \
+    curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
+        --output /tmp/flagcx.tar.gz \
+        "${FLAGCX_REPO%.git}/archive/${FLAGCX_REF}.tar.gz"; \
+    curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
+        --output /tmp/googletest.tar.gz \
+        "https://github.com/google/googletest/archive/${GOOGLETEST_REF}.tar.gz"; \
+    curl --http1.1 --fail --location --retry 20 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-limit 1024 --speed-time 60 \
+        --output /tmp/json.tar.gz \
+        "https://github.com/nlohmann/json/archive/${JSON_REF}.tar.gz"; \
+    tar -xzf /tmp/flagcx.tar.gz --strip-components=1 \
+        -C "${FLAGSCALE_DEPS}/FlagCX"; \
+    tar -xzf /tmp/googletest.tar.gz --strip-components=1 \
+        -C "${FLAGSCALE_DEPS}/FlagCX/third-party/googletest"; \
+    tar -xzf /tmp/json.tar.gz --strip-components=1 \
+        -C "${FLAGSCALE_DEPS}/FlagCX/third-party/json"; \
+    rm /tmp/flagcx.tar.gz /tmp/googletest.tar.gz /tmp/json.tar.gz; \
     python -m pip install --no-build-isolation -v "${FLAGSCALE_DEPS}/FlagCX"
 
 FROM deps AS dev

--- a/docker/hygon/Dockerfile.train
+++ b/docker/hygon/Dockerfile.train
@@ -52,6 +52,10 @@ LABEL io.flagscale.platform=hygon-bw1000 \
 
 ENV FLAGSCALE_HOME=/opt/flagscale \
     FLAGSCALE_DEPS=/opt/flagscale/deps \
+    CUDA_PATH=/opt/dtk/cuda/cuda-12 \
+    CUDA_HOME=/opt/dtk/cuda/cuda-12 \
+    DEVICE_HOME=/opt/dtk/cuda/cuda-12 \
+    CCL_HOME=/opt/dtk/cuda/cuda-12 \
     GEMS_VENDOR=amd \
     TE_FL_SKIP_CUDA=1 \
     TORCHINDUCTOR_WORKER_START=spawn \
@@ -65,6 +69,7 @@ RUN apt-get update && \
         curl \
         git \
         ninja-build \
+        patch \
         python3-dev && \
     rm -rf /var/lib/apt/lists/* && \
     git config --system http.version HTTP/1.1 && \
@@ -73,6 +78,11 @@ RUN apt-get update && \
 WORKDIR /workspace
 
 FROM base AS deps
+
+# The native FlagCX extension is finalized after DTK devices and /opt/hyhal
+# are mounted into a running container.
+COPY docker/hygon/flagcx-dtk26.04.patch /tmp/flagcx-dtk26.04.patch
+COPY docker/hygon/finalize-flagcx.sh /usr/local/bin/flagscale-hygon-finalize-flagcx
 
 ARG MEGATRON_REPO
 ARG MEGATRON_REF
@@ -87,6 +97,12 @@ ARG JSON_REF
 ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 
 ENV PIP_INDEX_URL=${PIP_INDEX_URL}
+
+RUN chmod 0755 /usr/local/bin/flagscale-hygon-finalize-flagcx && \
+    python -m pip install \
+        "hydra-core==1.3.5" \
+        "onnxscript==0.7.1" \
+        "typer>=0.9.0"
 
 RUN set -eux; \
     mkdir -p "${FLAGSCALE_DEPS}"; \
@@ -147,6 +163,8 @@ RUN set -eux; \
     tar -xzf /tmp/json.tar.gz --strip-components=1 \
         -C "${FLAGSCALE_DEPS}/FlagCX/third-party/json"; \
     rm /tmp/flagcx.tar.gz /tmp/googletest.tar.gz /tmp/json.tar.gz; \
+    patch --directory "${FLAGSCALE_DEPS}/FlagCX" --strip=1 \
+        < /tmp/flagcx-dtk26.04.patch; \
     python -m pip install --no-build-isolation -v "${FLAGSCALE_DEPS}/FlagCX"
 
 FROM deps AS dev

--- a/docker/hygon/finalize-flagcx.sh
+++ b/docker/hygon/finalize-flagcx.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export TORCH_DEVICE_BACKEND_AUTOLOAD=0
+export CUDA_PATH="${CUDA_PATH:-/opt/dtk/cuda/cuda-12}"
+export CUDA_HOME="${CUDA_HOME:-${CUDA_PATH}}"
+export DEVICE_HOME="${DEVICE_HOME:-${CUDA_PATH}}"
+export CCL_HOME="${CCL_HOME:-${CUDA_PATH}}"
+export LD_LIBRARY_PATH="${CUDA_PATH}/lib64:/opt/hyhal/lib:/opt/hyhal/lib64:${LD_LIBRARY_PATH:-}"
+
+flagcx_source="${FLAGSCALE_DEPS:-/opt/flagscale/deps}/FlagCX"
+
+python - <<'PY'
+import torch
+
+if not torch.cuda.is_available():
+    raise RuntimeError("DTK devices are unavailable; mount /opt/hyhal and /dev/kfd,/dev/dri")
+print(f"DTK devices available: {torch.cuda.device_count()}")
+PY
+
+if python -c "from flagcx import _C" >/dev/null 2>&1; then
+    echo "FlagCX extension is already installed"
+    exit 0
+fi
+
+rm -rf "${flagcx_source}/build"
+python -m pip install \
+    --force-reinstall \
+    --no-deps \
+    --no-build-isolation \
+    -v "${flagcx_source}"
+
+python - <<'PY'
+import torch
+import flagcx
+from flagcx import _C
+
+print(f"FlagCX ready on {torch.cuda.device_count()} DTK devices")
+PY

--- a/docker/hygon/flagcx-dtk26.04.patch
+++ b/docker/hygon/flagcx-dtk26.04.patch
@@ -1,0 +1,105 @@
+diff --git a/plugin/torch/_build_config.py b/plugin/torch/_build_config.py
+index 7b009d0..16a23ef 100644
+--- a/plugin/torch/_build_config.py
++++ b/plugin/torch/_build_config.py
+@@ -170,5 +170,6 @@ def get_device_config(adaptor_flag):
+     elif adaptor_flag == "-DUSE_DU_ADAPTOR":
+-        include_dirs += ["${CUDA_PATH}/include"]
+-        library_dirs += ["${CUDA_PATH}/lib64"]
+-        libs += ["cuda", "cudart", "c10_cuda", "torch_cuda"]
++        cuda_path = os.environ["CUDA_PATH"]
++        include_dirs += [os.path.join(cuda_path, "include")]
++        library_dirs += [os.path.join(cuda_path, "lib64")]
++        libs += ["cuda", "cudart", "c10_hip", "torch_hip"]
+     elif adaptor_flag == "-DUSE_KUNLUNXIN_ADAPTOR":
+diff --git a/plugin/torch/flagcx/include/event_flagcx.hpp b/plugin/torch/flagcx/include/event_flagcx.hpp
+index f7bda96..25f8792 100644
+--- a/plugin/torch/flagcx/include/event_flagcx.hpp
++++ b/plugin/torch/flagcx/include/event_flagcx.hpp
+@@ -28,4 +28,4 @@
+ #elif USE_DU_ADAPTOR
+-#include <ATen/cuda/CUDAEvent.h>
+-#include <cuda_runtime.h>
++#include <ATen/hip/HIPEvent.h>
++#include <hip/hip_runtime.h>
+ #elif USE_KUNLUNXIN_ADAPTOR
+@@ -226,8 +226,9 @@
+ #elif USE_DU_ADAPTOR
+ class flagcxDuEvent : public flagcxEvent {
+ public:
+-  flagcxDuEvent() { cudaEvent_ = at::cuda::CUDAEvent(cudaEventDisableTiming); }
++  flagcxDuEvent() { cudaEvent_ = at::cuda::CUDAEvent(hipEventDisableTiming); }
+-
++
+   void record(const int deviceId) override {
+-    cudaEvent_.record(at::cuda::getCurrentCUDAStream(deviceId));
++    cudaEvent_.record(
++        at::hip::getCurrentHIPStreamMasqueradingAsCUDA(deviceId));
+   }
+@@ -235,4 +236,4 @@ public:
+   void record(const flagcxStream_t &stream, const int deviceId) override {
+-    cudaEvent_.record(
+-        at::cuda::getStreamFromExternal(*(cudaStream_t *)stream, deviceId));
++    cudaEvent_.record(at::hip::getStreamFromExternalMasqueradingAsCUDA(
++        *(hipStream_t *)stream, deviceId));
+   }
+@@ -240,3 +241,4 @@ public:
+   void block(const int deviceId) override {
+-    cudaEvent_.block(at::cuda::getCurrentCUDAStream(deviceId));
++    cudaEvent_.block(
++        at::hip::getCurrentHIPStreamMasqueradingAsCUDA(deviceId));
+   }
+@@ -244,4 +246,4 @@ public:
+   void block(const flagcxStream_t &stream, const int deviceId) override {
+-    cudaEvent_.block(
+-        at::cuda::getStreamFromExternal(*(cudaStream_t *)stream, deviceId));
++    cudaEvent_.block(at::hip::getStreamFromExternalMasqueradingAsCUDA(
++        *(hipStream_t *)stream, deviceId));
+   }
+diff --git a/plugin/torch/flagcx/include/stream_guard_flagcx.hpp b/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
+index cff547a..698f5cb 100644
+--- a/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
++++ b/plugin/torch/flagcx/include/stream_guard_flagcx.hpp
+@@ -38,5 +38,5 @@
+ #include <c10/core/impl/InlineStreamGuard.h>
+-#include <c10/cuda/CUDAGuard.h>
+-#include <c10/cuda/impl/CUDAGuardImpl.h>
+-#include <cuda_runtime.h>
++#include <c10/hip/HIPGuard.h>
++#include <c10/hip/impl/HIPGuardImpl.h>
++#include <hip/hip_runtime.h>
+ #elif USE_KUNLUNXIN_ADAPTOR
+@@ -87,4 +87,4 @@ public:
+ #elif USE_DU_ADAPTOR
+-        guard_(
+-            at::cuda::getStreamFromExternal(*(cudaStream_t *)stream, deviceId))
++        guard_(at::hip::getStreamFromExternal(*(hipStream_t *)stream,
++                                              deviceId))
+ #elif USE_KUNLUNXIN_ADAPTOR
+@@ -150,4 +150,4 @@ public:
+ #elif USE_DU_ADAPTOR
+-    guard_.reset_stream(
+-        at::cuda::getStreamFromExternal(*(cudaStream_t *)stream, deviceId_));
++    guard_.reset_stream(at::hip::getStreamFromExternal(
++        *(hipStream_t *)stream, deviceId_));
+ #elif USE_KUNLUNXIN_ADAPTOR
+@@ -192,3 +192,3 @@ private:
+ #elif USE_DU_ADAPTOR
+-  c10::cuda::CUDAStreamGuard guard_;
++  c10::hip::HIPStreamGuard guard_;
+ #elif USE_KUNLUNXIN_ADAPTOR
+diff --git a/setup.py b/setup.py
+index e5e191d..51f8100 100644
+--- a/setup.py
++++ b/setup.py
+@@ -159,3 +159,9 @@ if CppExtension is not None:
+         include_dirs=include_dirs,
+-        extra_compile_args={"cxx": [adaptor_flag, torch_flag]},
++        extra_compile_args={
++            "cxx": [
++                adaptor_flag,
++                torch_flag,
++                "-DC10_CUDA_NO_CMAKE_CONFIGURE_FILE",
++            ]
++        },
+         extra_link_args=[],

--- a/tests/functional_tests/train/qwen3/conf/0_6b_hygon.yaml
+++ b/tests/functional_tests/train/qwen3/conf/0_6b_hygon.yaml
@@ -1,0 +1,44 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - _self_
+  - train: 0_6b_hygon
+
+experiment:
+  exp_name: 0_6b_hygon
+  exp_dir: tests/functional_tests/train/qwen3/test_results/0_6b_hygon
+  task:
+    type: train
+    backend: megatron
+    entrypoint: flagscale/train/megatron/train_gpt.py
+  runner:
+    ssh_port: null
+  shell_cmds: null
+  envs:
+    HYDRA_FULL_ERROR: 1
+    CUDA_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+    CUDA_DEVICE_MAX_CONNECTIONS: 1
+    GEMS_VENDOR: amd
+    TORCHINDUCTOR_WORKER_START: spawn
+    # DTK exposes CUDA-compatible libraries while device management stays in
+    # the host-mounted Hygon HAL directories.
+    LD_LIBRARY_PATH: /opt/dtk/cuda/cuda-12/lib64:/opt/hyhal/lib:/opt/hyhal/lib64
+  cmds:
+    before_start: ulimit -n 1048576
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/tests/functional_tests/train/qwen3/conf/train/0_6b_hygon.yaml
+++ b/tests/functional_tests/train/qwen3/conf/train/0_6b_hygon.yaml
@@ -1,0 +1,89 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - data_hygon
+
+system:
+  tensor_model_parallel_size: 1
+  pipeline_model_parallel_size: 1
+  disable_bias_linear: true
+  reset_position_ids: true
+  reset_attention_mask: true
+  qk_layernorm: true
+  use_distributed_optimizer: false
+  precision:
+    bf16: true
+    attention_softmax_in_fp32: true
+    accumulate_allreduce_grads_in_fp32: true
+  logging:
+    log_interval: 1
+    no_log_loss_scale_to_tensorboard: true
+  checkpoint:
+    no_save_optim: true
+    no_save_rng: true
+    no_load_optim: true
+    no_load_rng: true
+    save_interval: 100000
+    ckpt_format: torch
+    tensorboard_log_interval: 999999
+
+model:
+  deterministic_mode: true
+  transformer_impl: transformer_engine
+  attention_backend: unfused
+  no_check_for_nan_in_loss_and_grad: true
+  no_gradient_accumulation_fusion: true
+  te_fl_prefer: flagos
+  # FlagCX collectives are validated separately. Training currently uses the
+  # DTK NCCL-compatible backend because this FlagScale revision maps FlagCX to
+  # an unsupported txda device string during early rank initialization.
+  distributed_backend: nccl
+  num_layers: 28
+  hidden_size: 1024
+  ffn_hidden_size: 3072
+  kv_channels: 128
+  num_attention_heads: 16
+  group_query_attention: true
+  num_query_groups: 8
+  seq_length: 256
+  max_position_embeddings: 40960
+  norm_epsilon: 1e-6
+  use_rotary_position_embeddings: true
+  rotary_base: 1000000
+  no_rope_fusion: true
+  swiglu: true
+  normalization: RMSNorm
+  untie_embeddings_and_output_weights: false
+  no_position_embedding: true
+  init_method_std: 0.006
+  attention_dropout: 0.0
+  hidden_dropout: 0.0
+  clip_grad: 1.0
+  train_iters: 10
+  eval_iters: 0
+  eval_interval: 1000
+  micro_batch_size: 1
+  global_batch_size: 8
+  seed: 42
+  optimizer:
+    weight_decay: 0.1
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    lr_scheduler:
+      lr: 1.0e-5
+      min_lr: 1.0e-6
+      lr_warmup_samples: 0
+      lr_warmup_fraction: 0.01
+      lr_decay_style: cosine

--- a/tests/functional_tests/train/qwen3/conf/train/data_hygon.yaml
+++ b/tests/functional_tests/train/qwen3/conf/train/data_hygon.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data:
+  data_path: /home/gitlab-runner/data/Nemotron-CC-v2__High-Quality__part1_text_document
+  split: 1
+  no_mmap_bin_files: true
+  tokenizer:
+    tokenizer_type: QwenTokenizerFS
+    tokenizer_path: /home/gitlab-runner/tokenizers/qwentokenizer
+    vocab_size: 151936
+    make_vocab_size_divisible_by: 64

--- a/tests/test_utils/config/platforms/hygon.yaml
+++ b/tests/test_utils/config/platforms/hygon.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+device_types:
+  - bw1000
+
+bw1000:
+  name: "bw1000"
+  tests:
+    functional:
+      train:
+        qwen3: ["0_6b_hygon"]
+      hetero_train: {}
+      benchmark: {}
+      inference: {}
+      serve: {}
+    unit:
+      include: []
+      exclude: []


### PR DESCRIPTION
### PR Category
Hardware

### PR Types
New Features

### PR Description
- Add a BW1000/DTK 26.04 training Dockerfile based on the vendor vLLM image.
- Pin and install Megatron-LM-FL, FlagGems, TransformerEngine-FL, and FlagCX.
- Add the validated DTK compatibility patch and runtime FlagCX finalization helper.
- Support the legacy Docker builder and reset the vendor image entrypoint.

Validation completed on one BW1000 node:
- PyTorch 2.9.0 detected 8 BW devices.
- FlagGems, TransformerEngine-FL, and native FlagCX imports passed.
- Two-rank FlagCX all-reduce passed with result 3.0 on both ranks.
- Qwen3 0.6B training completed 2 iterations on 8 devices and saved the iteration-2 checkpoint.
- Local repository pre-commit checks passed.

Commits are intentionally left unsquashed while CI is being stabilized.